### PR TITLE
add where and changes attributes to query builders

### DIFF
--- a/fleet/_async/resources/sqlite.py
+++ b/fleet/_async/resources/sqlite.py
@@ -111,6 +111,21 @@ class AsyncSnapshotQueryBuilder:
         qb._conditions.append((column, "=", value))
         return qb
 
+    def where(
+        self,
+        conditions: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> "AsyncSnapshotQueryBuilder":
+        qb = self._clone()
+        merged: Dict[str, Any] = {}
+        if conditions:
+            merged.update(conditions)
+        if kwargs:
+            merged.update(kwargs)
+        for column, value in merged.items():
+            qb._conditions.append((column, "=", value))
+        return qb
+
     def limit(self, n: int) -> "AsyncSnapshotQueryBuilder":
         qb = self._clone()
         qb._limit = n
@@ -304,6 +319,15 @@ class AsyncSnapshotDiff:
         self._cached = diff
         return diff
 
+    @property
+    def changes(self) -> Dict[str, Dict[str, Any]]:
+        """Expose cached changes; ensure callers awaited a diff-producing method first."""
+        if self._cached is None:
+            raise RuntimeError(
+                "Diff not collected yet; await an operation like expect_only() first."
+            )
+        return self._cached
+
     async def expect_only(self, allowed_changes: List[Dict[str, Any]]):
         """Ensure only specified changes occurred."""
         diff = await self._collect()
@@ -470,6 +494,21 @@ class AsyncQueryBuilder:
 
     def eq(self, column: str, value: Any) -> "AsyncQueryBuilder":
         return self._add_condition(column, "=", value)
+
+    def where(
+        self,
+        conditions: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> "AsyncQueryBuilder":
+        qb = self._clone()
+        merged: Dict[str, Any] = {}
+        if conditions:
+            merged.update(conditions)
+        if kwargs:
+            merged.update(kwargs)
+        for column, value in merged.items():
+            qb._conditions.append((column, "=", value))
+        return qb
 
     def neq(self, column: str, value: Any) -> "AsyncQueryBuilder":
         return self._add_condition(column, "!=", value)

--- a/fleet/resources/sqlite.py
+++ b/fleet/resources/sqlite.py
@@ -111,6 +111,21 @@ class SyncSnapshotQueryBuilder:
         qb._conditions.append((column, "=", value))
         return qb
 
+    def where(
+        self,
+        conditions: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> "SyncSnapshotQueryBuilder":
+        qb = self._clone()
+        merged: Dict[str, Any] = {}
+        if conditions:
+            merged.update(conditions)
+        if kwargs:
+            merged.update(kwargs)
+        for column, value in merged.items():
+            qb._conditions.append((column, "=", value))
+        return qb
+
     def limit(self, n: int) -> "SyncSnapshotQueryBuilder":
         qb = self._clone()
         qb._limit = n
@@ -304,6 +319,11 @@ class SyncSnapshotDiff:
         self._cached = diff
         return diff
 
+    @property
+    def changes(self) -> Dict[str, Dict[str, Any]]:
+        """Expose the computed diff so callers can introspect like the legacy API."""
+        return self._collect()
+
     def expect_only(self, allowed_changes: List[Dict[str, Any]]):
         """Ensure only specified changes occurred."""
         diff = self._collect()
@@ -470,6 +490,21 @@ class SyncQueryBuilder:
 
     def eq(self, column: str, value: Any) -> "SyncQueryBuilder":
         return self._add_condition(column, "=", value)
+
+    def where(
+        self,
+        conditions: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> "SyncQueryBuilder":
+        qb = self._clone()
+        merged: Dict[str, Any] = {}
+        if conditions:
+            merged.update(conditions)
+        if kwargs:
+            merged.update(kwargs)
+        for column, value in merged.items():
+            qb._conditions.append((column, "=", value))
+        return qb
 
     def neq(self, column: str, value: Any) -> "SyncQueryBuilder":
         return self._add_condition(column, "!=", value)


### PR DESCRIPTION
This PR adds the expected `where` and `changes` attrs to the SnapshotQueryBuilder.

This should fix issues surfaced in [this thread](https://fleet-ai.slack.com/archives/C08V73G6AUR/p1758828212603609), but it's still unclear to me what the caller of the `where` and `changes` attributes are, as it doesn't appear in the diff functions / anywhere I grep for the code.