### PR TITLE
fix: allow verifier helper functions to be called from main verifier

### DIFF
--- a/fleet/_async/tasks.py
+++ b/fleet/_async/tasks.py
@@ -346,8 +346,9 @@ def verifier_from_string(
                 return False
             return target in numbers
 
-        # Create a local namespace for executing the code
-        local_namespace = {
+        # Create a globals namespace with all required imports
+        exec_globals = globals().copy()
+        exec_globals.update({
             "TASK_SUCCESSFUL_SCORE": TASK_SUCCESSFUL_SCORE,
             "TASK_FAILED_SCORE": TASK_FAILED_SCORE,
             "IgnoreConfig": IgnoreConfig,
@@ -358,10 +359,17 @@ def verifier_from_string(
             "json": json,
             "re": re,
             "string": string,
-        }
+        })
+
+        # Create a local namespace for executing the code
+        local_namespace = {}
 
         # Execute the cleaned verifier code in the namespace
-        exec(cleaned_code, globals(), local_namespace)
+        exec(cleaned_code, exec_globals, local_namespace)
+
+        # Merge local_namespace into exec_globals so helper functions are accessible
+        # from the main verifier function when it's called
+        exec_globals.update(local_namespace)
 
         # Find the function that was defined (not imported)
         # Functions defined via exec have co_filename == '<string>'

--- a/fleet/tasks.py
+++ b/fleet/tasks.py
@@ -364,6 +364,10 @@ def verifier_from_string(
         # Execute the cleaned verifier code in the namespace
         exec(cleaned_code, exec_globals, local_namespace)
 
+        # Merge local_namespace into exec_globals so helper functions are accessible
+        # from the main verifier function when it's called
+        exec_globals.update(local_namespace)
+
         # Find the function that was defined (not imported)
         # Functions defined via exec have co_filename == '<string>'
         # Imported functions have their actual module file path


### PR DESCRIPTION
## Problem

When verifier code contains multiple functions (e.g., a main verifier function and helper functions like `_validate_research_answer` or `_strict_equals`), the helper functions were not accessible from the main function.

This caused a `NameError` when the main function tried to call helpers, which was silently caught by `SyncVerifierFunction.__call__` and returned `0.0` with no error message or stdout.

## Root Cause

The `exec()` call in `verifier_from_string` created functions in `local_namespace`, but the main function's `__globals__` pointed to `exec_globals` which didn't contain the helper functions.

```python
# Before: helper functions in local_namespace not accessible
exec(cleaned_code, exec_globals, local_namespace)
# main_func.__globals__ == exec_globals, which doesn't have helpers
```

## Fix

Merge `local_namespace` into `exec_globals` after `exec()` so all defined functions are accessible when the verifier is called.

```python
exec(cleaned_code, exec_globals, local_namespace)
exec_globals.update(local_namespace)  # Now main_func can see helpers
```

## Testing

Verified locally that verifiers with helper functions now work correctly:
```python
code = '''
def main_verifier(env, final_answer=None):
    return helper_function()

def helper_function():
    return 1.0
'''
verifier = verifier_from_string(code, ...)
result = verifier(env)  # Now returns 1.0 instead of 0.0
```