### PR TITLE
Fix import bugs: add FleetPlaywrightWrapper export and fix cloudpickle dependency quoting

### DIFF
--- a/fleet/__init__.py
+++ b/fleet/__init__.py
@@ -37,6 +37,9 @@ from .verifiers import (
     TASK_SUCCESSFUL_SCORE,
 )
 
+# Import Playwright wrapper
+from .playwright import FleetPlaywrightWrapper
+
 # Import async verifiers (default verifier is async for modern usage)
 from ._async.verifiers import (
     verifier,
@@ -63,6 +66,8 @@ __all__ = [
     "FleetAPIError", 
     "FleetTimeoutError",
     "FleetConfigurationError",
+    # Playwright wrapper
+    "FleetPlaywrightWrapper",
     # Verifiers (async is default)
     "verifier",
     "verifier_sync", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "httpx-retries>=0.4.0",
     "typing-extensions>=4.0.0",
     "modulegraph2>=0.2.0",
-    cloudpickle==3.1.1,
+    "cloudpickle==3.1.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Add FleetPlaywrightWrapper import and export to fleet/__init__.py to make it available for users
- Fix missing quotes around cloudpickle dependency in pyproject.toml

## Test plan
- [ ] Verify FleetPlaywrightWrapper can be imported from fleet package
- [ ] Verify pyproject.toml syntax is valid
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)