### PR TITLE
feat(track): unified session format + cross-tool resume + session store

### DIFF
--- a/.github/workflows/publish-fleet-sdk.yml
+++ b/.github/workflows/publish-fleet-sdk.yml
@@ -51,6 +51,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
           pip install -e .
+      - name: Inject Supabase credentials
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          sed -i "s|%%SUPABASE_URL%%|$SUPABASE_URL|g" fleet/_supabase.py
+          sed -i "s|%%SUPABASE_ANON_KEY%%|$SUPABASE_ANON_KEY|g" fleet/_supabase.py
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/publish-fleet-sdk.yml
+++ b/.github/workflows/publish-fleet-sdk.yml
@@ -51,13 +51,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
           pip install -e .
-      - name: Inject Supabase credentials
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-        run: |
-          sed -i "s|%%SUPABASE_URL%%|$SUPABASE_URL|g" fleet/_supabase.py
-          sed -i "s|%%SUPABASE_ANON_KEY%%|$SUPABASE_ANON_KEY|g" fleet/_supabase.py
       - name: Build package
         run: |
           python -m build

--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -40,10 +40,12 @@ The SDK watches:
 - `~/.codex/sessions/**/*.jsonl`
 - `~/.codex/archived_sessions/**/*.jsonl`
 
-The daemon reacts to file events after a 2.5 second debounce, drains the upload
-queue every 10 seconds, and runs a full reconciliation every 10 minutes. Changed
-files are uploaded as complete scrubbed file bodies through presigned S3 `PUT`
-URLs. There is no chunking or compression.
+The v1 daemon uses full reconciliation as the sync trigger. On startup, and then
+every 10 minutes, it scans local session files, diffs them against the remote
+manifest, queues changed files, uploads complete scrubbed file bodies through
+presigned S3 `PUT` URLs, and writes a new manifest after successful uploads.
+There is no chunking or compression. The file watcher code remains available, but
+v1 does not use watcher-driven uploads by default.
 
 Theseus currently exposes:
 
@@ -81,5 +83,6 @@ See:
 - [Current State Assessment](./current-state-assessment.md)
 - [Goals](./goals.md)
 - [V2 Architecture](./v2-architecture.md)
+- [V2 Git-Like Sync Research](./v2-git-like-sync-research.md)
 - [Unified Session Format](./unified-session-format.md)
 - [Local Resume Test Plan](./local-resume-test-plan.md)

--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -1,0 +1,85 @@
+# FleetTrack Planning
+
+FleetTrack currently exists as a passive local-session sync daemon in the SDK plus
+thin server support in Theseus. This directory captures the plan for turning that
+prototype into a durable session archive and migration system.
+
+## Current Decision
+
+Do not scrap everything. Keep the current implementation as a useful bootstrap,
+but do not ship the current sync protocol as the long-term design.
+
+Keep:
+
+- Browser/JWT login flow and team/user-scoped auth.
+- `flt track enable/status/daemon` product surface.
+- OS service installation through launchd/systemd.
+- Source discovery for Claude, Codex, and Cursor local session stores.
+- Local SQLite queue and background daemon shape.
+- Orchestrator-as-control-plane model with presigned S3 uploads.
+- S3 tenant isolation by `team_id/user_id/device_id`.
+- Client and server-side path blocklists.
+
+Replace before scale:
+
+- Whole-file uploads for every changed transcript.
+- Flat "Merkle" manifest that only maps `path -> sha256`.
+- Raw-only storage with no semantic session/version model.
+- Lack of compression.
+- Lack of explicit commit protocol and conflict detection.
+- Reliance on S3 versioning as the only version history.
+- No local restore/resume validation before writing into live tool stores.
+
+## Existing Behavior
+
+The SDK watches:
+
+- `~/.claude/projects/**/*.jsonl`
+- `~/.cursor/projects/**/agent-transcripts/**/*.jsonl`
+- `~/.cursor/projects/**/agent-transcripts/**/*.txt`
+- `~/.codex/sessions/**/*.jsonl`
+- `~/.codex/archived_sessions/**/*.jsonl`
+
+The daemon reacts to file events after a 2.5 second debounce, drains the upload
+queue every 10 seconds, and runs a full reconciliation every 10 minutes. Changed
+files are uploaded as complete scrubbed file bodies through presigned S3 `PUT`
+URLs. There is no chunking or compression.
+
+Theseus currently exposes:
+
+- `POST /v1/track/provision`
+- `GET /v1/track/manifest`
+- `POST /v1/track/upload-urls`
+
+Objects are stored under:
+
+```text
+fleet-track-sessions/
+  {team_id}/{user_id}/{device_id}/
+    manifest.json
+    raw/.claude/projects/...
+    raw/.cursor/projects/...
+    raw/.codex/sessions/...
+```
+
+## Target Direction
+
+FleetTrack v2 should store immutable, compressed, content-addressed session
+segments plus explicit version manifests. The raw source archive remains the
+source of truth. A Fleet-owned canonical session model is a versioned projection
+over the raw archive, not a replacement for it.
+
+The core invariant is:
+
+```text
+raw restore must be byte-identical and load-safe; cross-tool conversion may be
+lossy, but must never write invalid native session files.
+```
+
+See:
+
+- [Current State Assessment](./current-state-assessment.md)
+- [Goals](./goals.md)
+- [V2 Architecture](./v2-architecture.md)
+- [Unified Session Format](./unified-session-format.md)
+- [Local Resume Test Plan](./local-resume-test-plan.md)

--- a/docs/fleet-track/current-state-assessment.md
+++ b/docs/fleet-track/current-state-assessment.md
@@ -31,8 +31,8 @@ The prototype does not yet prove the hard parts:
 | Auth | Browser/JWT login plus team ID | Yes | Track requires user-scoped credentials; this is correct for per-user isolation. |
 | Service install | launchd/systemd user daemon | Yes | Correct product shape. Needs better diagnostics. |
 | Source discovery | Claude, Cursor, Codex local paths | Yes | Keep but move source definitions into adapter modules. |
-| Watcher | watchdog with 2.5 second debounce | Yes | Useful for low-latency queueing. Not sufficient as the only correctness mechanism. |
-| Reconcile | full scan every 10 minutes | Yes | Keep as safety net. Replace whole-file hash diff with segment/version reconciliation. |
+| Watcher | watchdog module exists, but v1 daemon does not use watcher-driven uploads by default | Maybe | Useful later for latency, but too aggressive for whole-file v1 uploads. |
+| Reconcile | full scan on startup and every 10 minutes | Yes | V1 now treats this as the sync trigger. Replace whole-file hash diff with segment/version reconciliation in v2. |
 | Hash cache | SQLite path/mtime/size cache | Partly | Keep local state pattern. Extend for record offsets, generations, and segment manifests. |
 | Queue | SQLite upload queue | Yes | Keep. Change rows from file uploads to object uploads and version commits. |
 | Upload | whole scrubbed file via presigned S3 PUT | Replace | This is the main scalability problem. |
@@ -83,4 +83,3 @@ Do not scrap the branch. Port it and use it as the product skeleton.
 
 Do scrap the storage/sync protocol before relying on it for long sessions or
 cross-machine restore.
-

--- a/docs/fleet-track/current-state-assessment.md
+++ b/docs/fleet-track/current-state-assessment.md
@@ -1,0 +1,86 @@
+# Current State Assessment
+
+## Bottom Line
+
+Use the current FleetTrack code as a bootstrap, not as the final architecture.
+
+The prototype proves the right shape:
+
+- local daemon
+- source discovery
+- auth
+- queueing
+- presigned upload
+- S3-backed storage
+- basic status CLI
+
+The prototype does not yet prove the hard parts:
+
+- efficient long-session sync
+- semantic versioning
+- restore safety
+- canonical session model
+- local resume validation
+- cross-tool continuation
+
+## SDK Pieces
+
+| Area | Current State | Keep? | Notes |
+| --- | --- | --- | --- |
+| CLI | `flt track enable/status/daemon/logs` | Yes | Good namespace and first-run flow. Add `doctor`, `sessions`, `restore`, `validate`, and `continue` later. |
+| Auth | Browser/JWT login plus team ID | Yes | Track requires user-scoped credentials; this is correct for per-user isolation. |
+| Service install | launchd/systemd user daemon | Yes | Correct product shape. Needs better diagnostics. |
+| Source discovery | Claude, Cursor, Codex local paths | Yes | Keep but move source definitions into adapter modules. |
+| Watcher | watchdog with 2.5 second debounce | Yes | Useful for low-latency queueing. Not sufficient as the only correctness mechanism. |
+| Reconcile | full scan every 10 minutes | Yes | Keep as safety net. Replace whole-file hash diff with segment/version reconciliation. |
+| Hash cache | SQLite path/mtime/size cache | Partly | Keep local state pattern. Extend for record offsets, generations, and segment manifests. |
+| Queue | SQLite upload queue | Yes | Keep. Change rows from file uploads to object uploads and version commits. |
+| Upload | whole scrubbed file via presigned S3 PUT | Replace | This is the main scalability problem. |
+| Manifest | flat `path -> sha256` map | Replace | Useful only for prototype diffing. Need version manifests with segments. |
+| Scrubbing | local byte scrub before upload | Partly | Keep, but define whether hashes refer to raw, scrubbed, or both. |
+
+## Server Pieces
+
+| Area | Current State | Keep? | Notes |
+| --- | --- | --- | --- |
+| Router | public `/v1/track` router in Theseus | Yes | Keep v1 for compatibility, add v2 endpoints. |
+| Provision | validates device and returns user/team | Yes | No DB write; acceptable. Could add device registry later. |
+| Manifest fetch | reads one S3 `manifest.json` | Replace | V2 should fetch session/version manifests and refs. |
+| Upload URLs | returns presigned PUT URLs for paths | Replace | V2 should plan missing content-addressed objects. |
+| Storage | `fleet-track-sessions/{team}/{user}/{device}/raw/...` | Partly | Keep bucket and isolation. Add `v2/objects` and `v2/sessions`. |
+| Metrics | `logfire.info` for provision/upload URLs | Partly | Add explicit endpoint, object, commit, and restore metrics. |
+
+## Main Risks If We Ship V1 As-Is
+
+1. Large active sessions repeatedly upload as full files.
+2. S3 versioning can retain many large overwritten object versions.
+3. No compression means unnecessary network and storage cost.
+4. Hashes are over local bytes, while uploads are scrubbed bytes, so the manifest
+   hash is not a checksum of stored object bytes.
+5. No explicit commit protocol means the latest state is whatever manifest upload
+   wins last.
+6. No restore path exists.
+7. No validation path exists before writing restored sessions into live tool
+   directories.
+8. No canonical format exists for unified search or cross-tool continuation.
+
+## Migration Strategy
+
+Do not rewrite everything first. Make incremental replacements behind the same
+CLI surface:
+
+1. Keep `flt track enable` and the daemon service.
+2. Add local v2 segmenting and reassembly code with tests.
+3. Add `validate-local` and temp-HOME restore tests.
+4. Add v2 server planning and commit endpoints.
+5. Switch upload queue from file-path jobs to object-hash and commit jobs.
+6. Keep v1 raw whole-file upload behind a compatibility flag until v2 is stable.
+7. Add canonical projection as a separate worker or CLI operation.
+
+## Decision
+
+Do not scrap the branch. Port it and use it as the product skeleton.
+
+Do scrap the storage/sync protocol before relying on it for long sessions or
+cross-machine restore.
+

--- a/docs/fleet-track/goals.md
+++ b/docs/fleet-track/goals.md
@@ -1,0 +1,77 @@
+# FleetTrack Goals
+
+## Product Goals
+
+FleetTrack should make local AI coding sessions durable, searchable, restorable,
+and eventually portable across agent tools.
+
+The first useful product outcome is reliable backup and restore:
+
+- A user can enable FleetTrack and forget about it.
+- The daemon uploads session history without noticeably disrupting local work.
+- A user can restore sessions onto a new machine.
+- Restored same-tool sessions load cleanly.
+- If a restore cannot be validated, FleetTrack refuses to install a broken
+  session file.
+
+The second product outcome is cross-tool continuity:
+
+- A user can continue a Claude session in Codex, or a Codex session in Claude,
+  with a useful context bundle.
+- The converted session may be lossy.
+- The converted session must not corrupt or break the target tool's session
+  loader.
+
+The third product outcome is a Fleet-native session corpus:
+
+- Sessions can be indexed and searched across tools.
+- Tool calls, shell commands, patches, assistant messages, user messages,
+  reasoning summaries, attachments, and environment context can be queried using
+  one Fleet schema.
+- The canonical model preserves provenance back to raw records.
+
+## Non-Goals
+
+FleetTrack does not need perfect cross-tool replay in the first version.
+
+It should not try to synthesize private tool internals that are not understood.
+If a target tool needs hidden fields or opaque state to resume exactly, the
+adapter should fall back to creating a fresh valid continuation with a summary
+and transcript.
+
+FleetTrack should not write unvalidated synthetic records into live session
+directories.
+
+FleetTrack should not make orchestrator proxy large session payloads. The
+orchestrator should remain the control plane; bulk bytes should go directly to
+object storage.
+
+## Safety Invariants
+
+- Never split a JSON record inside a storage segment.
+- Never restore a partial session file.
+- Never install a reconstructed file unless all segment hashes verify.
+- Never install a native-format conversion unless the target adapter validator
+  accepts it.
+- Never mutate an active session file in place.
+- Always write restored files atomically through temp-file-and-rename.
+- Preserve unknown raw fields so adapters can improve later.
+- Treat raw native records as the archival source of truth.
+
+## Rollout Goals
+
+Phase 0: Document and assess the prototype.
+
+Phase 1: Implement local segmenter, manifest writer, and restore validator
+without changing the server.
+
+Phase 2: Add v2 server control-plane endpoints for missing-object planning and
+version commits.
+
+Phase 3: Add same-tool restore for Codex and Claude using temporary HOME-based
+validation.
+
+Phase 4: Add canonical session projection and read-only CLI inspection.
+
+Phase 5: Add conservative cross-tool continuation export.
+

--- a/docs/fleet-track/local-resume-test-plan.md
+++ b/docs/fleet-track/local-resume-test-plan.md
@@ -1,0 +1,136 @@
+# Local Resume Test Plan
+
+## Goal
+
+Prove that FleetTrack can restore and resume sessions without breaking local
+agent tools.
+
+Lossy conversion is acceptable for cross-tool continuation. Broken native
+session files are not acceptable.
+
+## Test Levels
+
+### Level 1: Raw Reassembly
+
+Input: a native session file.
+
+Steps:
+
+1. Segment the file at valid record boundaries.
+2. Compress and hash each segment.
+3. Reassemble the file from segments.
+4. Verify full-file hash equality.
+5. Parse every JSONL record.
+
+Pass condition: reassembled file is byte-identical and parse-valid.
+
+### Level 2: Same-Tool Restore Validation
+
+Input: a real Codex or Claude session file.
+
+Steps:
+
+1. Create a temporary HOME.
+2. Recreate only the minimal session directory for the target tool.
+3. Restore the reassembled raw file into the temp HOME.
+4. Run the target tool's safest available non-mutating resume/list command.
+5. Confirm the tool can discover or parse the restored session.
+
+Pass condition: the target tool accepts the restored file without loader errors.
+
+This must not use the user's live `~/.codex`, `~/.claude`, or `~/.cursor`
+directories.
+
+### Level 3: Same-Tool Resume Smoke
+
+Input: a small synthetic session created for testing.
+
+Steps:
+
+1. Create a throwaway session in the source tool.
+2. Archive it through FleetTrack.
+3. Restore it into a temp HOME.
+4. Attempt an actual resume in the temp HOME when the tool supports it.
+
+Pass condition: the tool starts from the restored session and can accept a new
+message.
+
+### Level 4: Cross-Tool Continuation
+
+Input: raw source session plus canonical projection.
+
+Steps:
+
+1. Project source records into `fleet.session.v1`.
+2. Export a conservative target-tool continuation candidate.
+3. Validate the candidate using the target adapter.
+4. Install into temp HOME only after validation.
+5. Attempt target-tool load/resume.
+
+Pass condition: target tool loads the continuation. Content may be summarized or
+lossy.
+
+## Local CLI Concepts
+
+Development-only commands:
+
+```text
+flt track sessions segment-local <path> --out /tmp/fleettrack-segments
+flt track sessions reassemble-local <manifest> --out /tmp/session.jsonl
+flt track sessions validate-local <path> --tool codex
+flt track sessions restore-local <manifest> --tool codex --home /tmp/fleettrack-home
+flt track sessions continue-local <manifest> --from claude --to codex --home /tmp/fleettrack-home
+```
+
+Production commands should hide these details behind `restore`, `validate`, and
+`continue`.
+
+## Adapter Validation Strategy
+
+Validation should be strict for same-tool restore:
+
+- JSONL must parse fully.
+- Required top-level keys must exist for the target tool/version.
+- Event ordering must be stable.
+- Parent pointers should refer to existing events where the tool expects them.
+- Restored files must be written atomically.
+
+Validation should be conservative for cross-tool exports:
+
+- Unknown events are allowed to be dropped or summarized.
+- Required target fields must be present.
+- No raw source-only objects should be injected into target-native files unless
+  the adapter explicitly supports them.
+- If the target adapter is uncertain, produce a context bundle instead of a
+  native session file.
+
+## Fixtures
+
+Create non-sensitive fixtures for:
+
+- Minimal Codex session.
+- Codex session with shell command and tool result.
+- Codex session with patch/file edits.
+- Minimal Claude session.
+- Claude session with tool use and tool result.
+- Claude session with subagent records.
+- Cursor transcript if available.
+- Corrupt JSONL with partial final line.
+- Truncated file.
+- File rewrite/truncation generation.
+
+Fixtures should be synthetic or scrubbed. Do not commit private user session
+content.
+
+## Success Criteria
+
+Before enabling v2 upload by default:
+
+- 100% pass for raw reassembly fixtures.
+- 100% pass for same-tool restore validation fixtures.
+- At least one real temp-HOME resume smoke for Codex.
+- At least one real temp-HOME resume smoke for Claude, if Claude exposes a safe
+  way to run it.
+- Cross-tool continuation must fail closed: if validation cannot prove safety,
+  it emits a context bundle and does not write a native session file.
+

--- a/docs/fleet-track/unified-session-format.md
+++ b/docs/fleet-track/unified-session-format.md
@@ -1,0 +1,161 @@
+# Unified Session Format
+
+## Purpose
+
+The unified format is a Fleet-owned projection over raw session records. It is
+for search, analysis, rendering, and best-effort continuation across tools.
+
+It is not the only source of truth. The raw native records remain archived so we
+can restore same-tool sessions exactly and improve adapters later.
+
+## Design Principle
+
+The unified model should be conservative:
+
+- Preserve provenance for every canonical event.
+- Preserve unknown source fields.
+- Prefer an explicit `unknown` event over dropping data.
+- Do not claim a cross-tool export is exact unless the target adapter validates
+  it.
+
+## Top-Level Objects
+
+```json
+{
+  "schema": "fleet.session.v1",
+  "session": {
+    "id": "...",
+    "source": "codex",
+    "source_session_id": "...",
+    "workspace": {
+      "cwd": "...",
+      "git_branch": "...",
+      "repo_hint": "..."
+    },
+    "started_at": "...",
+    "ended_at": null
+  },
+  "events": []
+}
+```
+
+## Event Envelope
+
+Every canonical event uses one envelope:
+
+```json
+{
+  "id": "stable event id",
+  "seq": 123,
+  "time": "2026-04-29T00:00:00Z",
+  "kind": "message",
+  "role": "assistant",
+  "parent_id": "...",
+  "turn_id": "...",
+  "source": {
+    "tool": "claude",
+    "path": ".claude/projects/...jsonl",
+    "record_seq": 456,
+    "record_sha256": "...",
+    "raw_object_hash": "...",
+    "adapter": "claude@0.1.0"
+  },
+  "body": {},
+  "unknown": {}
+}
+```
+
+`source` is mandatory. `unknown` is where adapter-preserved fields live when the
+canonical schema does not have a first-class representation.
+
+## Core Event Kinds
+
+- `session_meta`
+- `turn_start`
+- `turn_end`
+- `message`
+- `reasoning`
+- `tool_call`
+- `tool_result`
+- `shell_command`
+- `shell_result`
+- `file_patch`
+- `file_snapshot`
+- `attachment`
+- `permission_request`
+- `permission_result`
+- `environment_context`
+- `error`
+- `unknown`
+
+## Message Body
+
+```json
+{
+  "kind": "message",
+  "role": "user|assistant|system",
+  "body": {
+    "content": [
+      {"type": "text", "text": "..."},
+      {"type": "image_ref", "uri": "..."},
+      {"type": "file_ref", "path": "..."}
+    ]
+  }
+}
+```
+
+## Tool Call Body
+
+```json
+{
+  "kind": "tool_call",
+  "body": {
+    "call_id": "...",
+    "tool_name": "exec_command",
+    "arguments": {},
+    "status": "started|completed|failed"
+  }
+}
+```
+
+Tool results should preserve raw output references. Large outputs should be
+stored as separate content-addressed objects rather than embedded directly.
+
+## Same-Tool Restore
+
+Same-tool restore does not require the unified model. It reassembles raw native
+segments, verifies hashes, validates the file, and writes it into the target
+tool's session directory.
+
+This path should be exact.
+
+## Cross-Tool Continuation
+
+Cross-tool continuation uses the unified model to produce a valid target
+session or import bundle.
+
+Rules:
+
+- Prefer creating a new target session over modifying an existing one.
+- Include a summary, recent transcript, important tool calls/results, file
+  changes, and environment context.
+- Use only fields the target adapter is known to accept.
+- Validate before install.
+- If validation fails, output a markdown/context bundle instead.
+
+## Adapter Contract
+
+Each adapter should implement:
+
+```text
+detect(paths) -> source sessions
+parse(raw records) -> canonical events
+validate_raw_restore(file) -> ok/errors
+write_same_tool_restore(raw file, destination) -> result
+export_continuation(canonical session, destination tool) -> candidate
+validate_export(candidate) -> ok/errors
+```
+
+Adapters are versioned independently because Claude, Codex, and Cursor formats
+can change without notice.
+

--- a/docs/fleet-track/v2-architecture.md
+++ b/docs/fleet-track/v2-architecture.md
@@ -1,0 +1,192 @@
+# FleetTrack V2 Architecture
+
+## Summary
+
+FleetTrack v2 should be a content-addressed session archive with explicit
+version commits.
+
+The current implementation uploads whole changed files. That is simple, but it
+does not scale for long hot JSONL sessions. A single large transcript that
+changes frequently can be re-uploaded many times, and the S3 bucket currently has
+versioning enabled.
+
+V2 should upload immutable compressed segments and advance a session ref only
+after all required objects are present.
+
+## Storage Model
+
+Use immutable objects for data and small mutable refs for latest state.
+
+```text
+fleet-track-sessions/
+  v2/
+    objects/
+      sha256/
+        ab/cd/{object_hash}.zst
+    sessions/
+      {team_id}/{user_id}/{source}/{source_session_id}/
+        versions/{version_id}.json
+        refs/latest.json
+        raw-paths/{path_hash}.json
+```
+
+`objects/` are content-addressed and immutable. They can be shared by multiple
+versions, devices, or restored sessions if hashes match.
+
+`versions/` are immutable manifests.
+
+`refs/latest.json` is the only mutable pointer. It should be updated by the
+server with parent-version checks.
+
+## Segment Boundaries
+
+For JSONL sources, the segmenter must cut only at complete JSONL record
+boundaries. It must ignore a trailing incomplete line until the next pass.
+
+Segment cut policy:
+
+- target compressed size: 1-8 MiB
+- hard uncompressed cap: configurable, initially 32 MiB
+- max records per segment: configurable, initially 5,000
+- max open time for active files: 30-120 seconds
+- boundary rule: complete JSONL records only
+
+If a single JSONL record exceeds the hard cap, store it as a one-record segment.
+Do not split the record.
+
+For plain text transcripts, use line boundaries if possible. For unknown binary
+or opaque files, either store whole-file objects or use fixed-size chunks with a
+separate "opaque" file type. Opaque files are restorable but not canonicalized.
+
+## Local Checkpoints
+
+The daemon should keep a checkpoint per logical source file:
+
+```json
+{
+  "schema_version": 1,
+  "source": "codex",
+  "path": ".codex/sessions/2026/04/session.jsonl",
+  "file_id": "stable id derived from source metadata or path",
+  "generation": 3,
+  "last_complete_offset": 12345678,
+  "last_record_seq": 9182,
+  "prefix_sha256": "...",
+  "latest_version_id": "..."
+}
+```
+
+The checkpoint is an optimization, not trust. Reconciliation can rebuild state
+from local records and remote manifests.
+
+Detect file rewrite/truncation by comparing size, mtime, and prefix hash. If a
+file shrinks or its known prefix no longer matches, increment `generation` and
+commit a new version lineage for that path.
+
+## Version Manifest
+
+Each version is an immutable commit:
+
+```json
+{
+  "schema_version": 2,
+  "version_id": "sha256 of canonical manifest body",
+  "parent_version_id": "...",
+  "source": "codex",
+  "source_session_id": "...",
+  "device_id": "...",
+  "created_at": "2026-04-29T00:00:00Z",
+  "logical_files": [
+    {
+      "path": ".codex/sessions/...",
+      "generation": 3,
+      "file_kind": "jsonl",
+      "segments": [
+        {
+          "seq_start": 0,
+          "seq_end": 999,
+          "record_count": 1000,
+          "start_offset": 0,
+          "end_offset": 881231,
+          "raw_sha256": "...",
+          "object_hash": "...",
+          "compression": "zstd"
+        }
+      ],
+      "file_sha256": "sha256 of full reassembled file when known"
+    }
+  ],
+  "canonical_projection": {
+    "schema": "fleet.session.v1",
+    "adapter": "codex@0.1.0",
+    "status": "pending"
+  }
+}
+```
+
+`version_id` should be content-derived from a canonical JSON body so commits are
+deduplicable and tamper-evident.
+
+## Server API
+
+The v1 API can remain for compatibility. Add v2 endpoints:
+
+```text
+POST /v2/track/plan
+POST /v2/track/commit
+GET  /v2/track/sessions
+GET  /v2/track/sessions/{session_id}/manifest
+POST /v2/track/restore-plan
+```
+
+`/plan` accepts candidate object hashes and returns presigned upload URLs only
+for missing objects.
+
+`/commit` accepts a version manifest and an expected parent ref. The server
+checks that all referenced objects exist, writes the immutable version, then
+conditionally advances `refs/latest.json`.
+
+`/restore-plan` returns a manifest and presigned download URLs for required
+objects.
+
+## CLI Surface
+
+Keep `flt track` as the product namespace.
+
+Initial commands:
+
+```text
+flt track enable
+flt track status
+flt track doctor
+flt track sessions list
+flt track sessions inspect <session-id>
+flt track sessions validate <session-id>
+flt track sessions restore <session-id> --tool codex --dry-run
+flt track sessions restore <session-id> --tool codex
+flt track sessions export <session-id> --format markdown
+```
+
+Later commands:
+
+```text
+flt track sessions continue <session-id> --from claude --to codex
+flt track sessions canonicalize <session-id>
+flt track sessions diff <session-id> --version A..B
+```
+
+`restore` defaults to dry-run validation unless `--yes` or an interactive prompt
+confirms writing into the live session directory.
+
+## Current Prototype Reuse
+
+Use the current daemon as the scaffolding for v2:
+
+- Replace file upload work items with segment upload work items.
+- Replace `manifest.json` flat map with version manifests.
+- Keep the SQLite queue, but make queue rows object/commit oriented.
+- Keep the presigned URL pattern, but make the server return URLs for missing
+  object hashes.
+- Keep full reconciliation, but compare logical session versions rather than
+  whole-file hashes.
+

--- a/docs/fleet-track/v2-git-like-sync-research.md
+++ b/docs/fleet-track/v2-git-like-sync-research.md
@@ -1,0 +1,321 @@
+# FleetTrack V2 Git-Like Sync Research
+
+## Summary
+
+FleetTrack v2 should keep the product surface of v1, but replace the storage
+protocol with a git-like commit model optimized for append-only agent session
+files.
+
+The design should not depend on S3 bucket versioning as product history. S3
+versioning can remain a recovery backstop, but FleetTrack history should be
+represented explicitly by immutable objects, immutable version manifests, and
+mutable refs.
+
+The practical model is:
+
+- content-addressed objects store compressed session byte ranges
+- commits/version manifests describe a complete logical session state
+- refs point to the latest version for a branch
+- branches are per device or per continuation by default
+- listing defaults to refs/latest, not every version
+
+## Current V1 Cadence
+
+The current daemon uploads whole changed files, not append segments.
+
+Observed from the SDK implementation:
+
+- A full reconciliation scan runs on startup and every 10 minutes.
+- Reconciliation hashes local source files and queues files whose hashes differ
+  from the remote manifest.
+- The daemon main loop drains the queue every 10 seconds.
+- Each queue drain claims up to 32 files.
+- Uploads run with 8 worker threads.
+- Presigned URL requests are chunked at 100 paths.
+- JSONL uploads trim a trailing incomplete line before upload.
+- The remote manifest is uploaded after pending and in-flight queue items drain.
+
+The file watcher module still exists, but v1 does not use watcher-driven uploads
+by default. This keeps v1 as a simple end-to-end sync path rather than an
+aggressive hot-file uploader.
+
+This means changed files are normally picked up by the next reconciliation pass,
+or immediately when running the one-shot E2E path.
+
+## Goals
+
+V2 should support:
+
+- efficient backup of long active JSONL sessions
+- exact same-tool restore from raw native bytes
+- explicit version history without relying on S3 object versions
+- latest-only default listing
+- opt-in version history and diff views
+- local-first validation before orchestrator rollout
+- v1 shipping in parallel without shaping the v2 protocol
+
+## Non-Goals For The First V2
+
+Do not implement merge semantics initially.
+
+Do not allow multiple devices to advance the same branch as a normal path. If a
+session is restored or continued on another device, create a new branch/ref.
+
+Do not make the canonical Fleet event model the archival source of truth. The raw
+native byte archive remains the exact restore source. Canonical events are a
+projection for search, inspection, and cross-tool continuation.
+
+## Storage Primitives
+
+### Object
+
+An object is immutable compressed bytes, addressed by hash.
+
+```text
+v2/objects/sha256/ab/cd/{object_hash}.zst
+```
+
+The object hash should cover the stored bytes. Segment metadata can separately
+record the raw uncompressed hash.
+
+### Segment
+
+A segment is a contiguous range of one logical source file.
+
+For JSONL files, segments must only cut at complete JSONL record boundaries. A
+trailing partial line is ignored until it becomes complete.
+
+Recommended first policy:
+
+- target compressed size: 1-8 MiB
+- hard uncompressed cap: 32 MiB
+- max records per segment: 5,000
+- max open segment age: 30-120 seconds
+
+### Version
+
+A version is an immutable manifest equivalent to a git commit. It describes a
+complete logical session state, not only the delta.
+
+```json
+{
+  "schema_version": 2,
+  "version_id": "sha256(canonical body without version_id)",
+  "parent_version_id": "previous version or null",
+  "fleet_session_id": "...",
+  "branch_id": "...",
+  "source": "codex",
+  "source_session_id": "...",
+  "source_device_id": "...",
+  "created_at": "2026-05-05T00:00:00Z",
+  "logical_files": [
+    {
+      "path": ".codex/sessions/2026/05/05/rollout-....jsonl",
+      "generation": 1,
+      "file_kind": "jsonl",
+      "segments": [
+        {
+          "seq_start": 0,
+          "seq_end": 499,
+          "record_count": 500,
+          "start_offset": 0,
+          "end_offset": 812345,
+          "raw_sha256": "...",
+          "object_hash": "...",
+          "compression": "zstd"
+        }
+      ],
+      "file_sha256": "known when complete or fully reassembled"
+    }
+  ]
+}
+```
+
+The manifest should be canonical JSON so `version_id` is deterministic and
+tamper-evident.
+
+### Ref
+
+A ref is a small mutable pointer to the latest version for a branch.
+
+```json
+{
+  "schema_version": 1,
+  "fleet_session_id": "...",
+  "branch_id": "...",
+  "latest_version_id": "...",
+  "updated_at": "2026-05-05T00:00:00Z"
+}
+```
+
+Default listing should read refs, not versions. Version history should be
+explicit through commands such as `flt track versions <session>` or
+`flt track ls --all-versions`.
+
+### Branch
+
+A branch is one append line of history. The initial branch id can be derived from
+device, tool, and native source session id.
+
+```text
+{source_device_id}:{source}:{source_session_id}
+```
+
+If a session is restored and continued on another device, the continuation should
+create a new branch. It can have `parent_version_id` pointing at the restored
+version, but it should not advance the source device's branch.
+
+This avoids merge/rebase complexity while preserving provenance.
+
+## Local Checkpoints
+
+The SDK should maintain a local checkpoint per logical source file.
+
+```json
+{
+  "schema_version": 1,
+  "source": "codex",
+  "path": ".codex/sessions/...",
+  "fleet_session_id": "...",
+  "branch_id": "...",
+  "generation": 1,
+  "last_complete_offset": 12345678,
+  "last_record_seq": 9182,
+  "prefix_sha256": "...",
+  "latest_version_id": "..."
+}
+```
+
+The checkpoint is an optimization, not authority. Reconciliation must be able to
+rebuild from local bytes and remote manifests.
+
+If a file shrinks or the known prefix hash no longer matches, increment
+`generation` and commit a new lineage for that file path.
+
+## Commit Cadence
+
+Do not commit every event.
+
+Use a bounded policy for active sessions:
+
+- commit when a segment reaches target size
+- commit when at least N complete records are available
+- commit after an idle window, initially 30-120 seconds
+- commit on daemon shutdown when possible
+- keep periodic full reconciliation as a backstop
+
+A good first default is:
+
+- `min_records_for_commit = 100`
+- `target_compressed_segment_size = 1 MiB`
+- `max_open_segment_age = 60 seconds`
+- `reconcile_interval = 10 minutes`
+
+The exact numbers can move after local benchmarks. The important property is
+that active sessions get near-real-time durability without creating one commit
+per JSONL row.
+
+## Orchestrator API
+
+The orchestrator remains the control plane. Large bytes go directly to S3 via
+presigned URLs.
+
+Required v2 endpoints:
+
+```text
+POST /v2/track/plan
+POST /v2/track/commit
+GET  /v2/track/sessions
+GET  /v2/track/sessions/{session_id}/versions
+GET  /v2/track/sessions/{session_id}/versions/{version_id}
+POST /v2/track/restore-plan
+```
+
+`/plan` accepts candidate object hashes, sizes, and content types. It returns
+presigned upload URLs only for missing objects.
+
+`/commit` accepts a version manifest, branch id, and expected parent version. The
+server validates that every referenced object exists, writes the immutable
+version, and advances the ref only if the expected parent still matches.
+
+Parent mismatches should be rare because branches are per device/continuation. If
+they happen, the server should reject the commit. The client can fetch the branch
+head and create a new continuation branch rather than attempting a merge.
+
+`/restore-plan` returns a selected version manifest plus presigned download URLs
+for required objects.
+
+## SDK Queue Model
+
+Keep the SQLite queue pattern, but change work items.
+
+V1 rows are effectively:
+
+```text
+upload_file(path, sha256)
+```
+
+V2 rows should be:
+
+```text
+upload_object(object_hash, local_spool_path, size, compression)
+commit_version(version_id, branch_id, expected_parent_version_id)
+```
+
+The commit item must not run until all referenced object upload items have
+succeeded.
+
+## Local Test Plan
+
+Build v2 locally before orchestrator changes are required.
+
+Use a filesystem-backed fake object store and fake commit store:
+
+```text
+.fleet/track/v2-local/
+  objects/sha256/...
+  sessions/.../versions/...
+  sessions/.../refs/...
+```
+
+Required local tests:
+
+- JSONL segmenter never splits records.
+- Trailing partial JSONL lines are ignored until complete.
+- Append-only update uploads only new segments.
+- Reassembly produces byte-identical raw files.
+- Object hashes verify before restore.
+- Version ids are deterministic for canonical manifests.
+- Default list returns only latest refs.
+- `--all-versions` or equivalent returns history.
+- File truncation/rewrite increments generation.
+- Restore writes through temp-file-and-rename.
+- Restored Claude/Codex files pass adapter validation in a temp `HOME`.
+
+These tests should run without network and without touching real user session
+directories.
+
+## Relationship To V1
+
+V1 can ship now as a bootstrap, but v2 should not be constrained by its storage
+shape.
+
+Reusable v1 pieces:
+
+- CLI namespace
+- auth
+- daemon install/status/logs
+- source discovery
+- SQLite queue infrastructure
+- presigned S3 upload pattern
+- periodic reconciliation
+
+Replace for v2:
+
+- whole-file uploads
+- flat `manifest.json`
+- path-keyed S3 objects as the main version model
+- hashes over local bytes that do not match uploaded scrubbed bytes
+
+If v2 is implemented cleanly, existing v1 S3 data can be ignored or imported by a
+one-off migration later. V2 should be the long-term restore/version protocol.

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -46,7 +46,15 @@ class BaseWrapper:
         jwt: Optional[str] = None,
         team_id: Optional[str] = None,
     ):
-        if api_key is None and not (jwt and team_id):
+        # Pin the auth mode at construction time. Falling back from
+        # "intended JWT" to api_key at request time produces
+        # `Authorization: Bearer None` when api_key is unset, which
+        # masks the real config error.
+        if jwt and team_id:
+            self._auth_mode = "jwt"
+        elif api_key:
+            self._auth_mode = "api_key"
+        else:
             raise ValueError("Provide api_key or both jwt and team_id")
         self.api_key = api_key
         self.jwt = jwt
@@ -60,10 +68,18 @@ class BaseWrapper:
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": __version__,
         }
-        if self.jwt and self.team_id:
+        if self._auth_mode == "jwt":
+            if not self.jwt or not self.team_id:
+                raise FleetAuthenticationError(
+                    "JWT auth was selected at init but jwt/team_id are no longer set"
+                )
             headers["X-JWT-Token"] = self.jwt
             headers["X-Team-ID"] = self.team_id
-        else:
+        else:  # "api_key"
+            if not self.api_key:
+                raise FleetAuthenticationError(
+                    "API-key auth was selected at init but api_key is no longer set"
+                )
             headers["Authorization"] = f"Bearer {self.api_key}"
 
         # Add request ID for idempotency (persists across retries)

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -38,10 +38,19 @@ class EnvironmentBase(InstanceResponse):
 
 
 class BaseWrapper:
-    def __init__(self, *, api_key: Optional[str], base_url: Optional[str]):
-        if api_key is None:
-            raise ValueError("api_key is required")
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str],
+        base_url: Optional[str],
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ):
+        if api_key is None and not (jwt and team_id):
+            raise ValueError("Provide api_key or both jwt and team_id")
         self.api_key = api_key
+        self.jwt = jwt
+        self.team_id = team_id
         if base_url is None:
             base_url = GLOBAL_BASE_URL
         self.base_url = base_url
@@ -51,7 +60,11 @@ class BaseWrapper:
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": __version__,
         }
-        headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.jwt and self.team_id:
+            headers["X-JWT-Token"] = self.jwt
+            headers["X-Team-ID"] = self.team_id
+        else:
+            headers["Authorization"] = f"Bearer {self.api_key}"
 
         # Add request ID for idempotency (persists across retries)
         if request_id:

--- a/fleet/_async/client.py
+++ b/fleet/_async/client.py
@@ -515,6 +515,8 @@ class AsyncFleet:
         httpx_client: Optional[httpx.AsyncClient] = None,
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float = DEFAULT_TIMEOUT,
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
     ):
         if api_key is None:
             api_key = os.getenv("FLEET_API_KEY")
@@ -525,6 +527,8 @@ class AsyncFleet:
             api_key=api_key,
             base_url=base_url,
             httpx_client=self._httpx_client,
+            jwt=jwt,
+            team_id=team_id,
         )
 
     async def list_envs(self) -> List[EnvironmentModel]:

--- a/fleet/_supabase.py
+++ b/fleet/_supabase.py
@@ -1,0 +1,6 @@
+# Placeholder values are replaced at build time by the publish workflow.
+# For local development, set SUPABASE_URL and SUPABASE_ANON_KEY env vars.
+import os
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "%%SUPABASE_URL%%")
+SUPABASE_ANON_KEY = os.environ.get("SUPABASE_ANON_KEY", "%%SUPABASE_ANON_KEY%%")

--- a/fleet/_supabase.py
+++ b/fleet/_supabase.py
@@ -2,5 +2,22 @@
 # For local development, set SUPABASE_URL and SUPABASE_ANON_KEY env vars.
 import os
 
-SUPABASE_URL = os.environ.get("SUPABASE_URL", "%%SUPABASE_URL%%")
-SUPABASE_ANON_KEY = os.environ.get("SUPABASE_ANON_KEY", "%%SUPABASE_ANON_KEY%%")
+_PLACEHOLDER_URL = "%%SUPABASE_URL%%"
+_PLACEHOLDER_ANON_KEY = "%%SUPABASE_ANON_KEY%%"
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL", _PLACEHOLDER_URL)
+SUPABASE_ANON_KEY = os.environ.get("SUPABASE_ANON_KEY", _PLACEHOLDER_ANON_KEY)
+
+
+def is_configured() -> bool:
+    """True if Supabase credentials are present and not the build-time
+    placeholders. Callers should check this before issuing requests so
+    we surface a clear "not configured" error instead of trying to POST
+    to a literal `%%SUPABASE_URL%%/...` and getting a cryptic DNS or
+    connection error from httpx."""
+    return (
+        bool(SUPABASE_URL)
+        and SUPABASE_URL != _PLACEHOLDER_URL
+        and bool(SUPABASE_ANON_KEY)
+        and SUPABASE_ANON_KEY != _PLACEHOLDER_ANON_KEY
+    )

--- a/fleet/_supabase.py
+++ b/fleet/_supabase.py
@@ -1,5 +1,6 @@
-# Placeholder values are replaced at build time by the publish workflow.
-# For local development, set SUPABASE_URL and SUPABASE_ANON_KEY env vars.
+# Supabase refresh is a temporary compatibility path for browser-login
+# credentials. Values must come from the runtime environment; do not bake them
+# into published distributions.
 import os
 
 _PLACEHOLDER_URL = "%%SUPABASE_URL%%"

--- a/fleet/auth.py
+++ b/fleet/auth.py
@@ -1,0 +1,101 @@
+"""Fleet CLI authentication — credential storage and token management."""
+
+import base64
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+from ._supabase import SUPABASE_ANON_KEY, SUPABASE_URL
+
+CREDENTIALS_FILE = Path.home() / ".fleet" / "credentials.json"
+
+# Refresh token 60 seconds before expiry to avoid race conditions
+_REFRESH_BUFFER_SECS = 60
+
+
+def save_credentials(data: dict) -> None:
+    """Write credentials to ~/.fleet/credentials.json with restricted permissions."""
+    CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(CREDENTIALS_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+    os.chmod(CREDENTIALS_FILE, 0o600)
+
+
+def load_credentials() -> Optional[dict]:
+    """Read credentials from ~/.fleet/credentials.json, or None if not present."""
+    if not CREDENTIALS_FILE.exists():
+        return None
+    try:
+        with open(CREDENTIALS_FILE) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def clear_credentials() -> None:
+    """Delete stored credentials."""
+    if CREDENTIALS_FILE.exists():
+        CREDENTIALS_FILE.unlink()
+
+
+def is_token_expired(access_token: str) -> bool:
+    """Return True if the JWT is expired or within the refresh buffer window."""
+    try:
+        payload_b64 = access_token.split(".")[1]
+        # JWT uses base64url; pad to a multiple of 4 (% 4 == 0 needs no padding)
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return time.time() > payload["exp"] - _REFRESH_BUFFER_SECS
+    except Exception:
+        return True
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    """Exchange a Supabase refresh token for a new session."""
+    response = httpx.post(
+        f"{SUPABASE_URL}/auth/v1/token?grant_type=refresh_token",
+        headers={
+            "apikey": SUPABASE_ANON_KEY,
+            "Content-Type": "application/json",
+        },
+        json={"refresh_token": refresh_token},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_valid_token() -> Optional[Tuple[str, str]]:
+    """Return (access_token, team_id) from stored credentials, refreshing if needed.
+
+    Returns None if the user is not logged in or credentials are unusable.
+    """
+    creds = load_credentials()
+    if not creds:
+        return None
+
+    access_token = creds.get("access_token")
+    team_id = creds.get("team_id")
+
+    if not access_token or not team_id:
+        return None
+
+    if is_token_expired(access_token):
+        stored_refresh = creds.get("refresh_token")
+        if not stored_refresh:
+            return None
+        try:
+            refreshed = refresh_access_token(stored_refresh)
+            access_token = refreshed["access_token"]
+            creds["access_token"] = access_token
+            if refreshed.get("refresh_token"):
+                creds["refresh_token"] = refreshed["refresh_token"]
+            save_credentials(creds)
+        except Exception:
+            return None
+
+    return (access_token, team_id)

--- a/fleet/auth.py
+++ b/fleet/auth.py
@@ -3,13 +3,18 @@
 import base64
 import json
 import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Optional, Tuple
 
 import httpx
 
-from ._supabase import SUPABASE_ANON_KEY, SUPABASE_URL, is_configured as _supabase_configured
+from ._supabase import (
+    SUPABASE_ANON_KEY,
+    SUPABASE_URL,
+    is_configured as _supabase_configured,
+)
 
 CREDENTIALS_FILE = Path.home() / ".fleet" / "credentials.json"
 
@@ -20,9 +25,29 @@ _REFRESH_BUFFER_SECS = 60
 def save_credentials(data: dict) -> None:
     """Write credentials to ~/.fleet/credentials.json with restricted permissions."""
     CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(CREDENTIALS_FILE, "w") as f:
-        json.dump(data, f, indent=2)
-    os.chmod(CREDENTIALS_FILE, 0o600)
+    fd, tmp = tempfile.mkstemp(
+        dir=CREDENTIALS_FILE.parent,
+        prefix=f".{CREDENTIALS_FILE.name}-",
+        suffix=".tmp",
+        text=True,
+    )
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, CREDENTIALS_FILE)
+        os.chmod(CREDENTIALS_FILE, 0o600)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def load_credentials() -> Optional[dict]:
@@ -59,8 +84,7 @@ def refresh_access_token(refresh_token: str) -> dict:
     if not _supabase_configured():
         raise RuntimeError(
             "Supabase credentials are not configured. Set SUPABASE_URL and "
-            "SUPABASE_ANON_KEY env vars, or use a published wheel where the "
-            "publish workflow injects them."
+            "SUPABASE_ANON_KEY env vars, or run `flt login` again."
         )
     response = httpx.post(
         f"{SUPABASE_URL}/auth/v1/token?grant_type=refresh_token",

--- a/fleet/auth.py
+++ b/fleet/auth.py
@@ -9,7 +9,7 @@ from typing import Optional, Tuple
 
 import httpx
 
-from ._supabase import SUPABASE_ANON_KEY, SUPABASE_URL
+from ._supabase import SUPABASE_ANON_KEY, SUPABASE_URL, is_configured as _supabase_configured
 
 CREDENTIALS_FILE = Path.home() / ".fleet" / "credentials.json"
 
@@ -56,6 +56,12 @@ def is_token_expired(access_token: str) -> bool:
 
 def refresh_access_token(refresh_token: str) -> dict:
     """Exchange a Supabase refresh token for a new session."""
+    if not _supabase_configured():
+        raise RuntimeError(
+            "Supabase credentials are not configured. Set SUPABASE_URL and "
+            "SUPABASE_ANON_KEY env vars, or use a published wheel where the "
+            "publish workflow injects them."
+        )
     response = httpx.post(
         f"{SUPABASE_URL}/auth/v1/token?grant_type=refresh_token",
         headers={

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -39,10 +39,19 @@ class EnvironmentBase(InstanceResponse):
 
 
 class BaseWrapper:
-    def __init__(self, *, api_key: Optional[str], base_url: Optional[str]):
-        if api_key is None:
-            raise ValueError("api_key is required")
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str],
+        base_url: Optional[str],
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ):
+        if api_key is None and not (jwt and team_id):
+            raise ValueError("Provide api_key or both jwt and team_id")
         self.api_key = api_key
+        self.jwt = jwt
+        self.team_id = team_id
         if base_url is None:
             base_url = GLOBAL_BASE_URL
         self.base_url = base_url
@@ -52,7 +61,11 @@ class BaseWrapper:
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": __version__,
         }
-        headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.jwt and self.team_id:
+            headers["X-JWT-Token"] = self.jwt
+            headers["X-Team-ID"] = self.team_id
+        else:
+            headers["Authorization"] = f"Bearer {self.api_key}"
 
         # Add request ID for idempotency (persists across retries)
         if request_id:

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -47,7 +47,15 @@ class BaseWrapper:
         jwt: Optional[str] = None,
         team_id: Optional[str] = None,
     ):
-        if api_key is None and not (jwt and team_id):
+        # Pin the auth mode at construction time. Falling back from
+        # "intended JWT" to api_key at request time produces
+        # `Authorization: Bearer None` when api_key is unset, which
+        # masks the real config error.
+        if jwt and team_id:
+            self._auth_mode = "jwt"
+        elif api_key:
+            self._auth_mode = "api_key"
+        else:
             raise ValueError("Provide api_key or both jwt and team_id")
         self.api_key = api_key
         self.jwt = jwt
@@ -61,10 +69,18 @@ class BaseWrapper:
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": __version__,
         }
-        if self.jwt and self.team_id:
+        if self._auth_mode == "jwt":
+            if not self.jwt or not self.team_id:
+                raise FleetAuthenticationError(
+                    "JWT auth was selected at init but jwt/team_id are no longer set"
+                )
             headers["X-JWT-Token"] = self.jwt
             headers["X-Team-ID"] = self.team_id
-        else:
+        else:  # "api_key"
+            if not self.api_key:
+                raise FleetAuthenticationError(
+                    "API-key auth was selected at init but api_key is no longer set"
+                )
             headers["Authorization"] = f"Bearer {self.api_key}"
 
         # Add request ID for idempotency (persists across retries)

--- a/fleet/cli.py
+++ b/fleet/cli.py
@@ -44,10 +44,13 @@ sessions_app = typer.Typer(help="Manage sessions", no_args_is_help=True)
 eval_app = typer.Typer(help="Run evaluations", no_args_is_help=True)
 projects_app = typer.Typer(help="Manage projects", no_args_is_help=True)
 
+from .track.cli import app as track_app  # noqa: E402
+
 app.add_typer(jobs_app, name="jobs")
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(eval_app, name="eval")
 app.add_typer(projects_app, name="projects")
+app.add_typer(track_app, name="track")
 
 console = Console()
 
@@ -82,16 +85,25 @@ def format_status(status: Optional[str]) -> str:
 
 
 def get_client() -> Fleet:
-    """Get a Fleet client using environment variables."""
+    """Get a Fleet client, preferring FLEET_API_KEY then stored login credentials."""
     api_key = os.getenv("FLEET_API_KEY")
-    if not api_key:
-        console.print(
-            "[red]Error:[/red] FLEET_API_KEY environment variable not set",
-            style="bold",
-        )
-        raise typer.Exit(1)
     base_url = os.getenv("FLEET_BASE_URL", CLI_DEFAULT_BASE_URL)
-    return Fleet(api_key=api_key, base_url=base_url)
+
+    if api_key:
+        return Fleet(api_key=api_key, base_url=base_url)
+
+    from .auth import get_valid_token
+
+    result = get_valid_token()
+    if result:
+        jwt, team_id = result
+        return Fleet(jwt=jwt, team_id=team_id, base_url=base_url)
+
+    console.print(
+        "[red]Not authenticated.[/red] Run [bold]flt login[/bold] or set FLEET_API_KEY.",
+        style="bold",
+    )
+    raise typer.Exit(1)
 
 
 def _run_oversight(job_id: str, model: str = "anthropic/claude-sonnet-4"):
@@ -1050,6 +1062,147 @@ def eval_run(
             console.print(f"[dim]Check status: flt jobs get {job_id}[/dim]")
             if oversight:
                 console.print(f"[dim]Run oversight manually: flt jobs oversight {job_id}[/dim]")
+
+
+@app.command()
+def login():
+    """Authenticate the CLI by logging in through the Fleet web app."""
+    import secrets
+    import socket
+    import threading
+    import webbrowser
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from urllib.parse import parse_qs, urlparse
+
+    from .auth import save_credentials
+
+    state = secrets.token_urlsafe(16)
+    result: dict = {}
+    server_ready = threading.Event()
+    done = threading.Event()
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+            if params.get("state") != state:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Invalid state")
+                return
+
+            result.update(params)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<html><body><h1>Fleet CLI login complete.</h1>"
+                b"<p>You can close this window.</p></body></html>"
+            )
+            done.set()
+
+        def log_message(self, format, *args):
+            return
+
+    def serve():
+        server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+        server_ready.set()
+        while not done.is_set():
+            server.handle_request()
+        server.server_close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    server_ready.wait()
+
+    login_url = f"https://fleetai.com/cli-login?port={port}&state={state}"
+    console.print("[bold]Opening Fleet login in your browser...[/bold]")
+    console.print(f"[dim]If the browser didn't open, visit:[/dim] {login_url}")
+    webbrowser.open(login_url)
+
+    console.print("[dim]Waiting for authentication (Ctrl+C to cancel)...[/dim]")
+    try:
+        done.wait(timeout=300)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Login cancelled.[/yellow]")
+        raise typer.Exit(1)
+
+    if not result.get("access_token"):
+        console.print("[red]Login failed - no token received.[/red]")
+        raise typer.Exit(1)
+
+    save_credentials(
+        {
+            "email": result.get("email", ""),
+            "access_token": result["access_token"],
+            "refresh_token": result.get("refresh_token", ""),
+            "team_id": result["team_id"],
+            "team_name": result.get("team_name", ""),
+            "expires_at": result.get("expires_at", ""),
+        }
+    )
+
+    email = result.get("email", "unknown")
+    team_name = result.get("team_name", result["team_id"])
+    console.print(f"\n[green]✓[/green] Logged in as [bold]{email}[/bold] (Team: {team_name})")
+
+
+@app.command()
+def logout():
+    """Clear stored Fleet credentials."""
+    from .auth import clear_credentials, load_credentials
+
+    creds = load_credentials()
+    if not creds:
+        console.print("[dim]Not logged in.[/dim]")
+        return
+
+    clear_credentials()
+    email = creds.get("email", "")
+    console.print(f"[green]✓[/green] Logged out{f' ({email})' if email else ''}.")
+
+
+@app.command()
+def whoami():
+    """Show current authentication status."""
+    from .auth import CREDENTIALS_FILE, get_valid_token, load_credentials
+
+    api_key = os.getenv("FLEET_API_KEY")
+    if api_key:
+        console.print("[bold]Auth:[/bold] API key (FLEET_API_KEY)")
+        console.print(f"[bold]Key:[/bold] {api_key[:8]}...{api_key[-4:]}")
+        return
+
+    creds = load_credentials()
+    if not creds:
+        console.print("[dim]Not logged in.[/dim] Run [bold]flt login[/bold].")
+        return
+
+    token_result = get_valid_token()
+    if not token_result:
+        console.print(
+            "[yellow]Stored credentials are expired.[/yellow] "
+            "Run [bold]flt login[/bold] again."
+        )
+        return
+
+    console.print(f"[bold]Auth:[/bold] Browser login ({CREDENTIALS_FILE})")
+    if creds.get("email"):
+        console.print(f"[bold]Email:[/bold] {creds['email']}")
+    if creds.get("team_name"):
+        console.print(f"[bold]Team:[/bold] {creds['team_name']}")
+    if creds.get("team_id"):
+        console.print(f"[bold]Team ID:[/bold] {creds['team_id']}")
 
 
 def main():

--- a/fleet/cli.py
+++ b/fleet/cli.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 # Load .env file if present (before other imports that might need env vars)
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
     pass  # python-dotenv not installed, skip
@@ -20,7 +21,14 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, TaskProgressColumn, TimeRemainingColumn
+    from rich.progress import (
+        Progress,
+        SpinnerColumn,
+        BarColumn,
+        TextColumn,
+        TaskProgressColumn,
+        TimeRemainingColumn,
+    )
     from rich.table import Table
 except ImportError:
     print(
@@ -58,6 +66,13 @@ console = Console()
 CLI_DEFAULT_BASE_URL = "https://us-west-1.fleetai.com"
 
 
+def _mask_secret(value: str) -> str:
+    """Mask a credential without exposing short values in full."""
+    if len(value) <= 16:
+        return "[redacted]"
+    return f"{value[:8]}...{value[-4:]}"
+
+
 def colorize_score(score: float) -> str:
     """Color a score from red (0.0) to yellow (0.5) to green (1.0)."""
     if score >= 0.7:
@@ -72,7 +87,7 @@ def format_status(status: Optional[str]) -> str:
     """Format job status with color and clean text."""
     if not status:
         return "[dim]-[/dim]"
-    
+
     status_map = {
         "completed": "[green]✓ completed[/green]",
         "in_progress": "[yellow]● running[/yellow]",
@@ -109,18 +124,20 @@ def get_client() -> Fleet:
 def _run_oversight(job_id: str, model: str = "anthropic/claude-sonnet-4"):
     """Run oversight summarization on a completed job."""
     import httpx
-    
+
     api_key = os.getenv("FLEET_API_KEY")
     if not api_key:
-        console.print("[yellow]Warning:[/yellow] FLEET_API_KEY not set, skipping oversight")
+        console.print(
+            "[yellow]Warning:[/yellow] FLEET_API_KEY not set, skipping oversight"
+        )
         return
-    
+
     base_url = os.getenv("FLEET_BASE_URL", CLI_DEFAULT_BASE_URL)
     oversight_url = f"{base_url}/v1/summarize/job"
-    
+
     console.print()
     console.print("[bold]Running Oversight Analysis...[/bold]")
-    
+
     try:
         with httpx.Client(timeout=300) as client:
             response = client.post(
@@ -138,16 +155,20 @@ def _run_oversight(job_id: str, model: str = "anthropic/claude-sonnet-4"):
                     "max_concurrent": 20,
                 },
             )
-            
+
             if response.status_code == 200:
                 result = response.json()
                 console.print(f"[green]✓[/green] Oversight analysis started")
                 if "summary_id" in result:
                     console.print(f"  Summary ID: [cyan]{result['summary_id']}[/cyan]")
                 # Show link to dashboard
-                console.print(f"  View: [cyan]https://fleetai.com/dashboard/jobs/{job_id}[/cyan]")
+                console.print(
+                    f"  View: [cyan]https://fleetai.com/dashboard/jobs/{job_id}[/cyan]"
+                )
             else:
-                console.print(f"[yellow]Warning:[/yellow] Oversight API returned {response.status_code}")
+                console.print(
+                    f"[yellow]Warning:[/yellow] Oversight API returned {response.status_code}"
+                )
                 console.print(f"  {response.text[:200]}")
     except Exception as e:
         console.print(f"[yellow]Warning:[/yellow] Oversight request failed: {e}")
@@ -158,7 +179,9 @@ def _run_oversight(job_id: str, model: str = "anthropic/claude-sonnet-4"):
 
 @jobs_app.command("list")
 def list_jobs(
-    team_id: Optional[str] = typer.Option(None, "--team-id", help="Filter by team ID (admin only)"),
+    team_id: Optional[str] = typer.Option(
+        None, "--team-id", help="Filter by team ID (admin only)"
+    ),
     output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """List all jobs."""
@@ -188,32 +211,63 @@ def list_jobs(
         )
 
     console.print(table)
-    
+
     # Show tips with a real job ID from the results
     first_job_id = jobs[0].id
     console.print()
     console.print("[dim]Tips:[/dim]")
     console.print(f"[dim]  Job details:       flt jobs get {first_job_id}[/dim]")
     console.print(f"[dim]  Job sessions:      flt jobs sessions {first_job_id}[/dim]")
-    console.print(f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]")
+    console.print(
+        f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]"
+    )
 
 
 @jobs_app.command("create")
 def create_job(
-    model: List[str] = typer.Option(..., "--model", "-m", help="Model in 'provider/model' format (repeatable)"),
-    env_key: Optional[str] = typer.Option(None, "--env-key", "-e", help="Environment key"),
-    project_key: Optional[str] = typer.Option(None, "--project-key", "-p", help="Project key"),
-    task_keys: Optional[List[str]] = typer.Option(None, "--task-key", "-t", help="Task key (repeatable)"),
-    name: Optional[str] = typer.Option(None, "--name", "-n", help="Job name. Supports placeholders: {id} (UUID), {sid} (short UUID), {i} (auto-increment, must be suffix)"),
+    model: List[str] = typer.Option(
+        ..., "--model", "-m", help="Model in 'provider/model' format (repeatable)"
+    ),
+    env_key: Optional[str] = typer.Option(
+        None, "--env-key", "-e", help="Environment key"
+    ),
+    project_key: Optional[str] = typer.Option(
+        None, "--project-key", "-p", help="Project key"
+    ),
+    task_keys: Optional[List[str]] = typer.Option(
+        None, "--task-key", "-t", help="Task key (repeatable)"
+    ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Job name. Supports placeholders: {id} (UUID), {sid} (short UUID), {i} (auto-increment, must be suffix)",
+    ),
     pass_k: int = typer.Option(1, "--pass-k", help="Number of passes"),
-    max_steps: Optional[int] = typer.Option(None, "--max-steps", help="Maximum agent steps"),
+    max_steps: Optional[int] = typer.Option(
+        None, "--max-steps", help="Maximum agent steps"
+    ),
     max_duration: int = typer.Option(60, "--max-duration", help="Timeout in minutes"),
-    max_concurrent: int = typer.Option(30, "--max-concurrent", help="Max concurrent per model"),
-    mode: Optional[str] = typer.Option(None, "--mode", help="Mode: 'tool-use' or 'computer-use'"),
-    system_prompt: Optional[str] = typer.Option(None, "--system-prompt", help="Custom system prompt"),
-    model_prompt: Optional[List[str]] = typer.Option(None, "--model-prompt", help="Per-model prompt in 'provider/model=prompt' format (repeatable)"),
-    byok: Optional[List[str]] = typer.Option(None, "--byok", help="Bring Your Own Key in 'provider=key' format (repeatable)"),
-    byok_ttl: Optional[int] = typer.Option(None, "--byok-ttl", help="TTL for BYOK keys in minutes"),
+    max_concurrent: int = typer.Option(
+        30, "--max-concurrent", help="Max concurrent per model"
+    ),
+    mode: Optional[str] = typer.Option(
+        None, "--mode", help="Mode: 'tool-use' or 'computer-use'"
+    ),
+    system_prompt: Optional[str] = typer.Option(
+        None, "--system-prompt", help="Custom system prompt"
+    ),
+    model_prompt: Optional[List[str]] = typer.Option(
+        None,
+        "--model-prompt",
+        help="Per-model prompt in 'provider/model=prompt' format (repeatable)",
+    ),
+    byok: Optional[List[str]] = typer.Option(
+        None, "--byok", help="Bring Your Own Key in 'provider=key' format (repeatable)"
+    ),
+    byok_ttl: Optional[int] = typer.Option(
+        None, "--byok-ttl", help="TTL for BYOK keys in minutes"
+    ),
     harness: Optional[str] = typer.Option(None, "--harness", help="Harness identifier"),
     output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
@@ -260,7 +314,7 @@ def create_job(
             byok_keys[provider] = key
 
     client = get_client()
-    
+
     try:
         result = client.create_job(
             models=model,
@@ -299,7 +353,9 @@ def create_job(
 @jobs_app.command("get")
 def get_job(
     job_id: str = typer.Argument(..., help="Job ID"),
-    team_id: Optional[str] = typer.Option(None, "--team-id", help="Team ID (admin only)"),
+    team_id: Optional[str] = typer.Option(
+        None, "--team-id", help="Team ID (admin only)"
+    ),
     output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Get details for a specific job."""
@@ -315,12 +371,14 @@ def get_job(
     console.print(f"  Name: {job.name or '-'}")
     console.print(f"  Status: {format_status(job.status)}")
     console.print(f"  Created At: {job.created_at or '-'}")
-    
+
     # Show tips
     console.print()
     console.print("[dim]Tips:[/dim]")
     console.print(f"[dim]  Job sessions:      flt jobs sessions {job.id}[/dim]")
-    console.print(f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]")
+    console.print(
+        f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]"
+    )
 
 
 @jobs_app.command("sessions")
@@ -341,11 +399,15 @@ def list_job_sessions(
 
     first_session_id = None
     for task_group in result.tasks:
-        task_name = task_group.task.key if task_group.task else task_group.task_id or "Unknown"
+        task_name = (
+            task_group.task.key if task_group.task else task_group.task_id or "Unknown"
+        )
         pass_rate_pct = task_group.pass_rate * 100
 
         console.print(f"[bold green]Task:[/bold green] {task_name}")
-        console.print(f"  Pass Rate: {task_group.passed_sessions}/{task_group.total_sessions} ({pass_rate_pct:.1f}%)")
+        console.print(
+            f"  Pass Rate: {task_group.passed_sessions}/{task_group.total_sessions} ({pass_rate_pct:.1f}%)"
+        )
         if task_group.average_score is not None:
             console.print(f"  Average Score: {task_group.average_score:.2f}")
 
@@ -383,13 +445,20 @@ def list_job_sessions(
     # Show tips with a real session ID
     if first_session_id:
         console.print("[dim]Tips:[/dim]")
-        console.print(f"[dim]  Session transcript: flt sessions transcript {first_session_id}[/dim]")
+        console.print(
+            f"[dim]  Session transcript: flt sessions transcript {first_session_id}[/dim]"
+        )
 
 
 @jobs_app.command("oversight")
 def run_job_oversight(
     job_id: str = typer.Argument(..., help="Job ID to analyze"),
-    model: str = typer.Option("anthropic/claude-sonnet-4", "--model", "-m", help="Model for oversight analysis"),
+    model: str = typer.Option(
+        "anthropic/claude-sonnet-4",
+        "--model",
+        "-m",
+        help="Model for oversight analysis",
+    ),
 ):
     """Run AI oversight analysis on a job."""
     _run_oversight(job_id, model)
@@ -430,12 +499,18 @@ def get_session_transcript(
 
     # Verifier result
     if result.verifier_execution:
-        status = "[green]PASS[/green]" if result.verifier_execution.success else "[red]FAIL[/red]"
+        status = (
+            "[green]PASS[/green]"
+            if result.verifier_execution.success
+            else "[red]FAIL[/red]"
+        )
         console.print(f"[bold]Verifier Result:[/bold] {status}")
         if result.verifier_execution.score is not None:
             score_colored = colorize_score(result.verifier_execution.score)
             console.print(f"  Score: {score_colored}")
-        console.print(f"  Execution Time: {result.verifier_execution.execution_time_ms}ms")
+        console.print(
+            f"  Execution Time: {result.verifier_execution.execution_time_ms}ms"
+        )
         console.print()
 
     # Transcript
@@ -471,7 +546,9 @@ def get_session_transcript(
                     elif item.get("type") == "image_url":
                         console.print(f"  [dim][Image][/dim]")
                     elif item.get("type") == "tool_use":
-                        console.print(f"  [dim]Tool: {item.get('name', 'unknown')}[/dim]")
+                        console.print(
+                            f"  [dim]Tool: {item.get('name', 'unknown')}[/dim]"
+                        )
                     elif item.get("type") == "tool_result":
                         console.print(f"  [dim]Tool Result[/dim]")
                 else:
@@ -498,26 +575,26 @@ def list_projects(
 ):
     """List all active projects."""
     client = get_client()
-    
+
     # Call the projects endpoint directly since there's no SDK method yet
     response = client.client.request("GET", "/v1/tasks/projects")
     data = response.json()
-    
+
     if output_json:
         console.print(json.dumps(data, indent=2, default=str))
         return
-    
+
     projects = data.get("projects", [])
-    
+
     if not projects:
         console.print("No projects found.")
         return
-    
+
     table = Table(title="Projects")
     table.add_column("Project Key", style="cyan", no_wrap=True)
     table.add_column("Modality", style="blue")
     table.add_column("Created At", style="dim")
-    
+
     for project in projects:
         modality = project.get("task_modality") or "-"
         # Clean up modality display
@@ -525,21 +602,23 @@ def list_projects(
             modality = "tool-use"
         elif modality == "computer_use":
             modality = "computer-use"
-        
+
         table.add_row(
             project.get("project_key", "-"),
             modality,
             project.get("created_at", "-"),
         )
-    
+
     console.print(table)
-    
+
     # Show tips
     if projects:
         first_project = projects[0].get("project_key", "my-project")
         console.print()
         console.print("[dim]Tips:[/dim]")
-        console.print(f"[dim]  Run eval: flt eval run -p {first_project} -m openai/gpt-4o-mini[/dim]")
+        console.print(
+            f"[dim]  Run eval: flt eval run -p {first_project} -m openai/gpt-4o-mini[/dim]"
+        )
 
 
 # Eval commands
@@ -563,10 +642,10 @@ def _run_local_agent(
     """Run agent locally with Docker-based browser control."""
     import asyncio
     import logging
-    
+
     if verbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(name)s: %(message)s')
-    
+        logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
+
     # Parse API keys
     api_keys = {}
     if os.getenv("GEMINI_API_KEY"):
@@ -575,17 +654,23 @@ def _run_local_agent(
         api_keys["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
     if os.getenv("ANTHROPIC_API_KEY"):
         api_keys["ANTHROPIC_API_KEY"] = os.getenv("ANTHROPIC_API_KEY")
-    
+
     # Parse BYOK and add to api_keys
     if byok:
-        provider_to_env = {"google": "GEMINI_API_KEY", "openai": "OPENAI_API_KEY", "anthropic": "ANTHROPIC_API_KEY"}
+        provider_to_env = {
+            "google": "GEMINI_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "anthropic": "ANTHROPIC_API_KEY",
+        }
         for b in byok:
             if "=" not in b:
                 console.print(f"[red]Error:[/red] Invalid --byok format: {b}")
                 raise typer.Exit(1)
             provider, key = b.split("=", 1)
-            api_keys[provider_to_env.get(provider.lower(), f"{provider.upper()}_API_KEY")] = key
-    
+            api_keys[
+                provider_to_env.get(provider.lower(), f"{provider.upper()}_API_KEY")
+            ] = key
+
     # Check for required API key based on agent
     if "gemini" in agent.lower() and "GEMINI_API_KEY" not in api_keys:
         console.print("[red]Error:[/red] GEMINI_API_KEY required for gemini_cua agent")
@@ -596,12 +681,16 @@ def _run_local_agent(
         console.print("Or pass via --byok:")
         console.print("  [cyan]flt eval run ... --byok google=your-key[/cyan]")
         raise typer.Exit(1)
-    
+
     if verbose:
         console.print(f"[dim]API keys configured: {list(api_keys.keys())}[/dim]")
-    
+
     # Display config (matching remote format)
-    suite_name = project_key if project_key else (', '.join(task_keys) if task_keys else "all tasks")
+    suite_name = (
+        project_key
+        if project_key
+        else (", ".join(task_keys) if task_keys else "all tasks")
+    )
     console.print()
     console.print("[green bold]Eval started[/green bold] [dim](local)[/dim]")
     console.print()
@@ -611,11 +700,14 @@ def _run_local_agent(
     console.print(f"  [bold]Max Steps[/bold]   {max_steps}")
     console.print(f"  [bold]Concurrent[/bold]  {max_concurrent}")
     if headful:
-        console.print(f"  [bold]Headful[/bold]     [green]Yes[/green] (browser visible via noVNC)")
+        console.print(
+            f"  [bold]Headful[/bold]     [green]Yes[/green] (browser visible via noVNC)"
+        )
     console.print()
-    
+
     async def run():
         from fleet.agent import run_agent
+
         return await run_agent(
             project_key=project_key,
             task_keys=task_keys,
@@ -628,10 +720,10 @@ def _run_local_agent(
             headful=headful,
             verbose=verbose,
         )
-    
+
     console.print("[dim]Starting...[/dim]")
     console.print()
-    
+
     job_id = None
     try:
         results, job_id = asyncio.run(run())
@@ -642,47 +734,56 @@ def _run_local_agent(
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
-    
+
     # Display results
     if output_json:
         output = []
         for r in results:
-            output.append({
-                "task_key": r.task_key,
-                "task_prompt": r.task_prompt,
-                "completed": r.agent_result.completed if r.agent_result else False,
-                "final_answer": r.agent_result.final_answer if r.agent_result else None,
-                "verification_success": r.verification_success,
-                "verification_score": r.verification_score,
-                "error": r.error or (r.agent_result.error if r.agent_result else None),
-                "steps_taken": r.agent_result.steps_taken if r.agent_result else 0,
-                "execution_time_ms": r.execution_time_ms,
-            })
+            output.append(
+                {
+                    "task_key": r.task_key,
+                    "task_prompt": r.task_prompt,
+                    "completed": r.agent_result.completed if r.agent_result else False,
+                    "final_answer": r.agent_result.final_answer
+                    if r.agent_result
+                    else None,
+                    "verification_success": r.verification_success,
+                    "verification_score": r.verification_score,
+                    "error": r.error
+                    or (r.agent_result.error if r.agent_result else None),
+                    "steps_taken": r.agent_result.steps_taken if r.agent_result else 0,
+                    "execution_time_ms": r.execution_time_ms,
+                }
+            )
         console.print(json.dumps(output, indent=2))
         return
-    
+
     # Show dashboard link panel (matching remote format)
     console.print()
     if job_id:
-        console.print(Panel(
-            f"[bold]Live agent traces[/bold]\n\n  https://www.fleetai.com/dashboard/jobs/{job_id}",
-            border_style="cyan",
-        ))
+        console.print(
+            Panel(
+                f"[bold]Live agent traces[/bold]\n\n  https://www.fleetai.com/dashboard/jobs/{job_id}",
+                border_style="cyan",
+            )
+        )
         console.print()
         console.print("[dim]Tips:[/dim]")
         console.print(f"[dim]  Job details:        flt jobs get {job_id}[/dim]")
         console.print(f"[dim]  Job sessions:       flt jobs sessions {job_id}[/dim]")
-        console.print(f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]")
-    
+        console.print(
+            f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]"
+        )
+
     # Summary
     console.print()
     console.print("[bold]Results[/bold]")
     console.print("-" * 60)
-    
+
     errors = 0
     scores = []
     completed = 0
-    
+
     for r in results:
         if r.error:
             status = "[red]ERROR[/red]"
@@ -708,27 +809,31 @@ def _run_local_agent(
             completed += 1
         else:
             status = "[red]INCOMPLETE[/red]"
-        
+
         key = r.task_key[:40] + "..." if len(r.task_key) > 40 else r.task_key
         console.print(f"  {status}  {key}")
-        
+
         if r.error:
             # Show first 100 chars of error
-            err = r.error.replace('\n', ' ')[:100]
+            err = r.error.replace("\n", " ")[:100]
             console.print(f"         [dim]{err}[/dim]")
-    
+
     console.print("-" * 60)
-    
+
     total = len(results)
     if total > 0:
         console.print(f"[bold]Completed:[/bold] {completed}/{total}")
         if scores:
             avg_score = sum(scores) / len(scores)
-            score_color = "green" if avg_score >= 0.7 else "yellow" if avg_score >= 0.4 else "red"
-            console.print(f"[bold]Avg. Score:[/bold] [{score_color}]{avg_score:.2f}[/{score_color}]")
+            score_color = (
+                "green" if avg_score >= 0.7 else "yellow" if avg_score >= 0.4 else "red"
+            )
+            console.print(
+                f"[bold]Avg. Score:[/bold] [{score_color}]{avg_score:.2f}[/{score_color}]"
+            )
         if errors:
             console.print(f"[bold]Errors:[/bold] [red]{errors}[/red]")
-    
+
     # Run oversight if requested
     if oversight and job_id:
         _run_oversight(job_id, oversight_model)
@@ -738,12 +843,13 @@ def _listen_for_detach_key(stop_event: threading.Event):
     """Listen for Ctrl+B in a background thread to signal detachment."""
     try:
         # Platform-specific keyboard input handling
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             import msvcrt
+
             while not stop_event.is_set():
                 if msvcrt.kbhit():
                     ch = msvcrt.getch()
-                    if ch == b'\x02':  # Ctrl+B
+                    if ch == b"\x02":  # Ctrl+B
                         stop_event.set()
                         break
                 time.sleep(0.1)
@@ -760,7 +866,7 @@ def _listen_for_detach_key(stop_event: threading.Event):
                     # Check if input is available with timeout
                     if select.select([sys.stdin], [], [], 0.1)[0]:
                         ch = sys.stdin.read(1)
-                        if ch == '\x02':  # Ctrl+B
+                        if ch == "\x02":  # Ctrl+B
                             stop_event.set()
                             break
             finally:
@@ -772,24 +878,49 @@ def _listen_for_detach_key(stop_event: threading.Event):
 
 @eval_app.command("run")
 def eval_run(
-    project_key: Optional[str] = typer.Option(None, "--project", "-p", help="Project key to evaluate"),
-    task_keys: Optional[List[str]] = typer.Option(None, "--task", "-t", help="Specific task key(s) to run (repeatable)"),
-    model: List[str] = typer.Option(..., "--model", "-m", help="Model (e.g., google/gemini-2.5-pro)"),
+    project_key: Optional[str] = typer.Option(
+        None, "--project", "-p", help="Project key to evaluate"
+    ),
+    task_keys: Optional[List[str]] = typer.Option(
+        None, "--task", "-t", help="Specific task key(s) to run (repeatable)"
+    ),
+    model: List[str] = typer.Option(
+        ..., "--model", "-m", help="Model (e.g., google/gemini-2.5-pro)"
+    ),
     name: Optional[str] = typer.Option(None, "--name", "-n", help="Job name"),
     pass_k: int = typer.Option(1, "--pass-k", "-k", help="Number of passes per task"),
-    max_steps: Optional[int] = typer.Option(None, "--max-steps", help="Maximum agent steps"),
+    max_steps: Optional[int] = typer.Option(
+        None, "--max-steps", help="Maximum agent steps"
+    ),
     max_duration: int = typer.Option(60, "--max-duration", help="Timeout in minutes"),
-    max_concurrent: int = typer.Option(30, "--max-concurrent", help="Max concurrent per model"),
-    byok: Optional[List[str]] = typer.Option(None, "--byok", help="Bring Your Own Key: 'provider=key'"),
+    max_concurrent: int = typer.Option(
+        30, "--max-concurrent", help="Max concurrent per model"
+    ),
+    byok: Optional[List[str]] = typer.Option(
+        None, "--byok", help="Bring Your Own Key: 'provider=key'"
+    ),
     no_watch: bool = typer.Option(False, "--no-watch", help="Don't watch progress"),
     output_json: bool = typer.Option(False, "--json", help="Output as JSON"),
     # Local execution
-    local: Optional[str] = typer.Option(None, "--local", "-l", help="Run locally. Use 'gemini_cua' for built-in or path for custom agent"),
-    headful: bool = typer.Option(False, "--headful", help="Show browser via noVNC (local mode)"),
+    local: Optional[str] = typer.Option(
+        None,
+        "--local",
+        "-l",
+        help="Run locally. Use 'gemini_cua' for built-in or path for custom agent",
+    ),
+    headful: bool = typer.Option(
+        False, "--headful", help="Show browser via noVNC (local mode)"
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show debug output"),
     # Oversight
-    oversight: bool = typer.Option(False, "--oversight", help="Run AI oversight analysis on job completion"),
-    oversight_model: str = typer.Option("anthropic/claude-sonnet-4", "--oversight-model", help="Model for oversight analysis"),
+    oversight: bool = typer.Option(
+        False, "--oversight", help="Run AI oversight analysis on job completion"
+    ),
+    oversight_model: str = typer.Option(
+        "anthropic/claude-sonnet-4",
+        "--oversight-model",
+        help="Model for oversight analysis",
+    ),
 ):
     """
     Run an evaluation on a project or specific tasks.
@@ -798,24 +929,26 @@ def eval_run(
     Examples:
       # Cloud execution (default)
       flt eval run -p my-project -m google/gemini-2.5-pro
-      
+
       # Run specific task(s)
       flt eval run -t task_abc123 -m google/gemini-2.5-pro --local gemini_cua
-      
+
       # Local with built-in agent
       flt eval run -p my-project -m google/gemini-2.5-pro --local gemini_cua
-      
+
       # Local with headful mode (watch the browser)
       flt eval run -p my-project -m google/gemini-2.5-pro --local gemini_cua --headful
-      
+
       # Local with custom agent
       flt eval run -p my-project -m google/gemini-2.5-pro --local ./my-agent
     """
     # Validate: need either project or task keys
     if not project_key and not task_keys:
-        console.print("[red]Error:[/red] Either --project (-p) or --task (-t) must be specified")
+        console.print(
+            "[red]Error:[/red] Either --project (-p) or --task (-t) must be specified"
+        )
         raise typer.Exit(1)
-    
+
     # Local mode
     if local is not None:
         _run_local_agent(
@@ -834,9 +967,9 @@ def eval_run(
             oversight_model=oversight_model,
         )
         return
-    
+
     client = get_client()
-    
+
     # Parse BYOK keys
     byok_keys = None
     if byok:
@@ -850,7 +983,7 @@ def eval_run(
                 raise typer.Exit(1)
             provider, key = b.split("=", 1)
             byok_keys[provider] = key
-    
+
     try:
         result = client.create_job(
             models=model,
@@ -865,7 +998,7 @@ def eval_run(
         )
     except Exception as e:
         error_str = str(e)
-        
+
         # Check if it's a model not found error and format nicely
         if "not found" in error_str.lower() and "available models" in error_str.lower():
             console.print(f"[red]Error:[/red] Invalid model specified")
@@ -876,6 +1009,7 @@ def eval_run(
                     models_part = error_str.split("Available models:")[1].strip()
                     # Parse the list string
                     import ast
+
                     available = ast.literal_eval(models_part)
                     console.print("[bold]Available models:[/bold]")
                     for m in sorted(available):
@@ -885,13 +1019,13 @@ def eval_run(
         else:
             console.print(f"[red]Error creating job:[/red] {e}")
         raise typer.Exit(1)
-    
+
     job_id = result.job_id
-    
+
     if output_json:
         console.print(json.dumps(result.model_dump(), indent=2, default=str))
         return
-    
+
     # Display summary
     suite_name = project_key if project_key else "all tasks"
     job_name = name or result.name  # Use provided name or server-generated name
@@ -905,26 +1039,32 @@ def eval_run(
     console.print(f"  [bold]Passes[/bold]    {pass_k}")
     console.print(f"  [bold]Job ID[/bold]    [cyan]{job_id}[/cyan]")
     console.print()
-    
+
     # Show dashboard link
-    console.print(Panel(
-        f"[bold]Live agent traces[/bold]\n\n  https://www.fleetai.com/dashboard/jobs/{job_id}",
-        border_style="cyan",
-    ))
+    console.print(
+        Panel(
+            f"[bold]Live agent traces[/bold]\n\n  https://www.fleetai.com/dashboard/jobs/{job_id}",
+            border_style="cyan",
+        )
+    )
     console.print()
-    
+
     # Show tips
     console.print("[dim]Tips:[/dim]")
     console.print(f"[dim]  Job details:       flt jobs get {job_id}[/dim]")
     console.print(f"[dim]  Job sessions:      flt jobs sessions {job_id}[/dim]")
-    console.print(f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]")
+    console.print(
+        f"[dim]  Session transcript: flt sessions transcript <session-id>[/dim]"
+    )
     console.print()
-    
+
     if no_watch:
         return
-    
+
     # Watch progress
-    console.print("[dim]Watching progress... (Press Ctrl+B to detach, job continues running)[/dim]")
+    console.print(
+        "[dim]Watching progress... (Press Ctrl+B to detach, job continues running)[/dim]"
+    )
     console.print()
 
     # Terminal statuses for sessions
@@ -935,7 +1075,9 @@ def eval_run(
     detach_event = threading.Event()
 
     # Start keyboard listener thread
-    listener_thread = threading.Thread(target=_listen_for_detach_key, args=(detach_event,), daemon=True)
+    listener_thread = threading.Thread(
+        target=_listen_for_detach_key, args=(detach_event,), daemon=True
+    )
     listener_thread.start()
 
     try:
@@ -948,20 +1090,21 @@ def eval_run(
             console=console,
         ) as progress:
             task = progress.add_task("[cyan]Starting eval...", total=None)
-            
+
             while True:
                 # Poll sessions for progress
                 try:
                     sessions_response = client.list_job_sessions(job_id)
                     total = sessions_response.total_sessions
-                    
+
                     # Count sessions in terminal state
                     completed = sum(
-                        1 for tg in sessions_response.tasks 
-                        for s in tg.sessions 
+                        1
+                        for tg in sessions_response.tasks
+                        for s in tg.sessions
                         if s.status in TERMINAL_SESSION_STATUSES
                     )
-                    
+
                     # Count passed sessions and collect scores
                     passed = 0
                     scores = []
@@ -972,31 +1115,28 @@ def eval_run(
                                     passed += 1
                                 if s.verifier_execution.score is not None:
                                     scores.append(s.verifier_execution.score)
-                    
+
                     # Calculate average score
                     avg_score = sum(scores) / len(scores) if scores else None
-                    
+
                     if total > 0:
                         # Build description with score if available
                         if avg_score is not None:
                             desc = f"[cyan]Running ({completed}/{total}) | {passed} passed | avg: {avg_score:.2f}[/cyan]"
                         else:
                             desc = f"[cyan]Running ({completed}/{total}) | {passed} passed[/cyan]"
-                        
+
                         progress.update(
-                            task, 
-                            completed=completed, 
-                            total=total,
-                            description=desc
+                            task, completed=completed, total=total, description=desc
                         )
-                        
+
                         # Check if all sessions are done
                         if completed >= total:
                             break
                 except:
                     # Sessions endpoint might not be ready yet
                     pass
-                
+
                 # Also check job status as fallback
                 try:
                     job = client.get_job(job_id)
@@ -1011,21 +1151,21 @@ def eval_run(
                     break
 
                 time.sleep(3)  # Poll every 3 seconds
-        
+
         # Show final status
         console.print()
         try:
             job = client.get_job(job_id)
             console.print(f"[bold]Final Status:[/bold] {format_status(job.status)}")
-            
+
             # Show summary stats
             sessions_response = client.list_job_sessions(job_id)
             total_passed = sum(tg.passed_sessions for tg in sessions_response.tasks)
             total_sessions = sessions_response.total_sessions
-            
+
             if total_sessions > 0:
                 pass_rate = (total_passed / total_sessions) * 100
-                
+
                 # Color the pass rate
                 if pass_rate >= 70:
                     rate_color = "green"
@@ -1033,9 +1173,11 @@ def eval_run(
                     rate_color = "yellow"
                 else:
                     rate_color = "red"
-                
-                console.print(f"[bold]Pass Rate:[/bold] [{rate_color}]{total_passed}/{total_sessions} ({pass_rate:.1f}%)[/{rate_color}]")
-                
+
+                console.print(
+                    f"[bold]Pass Rate:[/bold] [{rate_color}]{total_passed}/{total_sessions} ({pass_rate:.1f}%)[/{rate_color}]"
+                )
+
                 # Show per-task breakdown if multiple tasks
                 if len(sessions_response.tasks) > 1:
                     console.print()
@@ -1043,10 +1185,12 @@ def eval_run(
                     for tg in sessions_response.tasks:
                         task_name = tg.task.key if tg.task else tg.task_id or "Unknown"
                         task_rate = tg.pass_rate * 100
-                        console.print(f"  {task_name}: {tg.passed_sessions}/{tg.total_sessions} ({task_rate:.0f}%)")
+                        console.print(
+                            f"  {task_name}: {tg.passed_sessions}/{tg.total_sessions} ({task_rate:.0f}%)"
+                        )
         except:
             pass
-        
+
         # Run oversight if requested and job completed (not detached)
         if oversight and not detached:
             _run_oversight(job_id, oversight_model)
@@ -1058,103 +1202,197 @@ def eval_run(
         # Show detached message if user pressed Ctrl+B
         if detached:
             console.print()
-            console.print("[yellow]Detached. Eval continues running in background.[/yellow]")
+            console.print(
+                "[yellow]Detached. Eval continues running in background.[/yellow]"
+            )
             console.print(f"[dim]Check status: flt jobs get {job_id}[/dim]")
             if oversight:
-                console.print(f"[dim]Run oversight manually: flt jobs oversight {job_id}[/dim]")
+                console.print(
+                    f"[dim]Run oversight manually: flt jobs oversight {job_id}[/dim]"
+                )
 
 
 @app.command()
 def login():
     """Authenticate the CLI by logging in through the Fleet web app."""
     import secrets
-    import socket
     import threading
     import webbrowser
     from http.server import BaseHTTPRequestHandler, HTTPServer
-    from urllib.parse import parse_qs, urlparse
+    from urllib.parse import parse_qs, urlencode, urlparse
 
     from .auth import save_credentials
 
     state = secrets.token_urlsafe(16)
     result: dict = {}
-    server_ready = threading.Event()
     done = threading.Event()
 
-    sock = socket.socket()
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-    sock.close()
+    callback_bridge = b"""<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Fleet CLI login</title></head>
+  <body>
+    <h1>Completing Fleet CLI login...</h1>
+    <script>
+      (async () => {
+        const raw = window.location.hash.length > 1
+          ? window.location.hash.slice(1)
+          : window.location.search.slice(1);
+        window.history.replaceState(null, "", "/callback");
+        if (!raw) {
+          document.body.innerHTML = "<h1>Fleet CLI login failed.</h1><p>No credentials received.</p>";
+          return;
+        }
+        const response = await fetch("/callback", {
+          method: "POST",
+          headers: {"Content-Type": "application/x-www-form-urlencoded"},
+          body: raw
+        });
+        if (response.ok) {
+          document.body.innerHTML = "<h1>Fleet CLI login complete.</h1><p>You can close this window.</p>";
+        } else {
+          document.body.innerHTML = "<h1>Fleet CLI login failed.</h1><p>Return to your terminal and retry.</p>";
+        }
+      })();
+    </script>
+  </body>
+</html>"""
 
     class CallbackHandler(BaseHTTPRequestHandler):
+        def _send_html(self, status: int, body: bytes) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
         def do_GET(self):
             parsed = urlparse(self.path)
             if parsed.path != "/callback":
-                self.send_response(404)
-                self.end_headers()
+                self._send_html(404, b"Not found")
                 return
 
-            params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+            self._send_html(200, callback_bridge)
+
+        def do_POST(self):
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self._send_html(404, b"Not found")
+                return
+
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                content_length = 0
+            if content_length <= 0 or content_length > 32_768:
+                result["error"] = "invalid callback payload"
+                done.set()
+                self._send_html(400, b"Invalid callback payload")
+                return
+
+            body = self.rfile.read(content_length).decode("utf-8", errors="replace")
+            params = {
+                k: v[0] for k, v in parse_qs(body, keep_blank_values=True).items()
+            }
             if params.get("state") != state:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid state")
+                result["error"] = "invalid callback state"
+                done.set()
+                self._send_html(400, b"Invalid state")
+                return
+            if not params.get("access_token"):
+                result["error"] = "no token received"
+                done.set()
+                self._send_html(400, b"No token received")
+                return
+            if not params.get("team_id"):
+                result["error"] = "no team_id received"
+                done.set()
+                self._send_html(400, b"No team_id received")
                 return
 
             result.update(params)
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            self.wfile.write(
-                b"<html><body><h1>Fleet CLI login complete.</h1>"
-                b"<p>You can close this window.</p></body></html>"
-            )
             done.set()
+            self._send_html(
+                200,
+                b"<html><body><h1>Fleet CLI login complete.</h1>"
+                b"<p>You can close this window.</p></body></html>",
+            )
 
         def log_message(self, format, *args):
             return
 
+    try:
+        server = HTTPServer(("127.0.0.1", 0), CallbackHandler)
+    except OSError as e:
+        console.print(f"[red]Could not start local login callback server:[/red] {e}")
+        raise typer.Exit(1)
+    server.timeout = 1.0
+    port = server.server_address[1]
+
     def serve():
-        server = HTTPServer(("127.0.0.1", port), CallbackHandler)
-        server_ready.set()
-        while not done.is_set():
-            server.handle_request()
-        server.server_close()
+        try:
+            while not done.is_set():
+                server.handle_request()
+        finally:
+            server.server_close()
 
     thread = threading.Thread(target=serve, daemon=True)
     thread.start()
-    server_ready.wait()
 
-    login_url = f"https://fleetai.com/cli-login?port={port}&state={state}"
+    login_url = "https://fleetai.com/cli-login?" + urlencode(
+        {
+            "port": port,
+            "state": state,
+            "response_mode": "fragment_post",
+        }
+    )
     console.print("[bold]Opening Fleet login in your browser...[/bold]")
     console.print(f"[dim]If the browser didn't open, visit:[/dim] {login_url}")
     webbrowser.open(login_url)
 
     console.print("[dim]Waiting for authentication (Ctrl+C to cancel)...[/dim]")
     try:
-        done.wait(timeout=300)
+        authenticated = done.wait(timeout=300)
     except KeyboardInterrupt:
+        done.set()
+        thread.join(timeout=2)
         console.print("\n[yellow]Login cancelled.[/yellow]")
         raise typer.Exit(1)
 
-    if not result.get("access_token"):
+    if not authenticated:
+        done.set()
+        thread.join(timeout=2)
+        console.print("[red]Login timed out.[/red]")
+        raise typer.Exit(1)
+    thread.join(timeout=2)
+
+    if result.get("error"):
+        console.print(f"[red]Login failed - {result['error']}.[/red]")
+        raise typer.Exit(1)
+    access_token = result.get("access_token")
+    team_id = result.get("team_id")
+    if not access_token:
         console.print("[red]Login failed - no token received.[/red]")
+        raise typer.Exit(1)
+    if not team_id:
+        console.print("[red]Login failed - no team_id received.[/red]")
         raise typer.Exit(1)
 
     save_credentials(
         {
             "email": result.get("email", ""),
-            "access_token": result["access_token"],
+            "access_token": access_token,
             "refresh_token": result.get("refresh_token", ""),
-            "team_id": result["team_id"],
+            "team_id": team_id,
             "team_name": result.get("team_name", ""),
             "expires_at": result.get("expires_at", ""),
         }
     )
 
     email = result.get("email", "unknown")
-    team_name = result.get("team_name", result["team_id"])
-    console.print(f"\n[green]✓[/green] Logged in as [bold]{email}[/bold] (Team: {team_name})")
+    team_name = result.get("team_name", team_id)
+    console.print(
+        f"\n[green]✓[/green] Logged in as [bold]{email}[/bold] (Team: {team_name})"
+    )
 
 
 @app.command()
@@ -1180,7 +1418,7 @@ def whoami():
     api_key = os.getenv("FLEET_API_KEY")
     if api_key:
         console.print("[bold]Auth:[/bold] API key (FLEET_API_KEY)")
-        console.print(f"[bold]Key:[/bold] {api_key[:8]}...{api_key[-4:]}")
+        console.print(f"[bold]Key:[/bold] {_mask_secret(api_key)}")
         return
 
     creds = load_credentials()

--- a/fleet/client.py
+++ b/fleet/client.py
@@ -527,6 +527,8 @@ class Fleet:
         httpx_client: Optional[httpx.Client] = None,
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float = DEFAULT_TIMEOUT,
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
     ):
         if api_key is None:
             api_key = os.getenv("FLEET_API_KEY")
@@ -537,6 +539,8 @@ class Fleet:
             api_key=api_key,
             base_url=base_url,
             httpx_client=self._httpx_client,
+            jwt=jwt,
+            team_id=team_id,
         )
 
     def list_envs(self) -> List[EnvironmentModel]:

--- a/fleet/track/__init__.py
+++ b/fleet/track/__init__.py
@@ -1,0 +1,103 @@
+"""Fleet track — passive AI session sidecar.
+
+This package handles three things:
+
+  1. **Sync** local AI session files (claude, codex, cursor, opencode)
+     to a backing store (LocalSessionStore today; RemoteSessionStore
+     against theseus eventually).
+  2. **Convert** between session formats via a unified Event model so
+     a session written by one CLI can be resumed in another.
+  3. **Resume** sessions — same-tool (passes through to the native CLI)
+     or cross-tool (converts via unified, drops a checkout file the
+     target CLI's resume scan finds).
+
+The public surface below is what consumers should import. Internals
+(parsers, daemon plumbing, CLI commands) live in submodules and aren't
+re-exported here.
+"""
+
+from __future__ import annotations
+
+# --- Unified event model + format conversion --- #
+from .compactor import (
+    Compactor,
+    KNOWN_MODELS,
+    TokenBudget,
+    TruncationCompactor,
+    TruncationConfig,
+    budget_for,
+    estimate_event_tokens,
+    estimate_tokens,
+)
+from .converter import ConversionResult, convert
+from .paths import TrackPaths
+from .resumer import (
+    SUPPORTED_TOOLS,
+    CheckoutInfo,
+    gc_checkouts,
+    resume_session,
+)
+
+# --- Session store + chained view --- #
+from .sources import (
+    ClaudeSource,
+    CodexSource,
+    CursorSource,
+    Source,
+    SourceSummary,
+    default_sources,
+)
+from .store import (
+    ChainedSessionStore,
+    LocalSessionStore,
+    NativeFilesSessionStore,
+    Session,
+    SessionStore,
+)
+from .unified import (
+    AssistantMessage,
+    AssistantReasoning,
+    Attachment,
+    Event,
+    FileEdit,
+    Lifecycle,
+    OpaqueEvent,
+    Operator,
+    SessionEnd,
+    SessionStart,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+    ToolSpec,
+    TurnEnd,
+    TurnStart,
+    UserMessage,
+)
+
+__all__ = [
+    # Paths
+    "TrackPaths",
+    # Unified format
+    "Event",
+    "SessionStart", "SessionEnd",
+    "TurnStart", "TurnEnd",
+    "UserMessage", "AssistantMessage", "AssistantReasoning",
+    "ToolCall", "ToolResult", "ToolSpec",
+    "TokenUsage", "FileEdit",
+    "Operator", "Attachment", "Lifecycle", "OpaqueEvent",
+    # Sources
+    "Source", "SourceSummary",
+    "ClaudeSource", "CodexSource", "CursorSource",
+    "default_sources",
+    # Sessions
+    "Session", "SessionStore",
+    "LocalSessionStore", "NativeFilesSessionStore", "ChainedSessionStore",
+    # Compaction
+    "Compactor", "TruncationCompactor", "TruncationConfig",
+    "TokenBudget", "KNOWN_MODELS", "budget_for",
+    "estimate_tokens", "estimate_event_tokens",
+    # Resume + conversion
+    "resume_session", "CheckoutInfo", "SUPPORTED_TOOLS",
+    "convert", "ConversionResult",
+    "gc_checkouts",
+]

--- a/fleet/track/__init__.py
+++ b/fleet/track/__init__.py
@@ -3,8 +3,8 @@
 This package handles three things:
 
   1. **Sync** local AI session files (claude, codex, cursor, opencode)
-     to a backing store (LocalSessionStore today; RemoteSessionStore
-     against theseus eventually).
+     to a backing store (LocalSessionStore locally; RemoteSessionStore
+     against orchestrator).
   2. **Convert** between session formats via a unified Event model so
      a session written by one CLI can be resumed in another.
   3. **Resume** sessions — same-tool (passes through to the native CLI)
@@ -51,6 +51,7 @@ from .store import (
     ChainedSessionStore,
     LocalSessionStore,
     NativeFilesSessionStore,
+    RemoteSessionStore,
     Session,
     SessionStore,
 )
@@ -79,25 +80,50 @@ __all__ = [
     "TrackPaths",
     # Unified format
     "Event",
-    "SessionStart", "SessionEnd",
-    "TurnStart", "TurnEnd",
-    "UserMessage", "AssistantMessage", "AssistantReasoning",
-    "ToolCall", "ToolResult", "ToolSpec",
-    "TokenUsage", "FileEdit",
-    "Operator", "Attachment", "Lifecycle", "OpaqueEvent",
+    "SessionStart",
+    "SessionEnd",
+    "TurnStart",
+    "TurnEnd",
+    "UserMessage",
+    "AssistantMessage",
+    "AssistantReasoning",
+    "ToolCall",
+    "ToolResult",
+    "ToolSpec",
+    "TokenUsage",
+    "FileEdit",
+    "Operator",
+    "Attachment",
+    "Lifecycle",
+    "OpaqueEvent",
     # Sources
-    "Source", "SourceSummary",
-    "ClaudeSource", "CodexSource", "CursorSource",
+    "Source",
+    "SourceSummary",
+    "ClaudeSource",
+    "CodexSource",
+    "CursorSource",
     "default_sources",
     # Sessions
-    "Session", "SessionStore",
-    "LocalSessionStore", "NativeFilesSessionStore", "ChainedSessionStore",
+    "Session",
+    "SessionStore",
+    "LocalSessionStore",
+    "NativeFilesSessionStore",
+    "RemoteSessionStore",
+    "ChainedSessionStore",
     # Compaction
-    "Compactor", "TruncationCompactor", "TruncationConfig",
-    "TokenBudget", "KNOWN_MODELS", "budget_for",
-    "estimate_tokens", "estimate_event_tokens",
+    "Compactor",
+    "TruncationCompactor",
+    "TruncationConfig",
+    "TokenBudget",
+    "KNOWN_MODELS",
+    "budget_for",
+    "estimate_tokens",
+    "estimate_event_tokens",
     # Resume + conversion
-    "resume_session", "CheckoutInfo", "SUPPORTED_TOOLS",
-    "convert", "ConversionResult",
+    "resume_session",
+    "CheckoutInfo",
+    "SUPPORTED_TOOLS",
+    "convert",
+    "ConversionResult",
     "gc_checkouts",
 ]

--- a/fleet/track/_picker_page.py
+++ b/fleet/track/_picker_page.py
@@ -1,0 +1,165 @@
+"""fzf-reload helper: emit a page of session lines for the picker.
+
+Invoked by `pick_session` via fzf's `--bind` reload triggers:
+
+  - `change:reload(... --direction query --query {q})` — fired on every
+    keystroke; resets to page 0 with the new query string. fzf's own
+    fuzzy filtering is `--disabled` so this is the only path that
+    surfaces matching rows.
+  - `right:reload(... --direction next)` — paginate within the current
+    query.
+  - `left:reload(... --direction prev)` — go back one page.
+  - `alt-h:reload(... --direction first)` — back to page 0.
+
+State file (JSON):
+
+    {
+      "source":         "stub" | "native" | "remote" | "auto",
+      "tool":           Optional[str],
+      "cwd":            Optional[str],
+      "since":          Optional[str],
+      "query":          str,
+      "limit":          int,
+      "current_index":  int,
+      "cursors":        list[str|None]  # cursor used to fetch each page
+    }
+
+`cursors[i]` is the cursor passed to `store.page()` to load page `i`.
+Bidirectional walks work because cursors are deterministic w.r.t.
+their inputs — re-fetching page `i` with `cursors[i]` returns the same
+rows (modulo concurrent inserts, which are fine to surface).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    path.write_text(json.dumps(state))
+
+
+def _resolve_store(source: str):
+    # Lazy-import so this script stays fast to start. Reuses the CLI's
+    # store-resolution so behavior is consistent with the rest of `flt
+    # track` (auto chains, native filters, etc.).
+    from .cli import _resolve_session_store
+    return _resolve_session_store(source)
+
+
+def _fetch(state: dict[str, Any], cursor: Any):
+    store = _resolve_store(state["source"])
+    return store.page(
+        tool=state.get("tool"),
+        cwd=state.get("cwd"),
+        since=state.get("since"),
+        query=state.get("query") or None,
+        limit=state.get("limit", 20),
+        cursor=cursor,
+    )
+
+
+def _emit_page(
+    state: dict[str, Any],
+    direction: str,
+) -> tuple[list[str], dict[str, Any]]:
+    """Return (lines, updated_state).
+
+    `direction`:
+      - "query" — query already replaced upstream; reset to page 0.
+      - "first" — same as query but keep the existing query string.
+      - "next"  — advance one page (no-op at last).
+      - "prev"  — go back one page (no-op at page 0).
+    """
+    from .picker import _format_line
+
+    cursors = list(state.get("cursors") or [None])
+    idx = state.get("current_index", 0)
+
+    if direction in ("query", "first"):
+        # New query (or explicit reset) → page 0 of fresh result set.
+        new_idx = 0
+        cursors = [None]
+    elif direction == "next":
+        if idx + 1 < len(cursors):
+            new_idx = idx + 1
+        else:
+            # Need the current page's next_cursor before we can advance.
+            _, next_cursor = _fetch(state, cursors[idx])
+            if next_cursor is None:
+                return [], state  # already at last page
+            cursors.append(next_cursor)
+            new_idx = idx + 1
+    elif direction == "prev":
+        if idx == 0:
+            return [], state  # already at first page
+        new_idx = idx - 1
+    else:
+        raise SystemExit(f"unknown direction: {direction!r}")
+
+    items, next_cursor = _fetch(state, cursors[new_idx])
+    if next_cursor is not None and new_idx + 1 == len(cursors):
+        cursors.append(next_cursor)
+
+    lines = [_format_line(s) for s in items]
+    new_state = {
+        **state,
+        "current_index": new_idx,
+        "cursors": cursors,
+    }
+    return lines, new_state
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Internal helper for fzf reload paging in the track picker.",
+    )
+    parser.add_argument("--state-file", required=True)
+    parser.add_argument(
+        "--direction",
+        choices=["next", "prev", "first", "query"],
+        default="next",
+    )
+    parser.add_argument(
+        "--query",
+        default=None,
+        help="Replaces state.query when --direction=query (else ignored).",
+    )
+    args = parser.parse_args(argv)
+
+    state_path = Path(args.state_file)
+    state = _load_state(state_path)
+
+    if args.direction == "query":
+        # `{q}` from fzf may be empty (zero-length query) — treat as no filter.
+        state = {**state, "query": args.query or ""}
+
+    lines, new_state = _emit_page(state, args.direction)
+    _save_state(state_path, new_state)
+
+    # No-op at boundaries (first/last page, or "next" with nothing more):
+    # re-emit the current page so fzf's reload doesn't end up empty.
+    if not lines:
+        items, _ = _fetch(
+            new_state,
+            new_state.get("cursors", [None])[new_state.get("current_index", 0)],
+        )
+        from .picker import _format_line
+        lines = [_format_line(s) for s in items]
+
+    sys.stdout.write("\n".join(lines))
+    if lines:
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -1,0 +1,153 @@
+"""Theseus track API client.
+
+Three endpoints:
+  POST /v1/track/provision     → register machine, get S3 prefix
+  GET  /v1/track/manifest      → fetch remote Merkle state
+  POST /v1/track/upload-urls   → get presigned S3 PUT URLs for a list of paths
+
+Tests inject an `httpx.Client` built on `httpx.MockTransport` plus a fake
+auth provider, so no network and no creds file ever touch a unit test.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import socket
+from typing import Callable, Optional, Tuple
+
+import httpx
+
+from ..config import GLOBAL_BASE_URL
+
+log = logging.getLogger("fleet.track.api")
+
+DEFAULT_TIMEOUT = 30.0
+SERVER_UPLOAD_URL_BATCH_CAP = 100  # /v1/track/upload-urls returns 400 above this.
+
+
+# (access_token, team_id) — None when unauthenticated.
+AuthProvider = Callable[[], Optional[Tuple[str, str]]]
+
+
+class TrackAPIError(Exception):
+    pass
+
+
+def _default_auth_provider() -> Optional[Tuple[str, str]]:
+    """Production auth: read from `~/.fleet/credentials.json`."""
+    from ..auth import get_valid_token
+
+    return get_valid_token()
+
+
+def _default_base_url() -> str:
+    return (os.getenv("FLEET_TRACK_BASE_URL", GLOBAL_BASE_URL)).rstrip("/")
+
+
+class TrackAPIClient:
+    """Wraps the three /v1/track/* endpoints.
+
+    Constructor accepts either an `httpx.Client` (production: real network)
+    or an `httpx.Client(transport=httpx.MockTransport(handler))` (tests).
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Optional[httpx.Client] = None,
+        auth_provider: AuthProvider = _default_auth_provider,
+        base_url: Optional[str] = None,
+    ) -> None:
+        self._auth = auth_provider
+        if client is not None:
+            self._client = client
+            self._owns_client = False
+        else:
+            self._client = httpx.Client(
+                base_url=base_url or _default_base_url(),
+                timeout=DEFAULT_TIMEOUT,
+            )
+            self._owns_client = True
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> "TrackAPIClient":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------ #
+    # Endpoints                                                            #
+    # ------------------------------------------------------------------ #
+
+    def provision(self, device_id: str) -> dict:
+        """Register this device. Returns {device_id, team_id, user_id}."""
+        resp = self._client.post(
+            "/v1/track/provision",
+            json={
+                "device_id": device_id,
+                "hostname": socket.gethostname(),
+                "platform": platform.system().lower(),
+            },
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
+    def get_manifest(self, device_id: str) -> dict[str, str]:
+        """Fetch the remote Merkle manifest. Returns {} on first run."""
+        resp = self._client.get(
+            "/v1/track/manifest",
+            headers=self._headers(device_id=device_id),
+        )
+        _raise(resp)
+        return resp.json().get("files", {})
+
+    def get_upload_urls(self, device_id: str, paths: list[str]) -> dict[str, str]:
+        """Request presigned PUT URLs. Server caps batches at 100; we
+        chunk to match so a callsite asking for more never 400s."""
+        if not paths:
+            return {}
+
+        urls: dict[str, str] = {}
+        for chunk_start in range(0, len(paths), SERVER_UPLOAD_URL_BATCH_CAP):
+            chunk = paths[chunk_start : chunk_start + SERVER_UPLOAD_URL_BATCH_CAP]
+            resp = self._client.post(
+                "/v1/track/upload-urls",
+                json={"device_id": device_id, "paths": chunk},
+                headers=self._headers(),
+            )
+            _raise(resp)
+            urls.update(resp.json().get("urls", {}))
+        return urls
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _headers(self, device_id: Optional[str] = None) -> dict[str, str]:
+        token_info = self._auth()
+        if not token_info:
+            raise TrackAPIError("Not authenticated — run `flt login`")
+        access_token, team_id = token_info
+        headers = {
+            "X-JWT-Token": access_token,
+            "X-Team-ID": team_id,
+        }
+        if device_id:
+            headers["X-Device-ID"] = device_id
+        return headers
+
+
+def _raise(resp: httpx.Response) -> None:
+    if resp.status_code >= 400:
+        try:
+            detail = resp.json().get("detail", resp.text)
+        except Exception:
+            detail = resp.text
+        raise TrackAPIError(f"HTTP {resp.status_code}: {detail}")

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -1,9 +1,15 @@
 """Theseus track API client.
 
-Three endpoints:
+Upload endpoints:
   POST /v1/track/provision     → register machine, get S3 prefix
   GET  /v1/track/manifest      → fetch remote Merkle state
   POST /v1/track/upload-urls   → get presigned S3 PUT URLs for a list of paths
+
+Metadata endpoints:
+  POST /v1/track/sessions/{id}         → upsert one session metadata row
+  GET  /v1/track/sessions              → list/search remote sessions
+  GET  /v1/track/sessions/{id}         → fetch one session metadata row
+  GET  /v1/track/sessions/{id}/content → get a presigned S3 GET URL
 
 Tests inject an `httpx.Client` built on `httpx.MockTransport` plus a fake
 auth provider, so no network and no creds file ever touch a unit test.
@@ -15,7 +21,8 @@ import logging
 import os
 import platform
 import socket
-from typing import Callable, Optional, Tuple
+from dataclasses import asdict, is_dataclass
+from typing import Any, Callable, Mapping, Optional, Tuple
 
 import httpx
 
@@ -32,7 +39,16 @@ AuthProvider = Callable[[], Optional[Tuple[str, str]]]
 
 
 class TrackAPIError(Exception):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        detail: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.detail = detail
 
 
 def _default_auth_provider() -> Optional[Tuple[str, str]]:
@@ -126,6 +142,84 @@ class TrackAPIClient:
             urls.update(resp.json().get("urls", {}))
         return urls
 
+    def upsert_session(
+        self,
+        *,
+        device_id: str,
+        path: str,
+        session: Any,
+    ) -> None:
+        """Register metadata for a session file already uploaded to S3.
+
+        `path` is the source file path relative to the tracked home. The
+        orchestrator owns translation from that relative path to the final S3
+        key, so the SDK never has to construct team/user/device storage paths.
+        """
+        resp = self._client.post(
+            f"/v1/track/sessions/{_session_id(session)}",
+            json={
+                "device_id": device_id,
+                "path": path,
+                "session": _session_payload(session),
+            },
+            headers=self._headers(),
+        )
+        _raise(resp)
+
+    def list_sessions(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = 50,
+        cursor: Optional[str] = None,
+    ) -> dict:
+        params = _clean_params(
+            {
+                "tool": tool,
+                "cwd": cwd,
+                "since": since,
+                "query": query,
+                "limit": limit,
+                "cursor": cursor,
+            }
+        )
+        resp = self._client.get(
+            "/v1/track/sessions",
+            params=params,
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
+    def get_session(self, session_id: str) -> dict:
+        resp = self._client.get(
+            f"/v1/track/sessions/{session_id}",
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
+    def get_session_content_url(self, session_id: str) -> str:
+        resp = self._client.get(
+            f"/v1/track/sessions/{session_id}/content",
+            headers=self._headers(),
+        )
+        _raise(resp)
+        url = resp.json().get("url")
+        if not url:
+            raise TrackAPIError("Session content response did not include a URL")
+        return str(url)
+
+    def download_session_content(self, session_id: str) -> bytes:
+        """Fetch native session bytes via the orchestrator-issued S3 URL."""
+        url = self.get_session_content_url(session_id)
+        resp = self._client.get(url)
+        _raise(resp)
+        return resp.content
+
     # ------------------------------------------------------------------ #
     # Internals                                                            #
     # ------------------------------------------------------------------ #
@@ -150,4 +244,30 @@ def _raise(resp: httpx.Response) -> None:
             detail = resp.json().get("detail", resp.text)
         except Exception:
             detail = resp.text
-        raise TrackAPIError(f"HTTP {resp.status_code}: {detail}")
+        raise TrackAPIError(
+            f"HTTP {resp.status_code}: {detail}",
+            status_code=resp.status_code,
+            detail=detail,
+        )
+
+
+def _clean_params(params: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in params.items() if v is not None}
+
+
+def _session_payload(session: Any) -> dict[str, Any]:
+    if is_dataclass(session):
+        return asdict(session)
+    if isinstance(session, Mapping):
+        return dict(session)
+    raise TypeError(f"Unsupported session payload type: {type(session)!r}")
+
+
+def _session_id(session: Any) -> str:
+    if isinstance(session, Mapping):
+        sid = session.get("id")
+    else:
+        sid = getattr(session, "id", None)
+    if not sid:
+        raise ValueError("session.id is required")
+    return str(sid)

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -249,20 +249,62 @@ def list_sessions(
     tool: str = typer.Option(None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"),
     cwd: str = typer.Option(None, "--cwd", help="Filter by working directory"),
     since: str = typer.Option(None, "--since", help="Only sessions active since (ISO-8601 or natural)"),
-    limit: int = typer.Option(None, "--limit", "-n", help="Max number of rows"),
+    limit: int = typer.Option(50, "--limit", "-n", help="Max rows per page (1..200)"),
+    cursor: str = typer.Option(
+        None, "--cursor",
+        help="Opaque cursor from a prior `next_cursor:` line. Drives paged scripting.",
+    ),
     json_out: bool = typer.Option(False, "--json", help="Emit JSON for scripting"),
     source: str = typer.Option(
         "auto", "--source",
         help="Where to read sessions from: auto (native+stub), native (~/.claude, ~/.codex), stub (LocalSessionStore), remote (theseus, not yet wired).",
     ),
 ) -> None:
-    """List sessions across all tracked AI tools."""
+    """List sessions across all tracked AI tools.
+
+    Sort is fixed at recency-first (`last_active DESC, id DESC`) — same
+    on every backend so cursors are interchangeable.
+
+    Pagination is cursor-based. Pass `--cursor <token>` from a previous
+    `next_cursor:` line to fetch the next page. The cursor format is
+    byte-compatible with the orchestrator's `/v1/track/sessions` endpoint
+    so scripting against either side uses the same opaque tokens.
+    """
+    from .store import _decode_cursor, ChainedSessionStore  # noqa: F401
+
     store = _resolve_session_store(source)
-    sessions = store.list(tool=tool, cwd=cwd, since=since, limit=limit)
+
+    # `--cursor` requires a single backing store; chained stores don't
+    # support pagination (see ChainedSessionStore.page).
+    if cursor and isinstance(store, ChainedSessionStore):
+        raise typer.BadParameter(
+            "--cursor requires --source native | stub | remote; the default "
+            "`auto` chains multiple backends and can't paginate across them."
+        )
+    # Fail fast on malformed cursors so the user sees a clear error.
+    if cursor:
+        try:
+            _decode_cursor(cursor)
+        except ValueError as e:
+            raise typer.BadParameter(str(e))
+
+    if cursor or json_out:
+        # Paged scripting flow — any caller who passed --cursor wants the
+        # next_cursor surfaced; --json shape promises {items, next_cursor}.
+        sessions, next_cursor = store.page(
+            tool=tool, cwd=cwd, since=since, limit=limit, cursor=cursor,
+        )
+    else:
+        # Interactive flow — keep the existing flat-list shape.
+        sessions = store.list(tool=tool, cwd=cwd, since=since, limit=limit)
+        next_cursor = None
 
     if json_out:
         from dataclasses import asdict
-        console.print_json(json.dumps([asdict(s) for s in sessions]))
+        console.print_json(json.dumps({
+            "items": [asdict(s) for s in sessions],
+            "next_cursor": next_cursor,
+        }))
         return
 
     if not sessions:
@@ -290,6 +332,8 @@ def list_sessions(
             fork,
         )
     console.print(table)
+    if next_cursor:
+        console.print(f"[dim]next_cursor:[/dim] {next_cursor}")
 
 
 @app.command()

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -162,9 +162,15 @@ def status() -> None:
 
 
 @app.command()
-def daemon() -> None:
+def daemon(
+    once: bool = typer.Option(
+        False,
+        "--once",
+        help="Run one reconcile/upload/manifest pass and exit. Useful for local E2E tests.",
+    ),
+) -> None:
     """Run the sync daemon (called by launchd/systemd — not for direct use)."""
-    daemon_main()
+    daemon_main(once=once)
 
 
 @app.command()

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -407,27 +407,17 @@ def resume(
             pick_tool,
         )
         from .picker import _terminal_page_size
-        from .store import (
-            ChainedSessionStore,
-            DEFAULT_PAGE_LIMIT,
-            MAX_PAGE_LIMIT,
-        )
-        # Cursor paging requires a single backend (chained doesn't
-        # implement page()). Auto/chained falls back to eager buffer.
-        if isinstance(store, ChainedSessionStore):
-            sessions_iter = store.list(limit=MAX_PAGE_LIMIT)
-            page_state = None
-        else:
-            # Page size = terminal-readable height. fzf is `--disabled`
-            # so every keystroke re-queries server-side; user never sees
-            # a screen-full of pre-buffered rows they have to scroll.
-            page_limit = _terminal_page_size()
-            first_page, _ = store.page(limit=page_limit)
-            sessions_iter = first_page
-            page_state = PageState(source=source, limit=page_limit)
+        # Page size = terminal-readable height. fzf is `--disabled` so
+        # every keystroke re-queries server-side; user never sees a
+        # screen-full of pre-buffered rows they have to scroll. All
+        # backends (including chained `auto`) implement `page()` now,
+        # so the same path works regardless of `--source`.
+        page_limit = _terminal_page_size()
+        first_page, _ = store.page(limit=page_limit)
+        page_state = PageState(source=source, limit=page_limit)
         try:
             target_session = pick_session(
-                sessions_iter,
+                first_page,
                 header="type to search · → next page · ← prev",
                 page_state=page_state,
             )

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
-from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -46,8 +44,12 @@ def enable() -> None:
         paths.config_file.write_text(json.dumps(config, indent=2))
 
     if "device_id" not in config:
-        import re, socket
-        hostname = re.sub(r"[^a-z0-9-]", "-", socket.gethostname().lower())[:20].strip("-")
+        import re
+        import socket
+
+        hostname = re.sub(r"[^a-z0-9-]", "-", socket.gethostname().lower())[:20].strip(
+            "-"
+        )
         config["device_id"] = f"{hostname}-{str(uuid.uuid4()).replace('-','')[:8]}"
 
     device_id = config["device_id"]
@@ -64,7 +66,9 @@ def enable() -> None:
         creds = load_credentials() or {}
         config["email"] = creds.get("email", "")
         config["team_name"] = creds.get("team_name", "")
-        import platform, socket
+        import platform
+        import socket
+
         config["hostname"] = socket.gethostname()
         config["platform"] = platform.system().lower()
         paths.config_file.write_text(json.dumps(config, indent=2))
@@ -76,7 +80,9 @@ def enable() -> None:
     sources = detect_sources()
     found = [s for s in sources if s.is_present()]
     if not found:
-        console.print("[yellow]No AI tool sessions found[/yellow] (~/.claude, ~/.cursor, ~/.codex)")
+        console.print(
+            "[yellow]No AI tool sessions found[/yellow] (~/.claude, ~/.cursor, ~/.codex)"
+        )
     else:
         for s in found:
             console.print(f"  [green]✓[/green] Found {s.name} at {s.root}")
@@ -93,7 +99,9 @@ def enable() -> None:
         console.print(f"[red]Service install failed:[/red] {e}")
         raise typer.Exit(1)
 
-    console.print("\n[bold green]✓ Tracking enabled.[/bold green] Syncing in background.")
+    console.print(
+        "\n[bold green]✓ Tracking enabled.[/bold green] Syncing in background."
+    )
     console.print("  Run [bold]flt track status[/bold] to check progress.")
 
 
@@ -128,8 +136,12 @@ def status() -> None:
         console.print("[yellow]Daemon running but no status yet.[/yellow]")
         return
 
-    state_color = {"idle": "green", "syncing": "yellow", "error": "red"}.get(s.state, "white")
-    console.print(f"[{state_color}]● {s.state.upper()}[/{state_color}]  pid={s.pid}  last sync={s.last_sync or 'never'}")
+    state_color = {"idle": "green", "syncing": "yellow", "error": "red"}.get(
+        s.state, "white"
+    )
+    console.print(
+        f"[{state_color}]● {s.state.upper()}[/{state_color}]  pid={s.pid}  last sync={s.last_sync or 'never'}"
+    )
 
     # Queue stats
     q = UploadQueue(paths)
@@ -140,7 +152,9 @@ def status() -> None:
     done = stats.get("done", 0)
     failed = stats.get("failed", 0)
 
-    console.print(f"  Queue: [yellow]{pending}[/yellow] pending  [cyan]{in_flight}[/cyan] uploading  [green]{done}[/green] done  [red]{failed}[/red] failed")
+    console.print(
+        f"  Queue: [yellow]{pending}[/yellow] pending  [cyan]{in_flight}[/cyan] uploading  [green]{done}[/green] done  [red]{failed}[/red] failed"
+    )
 
     # Sources table
     if s.sources:
@@ -154,7 +168,7 @@ def status() -> None:
         console.print(table)
 
     if s.errors:
-        console.print(f"\n[red]Errors:[/red]")
+        console.print("\n[red]Errors:[/red]")
         for err in s.errors[-3:]:
             console.print(f"  {err}")
 
@@ -176,7 +190,8 @@ def daemon(
 @app.command()
 def gc(
     max_age_hours: int = typer.Option(
-        24, "--max-age-hours",
+        24,
+        "--max-age-hours",
         help="Remove fleet-track checkout files older than this. 0 removes all.",
     ),
 ) -> None:
@@ -204,6 +219,7 @@ def logs() -> None:
         console.print("No log file found.")
         raise typer.Exit(1)
     import subprocess
+
     subprocess.run(["tail", "-f", str(log_path)])
 
 
@@ -252,17 +268,23 @@ def _resolve_session_store(source: str):
 
 @app.command(name="ls")
 def list_sessions(
-    tool: str = typer.Option(None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"),
+    tool: str = typer.Option(
+        None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"
+    ),
     cwd: str = typer.Option(None, "--cwd", help="Filter by working directory"),
-    since: str = typer.Option(None, "--since", help="Only sessions active since (ISO-8601 or natural)"),
+    since: str = typer.Option(
+        None, "--since", help="Only sessions active since (ISO-8601 or natural)"
+    ),
     limit: int = typer.Option(50, "--limit", "-n", help="Max rows per page (1..200)"),
     cursor: str = typer.Option(
-        None, "--cursor",
+        None,
+        "--cursor",
         help="Opaque cursor from a prior `next_cursor:` line. Drives paged scripting.",
     ),
     json_out: bool = typer.Option(False, "--json", help="Emit JSON for scripting"),
     source: str = typer.Option(
-        "auto", "--source",
+        "auto",
+        "--source",
         help="Where to read sessions from: auto (native+stub), native (~/.claude, ~/.codex), stub (LocalSessionStore), remote (theseus, not yet wired).",
     ),
 ) -> None:
@@ -298,7 +320,11 @@ def list_sessions(
         # Paged scripting flow — any caller who passed --cursor wants the
         # next_cursor surfaced; --json shape promises {items, next_cursor}.
         sessions, next_cursor = store.page(
-            tool=tool, cwd=cwd, since=since, limit=limit, cursor=cursor,
+            tool=tool,
+            cwd=cwd,
+            since=since,
+            limit=limit,
+            cursor=cursor,
         )
     else:
         # Interactive flow — keep the existing flat-list shape.
@@ -307,10 +333,15 @@ def list_sessions(
 
     if json_out:
         from dataclasses import asdict
-        console.print_json(json.dumps({
-            "items": [asdict(s) for s in sessions],
-            "next_cursor": next_cursor,
-        }))
+
+        console.print_json(
+            json.dumps(
+                {
+                    "items": [asdict(s) for s in sessions],
+                    "next_cursor": next_cursor,
+                }
+            )
+        )
         return
 
     if not sessions:
@@ -327,6 +358,7 @@ def list_sessions(
     table.add_column("From")
 
     from .picker import _human_when, _short_cwd
+
     for s in sessions:
         fork = (s.forked_from or "")[:8] if s.forked_from else ""
         table.add_row(
@@ -344,46 +376,59 @@ def list_sessions(
 
 @app.command()
 def resume(
-    session_id: str = typer.Argument(None, help="Session id (full or unique prefix). Omit to pick interactively."),
-    in_tool: str = typer.Option(None, "--in", help="Resume in this tool (default: same as source)"),
+    session_id: str = typer.Argument(
+        None, help="Session id (full or unique prefix). Omit to pick interactively."
+    ),
+    in_tool: str = typer.Option(
+        None, "--in", help="Resume in this tool (default: same as source)"
+    ),
     last: bool = typer.Option(False, "--last", help="Resume the most recent session"),
-    prompt: str = typer.Option(None, "--prompt", "-p", help="Initial prompt to send to the resumed CLI"),
+    prompt: str = typer.Option(
+        None, "--prompt", "-p", help="Initial prompt to send to the resumed CLI"
+    ),
     source: str = typer.Option(
-        "auto", "--source",
+        "auto",
+        "--source",
         help="Where to read sessions from: auto (native+stub), native, stub, remote (not wired).",
     ),
     compact: bool = typer.Option(
-        True, "--compact/--no-compact",
+        True,
+        "--compact/--no-compact",
         help="Project the source session into a context-fitting view. "
-             "Default on. --no-compact ships the full history; large sessions "
-             "will overflow the target model's context window.",
+        "Default on. --no-compact ships the full history; large sessions "
+        "will overflow the target model's context window.",
     ),
     target_tokens: int = typer.Option(
-        0, "--target-tokens",
+        0,
+        "--target-tokens",
         help="Target token budget for the cross-tool checkout. 0 picks a "
-             "sensible default for the target tool/model.",
+        "sensible default for the target tool/model.",
     ),
     target_model: str = typer.Option(
-        None, "--target-model",
+        None,
+        "--target-model",
         help="Hint the target model (e.g. claude-opus-4-7, gpt-5) so the "
-             "compactor budgets correctly. Auto-detected when possible.",
+        "compactor budgets correctly. Auto-detected when possible.",
     ),
     max_tool_output: int = typer.Option(
-        4_000, "--max-tool-output",
+        4_000,
+        "--max-tool-output",
         help="Per-tool-result output character cap. 0 disables truncation.",
     ),
     summarize: bool = typer.Option(
-        True, "--summarize/--no-summarize",
+        True,
+        "--summarize/--no-summarize",
         help="When events are dropped to fit budget, prepend a structured "
-             "summary of what was dropped. Default on.",
+        "summary of what was dropped. Default on.",
     ),
 ) -> None:
     """Resume a tracked session in a (possibly different) AI tool.
 
-    Without an id, opens an interactive fzf picker. With `--in`, the
-    session is converted to the target tool's format and dropped into a
-    quarantined `.fleet-checkouts/` namespace before invoking the
-    target's native resume command.
+    Without an id, opens an interactive Textual picker (search at top,
+    table below; pgdn/pgup to page). With `--in`, the session is
+    converted to the target tool's format and dropped into a quarantined
+    `.fleet-checkouts/` namespace before invoking the target's native
+    resume command.
     """
     store = _resolve_session_store(source)
 
@@ -405,45 +450,23 @@ def resume(
             raise typer.Exit(1)
     else:
         # Interactive picker — two stages: session, then target tool.
-        from .picker import (
-            FzfNotInstalled,
-            PageState,
-            installed_tools,
-            pick_session,
-            pick_tool,
+        # Both stages use Textual (`textual` package); no external `fzf`
+        # binary required. Page size auto-fits the terminal so the user
+        # never has to scroll within a page; every keystroke re-queries
+        # the store via `page(query=...)`.
+        from .picker import installed_tools
+        from .picker_textual import pick_session_textual, pick_tool_textual
+
+        target_session = pick_session_textual(
+            store,
+            header="type to search · pgdn next · pgup prev · ⏎ open · esc cancel",
         )
-        from .picker import _terminal_page_size
-        # Page size = terminal-readable height. fzf is `--disabled` so
-        # every keystroke re-queries server-side; user never sees a
-        # screen-full of pre-buffered rows they have to scroll. All
-        # backends (including chained `auto`) implement `page()` now,
-        # so the same path works regardless of `--source`.
-        page_limit = _terminal_page_size()
-        first_page, _ = store.page(limit=page_limit)
-        page_state = PageState(source=source, limit=page_limit)
-        try:
-            target_session = pick_session(
-                first_page,
-                header="type to search · → next page · ← prev",
-                page_state=page_state,
-            )
-        except FzfNotInstalled as e:
-            console.print(f"[red]{e}[/red]")
-            raise typer.Exit(1)
         if target_session is None:
             console.print("[dim]Cancelled.[/dim]")
             raise typer.Exit(0)
-        # If pick_session returned a synthetic Session (id-only, picked
-        # from a later page that wasn't in the initial buffer), resolve
-        # the full record via the store.
-        if target_session.tool == "?":
-            resolved = store.get(target_session.id)
-            if resolved is None:
-                console.print(
-                    f"[red]Picked session {target_session.id!r} not found in store.[/red]"
-                )
-                raise typer.Exit(1)
-            target_session = resolved
+        # The textual picker returns Sessions straight from `store.page()`,
+        # so they're already fully populated — no synthesize-and-resolve
+        # dance needed.
 
         # Stage 2: target tool. Skip the picker if the user already passed
         # `--in`, or if there's exactly one CLI installed (no choice to make).
@@ -458,24 +481,21 @@ def resume(
             if len(available) == 1:
                 in_tool = available[0]
             else:
-                try:
-                    chosen_tool = pick_tool(
-                        target_session.tool,
-                        available=available,
-                        header=f"Resume {target_session.id[:8]} in which tool?",
-                    )
-                except FzfNotInstalled as e:
-                    console.print(f"[red]{e}[/red]")
-                    raise typer.Exit(1)
+                chosen_tool = pick_tool_textual(
+                    target_session.tool,
+                    available=available,
+                    header=f"Resume {target_session.id[:8]} in which tool?",
+                )
                 if chosen_tool is None:
                     console.print("[dim]Cancelled.[/dim]")
                     raise typer.Exit(0)
                 in_tool = chosen_tool
 
     target_tool = in_tool or target_session.tool
+    cwd_hint = f" [dim]in {target_session.cwd}[/dim]" if target_session.cwd else ""
     console.print(
         f"[dim]Resuming[/dim] {target_session.id[:8]} "
-        f"[dim]({target_session.tool} → {target_tool})[/dim]"
+        f"[dim]({target_session.tool} → {target_tool})[/dim]{cwd_hint}"
     )
 
     # The actual resume + checkout creation is implemented in resumer.py
@@ -486,11 +506,12 @@ def resume(
         TruncationConfig,
         budget_for,
     )
-    from .resumer import resume_session
+    from .resumer import RepoNotLocalError, resume_session
 
     if compact:
         budget = (
-            TokenBudget(target=target_tokens) if target_tokens > 0
+            TokenBudget(target=target_tokens)
+            if target_tokens > 0
             else budget_for(target_tool, target_model)
         )
         compactor = TruncationCompactor(
@@ -516,6 +537,11 @@ def resume(
     except NotImplementedError as e:
         console.print(f"[red]Not yet supported:[/red] {e}")
         raise typer.Exit(2)
+    except RepoNotLocalError as e:
+        # Cross-machine session whose repo we can't find on this host.
+        # Multi-line message — print verbatim, no [red] wrapper.
+        console.print(str(e))
+        raise typer.Exit(3)
     except Exception as e:
         console.print(f"[red]Resume failed:[/red] {e}")
         raise typer.Exit(1)

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -354,8 +354,13 @@ def resume(
             console.print(f"[red]No session matches[/red] {session_id!r}")
             raise typer.Exit(1)
     else:
-        # Interactive picker.
-        from .picker import FzfNotInstalled, pick_session
+        # Interactive picker — two stages: session, then target tool.
+        from .picker import (
+            FzfNotInstalled,
+            installed_tools,
+            pick_session,
+            pick_tool,
+        )
         try:
             target_session = pick_session(store.list(), header="Resume which session?")
         except FzfNotInstalled as e:
@@ -364,6 +369,33 @@ def resume(
         if target_session is None:
             console.print("[dim]Cancelled.[/dim]")
             raise typer.Exit(0)
+
+        # Stage 2: target tool. Skip the picker if the user already passed
+        # `--in`, or if there's exactly one CLI installed (no choice to make).
+        if in_tool is None:
+            available = installed_tools()
+            if not available:
+                console.print(
+                    "[red]No supported AI CLIs found on PATH.[/red] "
+                    "Install one of: claude, codex, cursor, opencode."
+                )
+                raise typer.Exit(1)
+            if len(available) == 1:
+                in_tool = available[0]
+            else:
+                try:
+                    chosen_tool = pick_tool(
+                        target_session.tool,
+                        available=available,
+                        header=f"Resume {target_session.id[:8]} in which tool?",
+                    )
+                except FzfNotInstalled as e:
+                    console.print(f"[red]{e}[/red]")
+                    raise typer.Exit(1)
+                if chosen_tool is None:
+                    console.print("[dim]Cancelled.[/dim]")
+                    raise typer.Exit(0)
+                in_tool = chosen_tool
 
     target_tool = in_tool or target_session.tool
     console.print(

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -401,18 +401,53 @@ def resume(
         # Interactive picker — two stages: session, then target tool.
         from .picker import (
             FzfNotInstalled,
+            PageState,
             installed_tools,
             pick_session,
             pick_tool,
         )
+        from .picker import _terminal_page_size
+        from .store import (
+            ChainedSessionStore,
+            DEFAULT_PAGE_LIMIT,
+            MAX_PAGE_LIMIT,
+        )
+        # Cursor paging requires a single backend (chained doesn't
+        # implement page()). Auto/chained falls back to eager buffer.
+        if isinstance(store, ChainedSessionStore):
+            sessions_iter = store.list(limit=MAX_PAGE_LIMIT)
+            page_state = None
+        else:
+            # Page size = terminal-readable height. fzf is `--disabled`
+            # so every keystroke re-queries server-side; user never sees
+            # a screen-full of pre-buffered rows they have to scroll.
+            page_limit = _terminal_page_size()
+            first_page, _ = store.page(limit=page_limit)
+            sessions_iter = first_page
+            page_state = PageState(source=source, limit=page_limit)
         try:
-            target_session = pick_session(store.list(), header="Resume which session?")
+            target_session = pick_session(
+                sessions_iter,
+                header="type to search · → next page · ← prev",
+                page_state=page_state,
+            )
         except FzfNotInstalled as e:
             console.print(f"[red]{e}[/red]")
             raise typer.Exit(1)
         if target_session is None:
             console.print("[dim]Cancelled.[/dim]")
             raise typer.Exit(0)
+        # If pick_session returned a synthetic Session (id-only, picked
+        # from a later page that wasn't in the initial buffer), resolve
+        # the full record via the store.
+        if target_session.tool == "?":
+            resolved = store.get(target_session.id)
+            if resolved is None:
+                console.print(
+                    f"[red]Picked session {target_session.id!r} not found in store.[/red]"
+                )
+                raise typer.Exit(1)
+            target_session = resolved
 
         # Stage 2: target tool. Skip the picker if the user already passed
         # `--in`, or if there's exactly one CLI installed (no choice to make).

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -50,7 +50,7 @@ def enable() -> None:
         hostname = re.sub(r"[^a-z0-9-]", "-", socket.gethostname().lower())[:20].strip(
             "-"
         )
-        config["device_id"] = f"{hostname}-{str(uuid.uuid4()).replace('-','')[:8]}"
+        config["device_id"] = f"{hostname}-{str(uuid.uuid4()).replace('-', '')[:8]}"
 
     device_id = config["device_id"]
 
@@ -237,12 +237,13 @@ def _resolve_session_store(source: str):
         AND anything explicitly ingested into the stub.
       - `native`: only the read-only view of `~/.claude` / `~/.codex`.
       - `stub`: only the LocalSessionStore (the dev stub).
-      - `remote`: future RemoteSessionStore (not yet wired).
+      - `remote`: orchestrator-backed metadata index.
     """
     from .store import (
         ChainedSessionStore,
         LocalSessionStore,
         NativeFilesSessionStore,
+        RemoteSessionStore,
     )
 
     paths = TrackPaths.default()
@@ -251,11 +252,7 @@ def _resolve_session_store(source: str):
     if source == "native":
         return NativeFilesSessionStore()
     if source == "remote":
-        raise typer.BadParameter(
-            "--source remote isn't wired yet. The contract is reserved for "
-            "the future RemoteSessionStore (theseus). Use --source auto, "
-            "native, or stub."
-        )
+        return RemoteSessionStore()
     if source == "auto":
         # LocalSessionStore first so explicitly-ingested rows shadow native
         # ones with the same id (e.g. forks re-stored after resume).
@@ -285,7 +282,7 @@ def list_sessions(
     source: str = typer.Option(
         "auto",
         "--source",
-        help="Where to read sessions from: auto (native+stub), native (~/.claude, ~/.codex), stub (LocalSessionStore), remote (theseus, not yet wired).",
+        help="Where to read sessions from: auto (native+stub), native (~/.claude, ~/.codex), stub (LocalSessionStore), remote (orchestrator).",
     ),
 ) -> None:
     """List sessions across all tracked AI tools.
@@ -389,7 +386,7 @@ def resume(
     source: str = typer.Option(
         "auto",
         "--source",
-        help="Where to read sessions from: auto (native+stub), native, stub, remote (not wired).",
+        help="Where to read sessions from: auto (native+stub), native, stub, remote.",
     ),
     compact: bool = typer.Option(
         True,

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -1,0 +1,414 @@
+"""flt track — CLI subcommands."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..auth import load_credentials
+from .api import TrackAPIClient, TrackAPIError
+from .daemon import main as daemon_main
+from .install import install, is_installed, uninstall
+from .paths import TrackPaths
+from .queue import UploadQueue
+from .sources import detect_sources
+from .status import is_running, read_status
+
+import uuid
+
+app = typer.Typer(help="Track local AI coding sessions", no_args_is_help=True)
+console = Console()
+
+
+@app.command()
+def enable() -> None:
+    """Scan this machine for AI sessions and start syncing."""
+    from ..auth import get_valid_token
+
+    paths = TrackPaths.default()
+
+    token = get_valid_token()
+    if not token:
+        console.print("[red]Not authenticated.[/red] Run [bold]flt login[/bold] first.")
+        raise typer.Exit(1)
+
+    # Load or create machine ID
+    paths.ensure_track_dir()
+    if paths.config_file.exists():
+        config = json.loads(paths.config_file.read_text())
+    else:
+        config = {}
+        paths.config_file.write_text(json.dumps(config, indent=2))
+
+    if "device_id" not in config:
+        import re, socket
+        hostname = re.sub(r"[^a-z0-9-]", "-", socket.gethostname().lower())[:20].strip("-")
+        config["device_id"] = f"{hostname}-{str(uuid.uuid4()).replace('-','')[:8]}"
+
+    device_id = config["device_id"]
+
+    # Provision with backend
+    console.print("Provisioning with Fleet...")
+    try:
+        api = TrackAPIClient()
+        result = api.provision(device_id)
+        config["team_id"] = result.get("team_id", "")
+        config["user_id"] = result.get("user_id", "")
+        # Pull email + team_name from stored credentials so the daemon can
+        # embed them in manifest.json for device → user association.
+        creds = load_credentials() or {}
+        config["email"] = creds.get("email", "")
+        config["team_name"] = creds.get("team_name", "")
+        import platform, socket
+        config["hostname"] = socket.gethostname()
+        config["platform"] = platform.system().lower()
+        paths.config_file.write_text(json.dumps(config, indent=2))
+    except TrackAPIError as e:
+        console.print(f"[red]Provision failed:[/red] {e}")
+        raise typer.Exit(1)
+
+    # Detect sources
+    sources = detect_sources()
+    found = [s for s in sources if s.is_present()]
+    if not found:
+        console.print("[yellow]No AI tool sessions found[/yellow] (~/.claude, ~/.cursor, ~/.codex)")
+    else:
+        for s in found:
+            console.print(f"  [green]✓[/green] Found {s.name} at {s.root}")
+
+    # Install and start daemon
+    if is_installed() and is_running(paths):
+        console.print("[yellow]Daemon already running.[/yellow] Restarting...")
+        uninstall()
+
+    console.print("Installing daemon service...")
+    try:
+        install(paths)
+    except Exception as e:
+        console.print(f"[red]Service install failed:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print("\n[bold green]✓ Tracking enabled.[/bold green] Syncing in background.")
+    console.print("  Run [bold]flt track status[/bold] to check progress.")
+
+
+@app.command()
+def disable() -> None:
+    """Stop tracking and remove the daemon service."""
+    if not is_installed():
+        console.print("Track daemon is not installed.")
+        return
+    uninstall()
+    console.print("[green]✓[/green] Track daemon removed.")
+
+
+@app.command()
+def status() -> None:
+    """Show sync status."""
+    paths = TrackPaths.default()
+    running = is_running(paths)
+    s = read_status(paths)
+
+    if not running:
+        console.print("[yellow]Daemon not running.[/yellow]", end=" ")
+        if not is_installed():
+            console.print("Run [bold]flt track enable[/bold] to start.")
+        else:
+            console.print("Service installed but not alive — check logs.")
+        if s:
+            console.print(f"  Last sync: {s.last_sync or 'never'}")
+        return
+
+    if not s:
+        console.print("[yellow]Daemon running but no status yet.[/yellow]")
+        return
+
+    state_color = {"idle": "green", "syncing": "yellow", "error": "red"}.get(s.state, "white")
+    console.print(f"[{state_color}]● {s.state.upper()}[/{state_color}]  pid={s.pid}  last sync={s.last_sync or 'never'}")
+
+    # Queue stats
+    q = UploadQueue(paths)
+    stats = q.stats()
+    q.close()
+    pending = stats.get("pending", 0)
+    in_flight = stats.get("in_flight", 0)
+    done = stats.get("done", 0)
+    failed = stats.get("failed", 0)
+
+    console.print(f"  Queue: [yellow]{pending}[/yellow] pending  [cyan]{in_flight}[/cyan] uploading  [green]{done}[/green] done  [red]{failed}[/red] failed")
+
+    # Sources table
+    if s.sources:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Agent")
+        table.add_column("Found", justify="center")
+        table.add_column("Files", justify="right")
+        for agent, info in s.sources.items():
+            found_str = "[green]✓[/green]" if info.get("found") else "[dim]✗[/dim]"
+            table.add_row(agent, found_str, str(info.get("files", 0)))
+        console.print(table)
+
+    if s.errors:
+        console.print(f"\n[red]Errors:[/red]")
+        for err in s.errors[-3:]:
+            console.print(f"  {err}")
+
+    console.print(f"\n  Logs: {paths.log_file}")
+
+
+@app.command()
+def daemon() -> None:
+    """Run the sync daemon (called by launchd/systemd — not for direct use)."""
+    daemon_main()
+
+
+@app.command()
+def gc(
+    max_age_hours: int = typer.Option(
+        24, "--max-age-hours",
+        help="Remove fleet-track checkout files older than this. 0 removes all.",
+    ),
+) -> None:
+    """Remove fleet-track-managed checkout files.
+
+    Identifies checkouts by the `_fleet_meta` marker on the first row
+    (never deletes native sessions). Useful after running cross-tool
+    resume tests to clean up the on-disk views.
+    """
+    from .resumer import gc_checkouts
+
+    n = gc_checkouts(max_age_hours=max_age_hours)
+    if n == 0:
+        console.print("[dim]Nothing to clean up.[/dim]")
+    else:
+        unit = "files" if n != 1 else "file"
+        console.print(f"[green]✓[/green] Removed {n} fleet-track checkout {unit}.")
+
+
+@app.command()
+def logs() -> None:
+    """Tail the daemon log."""
+    log_path = TrackPaths.default().log_file
+    if not log_path.exists():
+        console.print("No log file found.")
+        raise typer.Exit(1)
+    import subprocess
+    subprocess.run(["tail", "-f", str(log_path)])
+
+
+# ------------------------------------------------------------------ #
+# Session listing + resume                                              #
+# ------------------------------------------------------------------ #
+
+
+def _resolve_session_store(source: str):
+    """Build the SessionStore the CLI reads from based on `--source`.
+
+    Modes:
+      - `auto` (default): chained Native + Stub. What you actually want
+        for testing the picker — shows native session files on disk
+        AND anything explicitly ingested into the stub.
+      - `native`: only the read-only view of `~/.claude` / `~/.codex`.
+      - `stub`: only the LocalSessionStore (the dev stub).
+      - `remote`: future RemoteSessionStore (not yet wired).
+    """
+    from .store import (
+        ChainedSessionStore,
+        LocalSessionStore,
+        NativeFilesSessionStore,
+    )
+
+    paths = TrackPaths.default()
+    if source == "stub":
+        return LocalSessionStore(paths)
+    if source == "native":
+        return NativeFilesSessionStore()
+    if source == "remote":
+        raise typer.BadParameter(
+            "--source remote isn't wired yet. The contract is reserved for "
+            "the future RemoteSessionStore (theseus). Use --source auto, "
+            "native, or stub."
+        )
+    if source == "auto":
+        # LocalSessionStore first so explicitly-ingested rows shadow native
+        # ones with the same id (e.g. forks re-stored after resume).
+        return ChainedSessionStore(
+            LocalSessionStore(paths),
+            NativeFilesSessionStore(),
+        )
+    raise typer.BadParameter(f"Unknown --source value: {source!r}")
+
+
+@app.command(name="ls")
+def list_sessions(
+    tool: str = typer.Option(None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"),
+    cwd: str = typer.Option(None, "--cwd", help="Filter by working directory"),
+    since: str = typer.Option(None, "--since", help="Only sessions active since (ISO-8601 or natural)"),
+    limit: int = typer.Option(None, "--limit", "-n", help="Max number of rows"),
+    json_out: bool = typer.Option(False, "--json", help="Emit JSON for scripting"),
+    source: str = typer.Option(
+        "auto", "--source",
+        help="Where to read sessions from: auto (native+stub), native (~/.claude, ~/.codex), stub (LocalSessionStore), remote (theseus, not yet wired).",
+    ),
+) -> None:
+    """List sessions across all tracked AI tools."""
+    store = _resolve_session_store(source)
+    sessions = store.list(tool=tool, cwd=cwd, since=since, limit=limit)
+
+    if json_out:
+        from dataclasses import asdict
+        console.print_json(json.dumps([asdict(s) for s in sessions]))
+        return
+
+    if not sessions:
+        console.print("[dim]No sessions found.[/dim]")
+        console.print("  Run [bold]flt track enable[/bold] to start syncing.")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID")
+    table.add_column("Tool")
+    table.add_column("When")
+    table.add_column("Project")
+    table.add_column("Events", justify="right")
+    table.add_column("From")
+
+    from .picker import _human_when, _short_cwd
+    for s in sessions:
+        fork = (s.forked_from or "")[:8] if s.forked_from else ""
+        table.add_row(
+            s.id[:8],
+            s.tool,
+            _human_when(s.last_active or s.started_at),
+            _short_cwd(s.cwd),
+            str(s.event_count),
+            fork,
+        )
+    console.print(table)
+
+
+@app.command()
+def resume(
+    session_id: str = typer.Argument(None, help="Session id (full or unique prefix). Omit to pick interactively."),
+    in_tool: str = typer.Option(None, "--in", help="Resume in this tool (default: same as source)"),
+    last: bool = typer.Option(False, "--last", help="Resume the most recent session"),
+    prompt: str = typer.Option(None, "--prompt", "-p", help="Initial prompt to send to the resumed CLI"),
+    source: str = typer.Option(
+        "auto", "--source",
+        help="Where to read sessions from: auto (native+stub), native, stub, remote (not wired).",
+    ),
+    compact: bool = typer.Option(
+        True, "--compact/--no-compact",
+        help="Project the source session into a context-fitting view. "
+             "Default on. --no-compact ships the full history; large sessions "
+             "will overflow the target model's context window.",
+    ),
+    target_tokens: int = typer.Option(
+        0, "--target-tokens",
+        help="Target token budget for the cross-tool checkout. 0 picks a "
+             "sensible default for the target tool/model.",
+    ),
+    target_model: str = typer.Option(
+        None, "--target-model",
+        help="Hint the target model (e.g. claude-opus-4-7, gpt-5) so the "
+             "compactor budgets correctly. Auto-detected when possible.",
+    ),
+    max_tool_output: int = typer.Option(
+        4_000, "--max-tool-output",
+        help="Per-tool-result output character cap. 0 disables truncation.",
+    ),
+    summarize: bool = typer.Option(
+        True, "--summarize/--no-summarize",
+        help="When events are dropped to fit budget, prepend a structured "
+             "summary of what was dropped. Default on.",
+    ),
+) -> None:
+    """Resume a tracked session in a (possibly different) AI tool.
+
+    Without an id, opens an interactive fzf picker. With `--in`, the
+    session is converted to the target tool's format and dropped into a
+    quarantined `.fleet-checkouts/` namespace before invoking the
+    target's native resume command.
+    """
+    store = _resolve_session_store(source)
+
+    # Resolve which session.
+    if last:
+        sessions = store.list(limit=1)
+        if not sessions:
+            console.print("[red]No sessions found.[/red]")
+            raise typer.Exit(1)
+        target_session = sessions[0]
+    elif session_id:
+        try:
+            target_session = store.get(session_id)
+        except KeyError as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1)
+        if target_session is None:
+            console.print(f"[red]No session matches[/red] {session_id!r}")
+            raise typer.Exit(1)
+    else:
+        # Interactive picker.
+        from .picker import FzfNotInstalled, pick_session
+        try:
+            target_session = pick_session(store.list(), header="Resume which session?")
+        except FzfNotInstalled as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1)
+        if target_session is None:
+            console.print("[dim]Cancelled.[/dim]")
+            raise typer.Exit(0)
+
+    target_tool = in_tool or target_session.tool
+    console.print(
+        f"[dim]Resuming[/dim] {target_session.id[:8]} "
+        f"[dim]({target_session.tool} → {target_tool})[/dim]"
+    )
+
+    # The actual resume + checkout creation is implemented in resumer.py
+    # (kept out of cli.py so the dispatch logic is testable).
+    from .compactor import (
+        TokenBudget,
+        TruncationCompactor,
+        TruncationConfig,
+        budget_for,
+    )
+    from .resumer import resume_session
+
+    if compact:
+        budget = (
+            TokenBudget(target=target_tokens) if target_tokens > 0
+            else budget_for(target_tool, target_model)
+        )
+        compactor = TruncationCompactor(
+            budget=budget,
+            cfg=TruncationConfig(
+                max_tool_output_chars=max_tool_output if max_tool_output > 0 else None,
+                summarize_dropped=summarize,
+            ),
+        )
+    else:
+        compactor = None  # ship full history; will likely overflow large sessions
+
+    try:
+        resume_session(
+            store=store,
+            session=target_session,
+            target_tool=target_tool,
+            prompt=prompt,
+            paths=TrackPaths.default(),
+            compactor=compactor,
+            target_model=target_model,
+        )
+    except NotImplementedError as e:
+        console.print(f"[red]Not yet supported:[/red] {e}")
+        raise typer.Exit(2)
+    except Exception as e:
+        console.print(f"[red]Resume failed:[/red] {e}")
+        raise typer.Exit(1)

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -23,6 +23,11 @@ app = typer.Typer(help="Track local AI coding sessions", no_args_is_help=True)
 console = Console()
 
 
+def _write_config(paths: TrackPaths, config: dict) -> None:
+    paths.ensure_track_dir()
+    paths.config_file.write_text(json.dumps(config, indent=2))
+
+
 @app.command()
 def enable() -> None:
     """Scan this machine for AI sessions and start syncing."""
@@ -41,7 +46,6 @@ def enable() -> None:
         config = json.loads(paths.config_file.read_text())
     else:
         config = {}
-        paths.config_file.write_text(json.dumps(config, indent=2))
 
     if "device_id" not in config:
         import re
@@ -51,6 +55,7 @@ def enable() -> None:
             "-"
         )
         config["device_id"] = f"{hostname}-{str(uuid.uuid4()).replace('-', '')[:8]}"
+        _write_config(paths, config)
 
     device_id = config["device_id"]
 
@@ -71,7 +76,7 @@ def enable() -> None:
 
         config["hostname"] = socket.gethostname()
         config["platform"] = platform.system().lower()
-        paths.config_file.write_text(json.dumps(config, indent=2))
+        _write_config(paths, config)
     except TrackAPIError as e:
         console.print(f"[red]Provision failed:[/red] {e}")
         raise typer.Exit(1)

--- a/fleet/track/compactor.py
+++ b/fleet/track/compactor.py
@@ -1,0 +1,511 @@
+"""Compactor protocol — projecting a session's full event log into a
+context-fitting view for resume.
+
+The canonical session is preserved (in `LocalSessionStore`, the future
+`RemoteSessionStore`, and the native files on disk). The *view* we hand
+the target CLI is the largest faithful subset that fits its model's
+context window, optionally prefaced by a summary of what was dropped.
+
+# The interface
+
+A `Compactor` is a `Callable[[list[Event]], list[Event]]` — produces a
+shorter event stream from a longer one. Today only `TruncationCompactor`
+is implemented (approach A: drop oldest turns until under a token budget,
+prepend a deterministic structural summary of dropped events).
+
+The protocol is the seam for future strategies:
+
+  - `LLMSummarizingCompactor` — call an LLM to summarize dropped turns
+    instead of using deterministic metadata. Richer, costs $.
+  - `RecallToolCompactor` — keep recent turns verbatim, inject a
+    `recall(query)` tool, leave older content in the canonical store.
+    Effectively unbounded context. Real work to build.
+
+A future resume call swaps in a different `Compactor` with one line:
+
+    resume_session(..., compactor=LLMSummarizingCompactor(model="haiku"))
+
+# Token budgets
+
+Different target tools/models have different context windows. The budget
+is target-aware: claude-opus-4-7 has a 1M window; gpt-5 has 256K; cursor
+varies. `budget_for(tool, model=None)` returns a sensible byte budget
+with a safety margin (default 85% of the raw window).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Protocol
+
+from .unified import (
+    Attachment,
+    AssistantReasoning,
+    Event,
+    Lifecycle,
+    OpaqueEvent,
+    ToolCall,
+    ToolResult,
+    UserMessage,
+)
+
+log = logging.getLogger("fleet.track.compactor")
+
+
+# ------------------------------------------------------------------ #
+# Token counting                                                       #
+# ------------------------------------------------------------------ #
+
+
+def _try_tiktoken_encoder():
+    """Return a tiktoken encoding if installed; None otherwise.
+
+    `cl100k_base` is the standard encoder for gpt-4-class models and
+    close enough for "is this under 256K?" arithmetic. The exact tokenizer
+    a model uses doesn't matter for this kind of budgeting — we want a
+    rough estimate within 5–10%, not a precise count.
+    """
+    try:
+        import tiktoken
+        return tiktoken.get_encoding("cl100k_base")
+    except (ImportError, Exception):
+        return None
+
+
+_ENCODER = _try_tiktoken_encoder()
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate the token count of `text`.
+
+    Uses tiktoken when available; falls back to a 4-chars-per-token
+    heuristic. The fallback overestimates for code (which is denser)
+    and underestimates for natural language; either way it's within
+    20% — fine for budget-fitting decisions.
+    """
+    if _ENCODER is not None:
+        try:
+            return len(_ENCODER.encode(text))
+        except Exception:
+            pass
+    return max(1, len(text) // 4)
+
+
+def estimate_event_tokens(event: Event) -> int:
+    """Approximate the token cost of one event after cross-source emission.
+
+    Captures: text/output content, tool input JSON, structural metadata
+    (id, tool_call_id, timestamps, name fields), and per-event JSON
+    wrapping. We bias **high** so the budget-walker stays conservative —
+    better to leave a few thousand tokens unused than overflow.
+
+    Empirical: for a typical cross-source-emitted codex row, this
+    estimator was within ~5% of the actual encoded token count on a
+    2K-event corpus.
+    """
+    import json as _j
+
+    text_tokens = 0
+    for attr in ("text", "output"):
+        v = getattr(event, attr, None)
+        if isinstance(v, str):
+            text_tokens += estimate_tokens(v)
+
+    inp = getattr(event, "input", None)
+    if isinstance(inp, dict) and inp:
+        text_tokens += estimate_tokens(_j.dumps(inp, ensure_ascii=False))
+
+    # Per-event JSON wrapping is the dominant overhead source. For
+    # cross-source emission to claude, every row carries a ~250-char
+    # metadata block (uuid, parentUuid, sessionId, cwd, gitBranch,
+    # version, entrypoint, isSidechain, userType, timestamp).
+    # That's ~80 tokens of fixed cost regardless of content. Codex
+    # rows are smaller (~80 chars wrapper) but we bias high to avoid
+    # overshoot — the cost of leaving budget unused is tiny; the cost
+    # of overflow is a failed resume.
+    wrapping_tokens = 90
+
+    return text_tokens + wrapping_tokens
+
+
+# ------------------------------------------------------------------ #
+# Model registry + budgets                                             #
+# ------------------------------------------------------------------ #
+
+
+@dataclass(frozen=True)
+class TokenBudget:
+    """How many tokens the compactor should aim to fit under.
+
+    `target` is the model's raw context window; `margin` is the safety
+    fraction we actually use (e.g. 0.85 of 256K = 217K usable). Margin
+    accounts for: tokenizer mismatch, the target CLI's own runtime
+    overhead (system prompts it injects on resume), and whatever the
+    user wants to ask in the resumed turn.
+    """
+
+    target: int
+    margin: float = 0.85
+
+    @property
+    def usable(self) -> int:
+        return int(self.target * self.margin)
+
+
+# Raw context windows for known models. Numbers are documented limits;
+# add new entries as they ship.
+KNOWN_MODELS: dict[str, int] = {
+    # Anthropic (Claude 4.x)
+    "claude-opus-4-7": 1_000_000,
+    "claude-opus-4-6": 200_000,
+    "claude-sonnet-4-6": 200_000,
+    "claude-sonnet-4-5": 200_000,
+    "claude-haiku-4-5": 200_000,
+    # Anthropic (older — still in some live sessions)
+    "claude-opus-4": 200_000,
+    "claude-sonnet-4": 200_000,
+    # OpenAI (GPT-5 family)
+    "gpt-5": 256_000,
+    "gpt-5.5": 256_000,
+    "gpt-5-turbo": 256_000,
+    # OpenAI (older)
+    "gpt-4o": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4": 8_192,
+}
+
+
+# Default budget per target tool when the model isn't known.
+# Conservative — we'd rather drop a few turns than overflow.
+DEFAULT_TOOL_BUDGETS: dict[str, int] = {
+    "claude": 180_000,    # safe under 200K (most models); 1M-window Opus has more headroom
+    "codex": 200_000,     # safe under 256K (gpt-5)
+    "cursor": 100_000,    # conservative; cursor exposes various models
+    "opencode": 100_000,  # conservative
+}
+
+
+def budget_for(tool: str, model: Optional[str] = None) -> TokenBudget:
+    """Return the token budget for resume into `tool` / `model`.
+
+    Model-aware when possible (looks up `model` in `KNOWN_MODELS`),
+    falls back to `DEFAULT_TOOL_BUDGETS[tool]`, falls back to a
+    conservative 100K.
+    """
+    if model and model in KNOWN_MODELS:
+        return TokenBudget(target=KNOWN_MODELS[model])
+    if tool in DEFAULT_TOOL_BUDGETS:
+        return TokenBudget(target=DEFAULT_TOOL_BUDGETS[tool])
+    return TokenBudget(target=100_000)
+
+
+# ------------------------------------------------------------------ #
+# Protocol                                                             #
+# ------------------------------------------------------------------ #
+
+
+class Compactor(Protocol):
+    """Project an event stream into a context-fitting view.
+
+    Implementations must:
+      - Be deterministic (given same input, same output) OR document
+        otherwise (LLM-based compactors aren't deterministic).
+      - Never crash on real-world event streams.
+      - Preserve any `SessionStart` event at the head if present.
+
+    Implementations should:
+      - Drop events the target tool can't render usefully (Attachment,
+        Lifecycle, Reasoning) before truncating.
+      - Truncate large `ToolResult.output` strings rather than dropping
+        the whole event.
+      - When dropping turns, prepend a summary of what was dropped so
+        the resumed model retains structural awareness.
+    """
+
+    def compact(self, events: list[Event]) -> list[Event]: ...
+
+
+# ------------------------------------------------------------------ #
+# TruncationCompactor — approach A                                     #
+# ------------------------------------------------------------------ #
+
+
+@dataclass(frozen=True)
+class TruncationConfig:
+    """Knobs for TruncationCompactor."""
+
+    drop_attachments: bool = True
+    drop_lifecycle: bool = True
+    drop_reasoning: bool = True
+    drop_opaque: bool = True
+    drop_token_usage: bool = True
+
+    # Per-tool-result output cap. None = no truncation.
+    max_tool_output_chars: Optional[int] = 4_000
+    truncation_marker: str = "\n\n…[truncated by fleet-track for cross-tool resume]"
+
+    # Whether to prepend a deterministic summary when we drop turns.
+    summarize_dropped: bool = True
+
+
+class TruncationCompactor:
+    """Approach A: drop noise, truncate large outputs, drop oldest
+    turns until under a token budget. Prepends a deterministic
+    structural summary of dropped events so the resumed model has
+    context awareness even of dropped turns.
+
+    Algorithm:
+      1. Drop noise events (per `cfg`).
+      2. Truncate large ToolResult.output fields.
+      3. If still over budget, walk from the end backwards keeping
+         events while the running token total is under budget. Emit a
+         summary message describing what got dropped.
+      4. SessionStart at the head is always preserved.
+    """
+
+    def __init__(
+        self,
+        *,
+        budget: TokenBudget,
+        cfg: Optional[TruncationConfig] = None,
+        token_estimator: Callable[[Event], int] = estimate_event_tokens,
+        # Optional callable that converts the trimmed event list into
+        # the actual emission bytes, so we can verify the post-emission
+        # token count and refine if our per-event estimator was off.
+        # When None, we trust the estimator and skip verification.
+        emission_estimator: Optional[Callable[[list[Event]], int]] = None,
+        max_refinement_passes: int = 4,
+    ) -> None:
+        self.budget = budget
+        self.cfg = cfg or TruncationConfig()
+        self._estimate = token_estimator
+        self._emission_estimator = emission_estimator
+        self._max_refinement_passes = max_refinement_passes
+
+    def compact(self, events: list[Event]) -> list[Event]:
+        # Stage 1: drop noise.
+        cleaned = self._drop_noise(events)
+
+        # Stage 2: truncate large outputs.
+        cleaned = [self._maybe_truncate_output(ev) for ev in cleaned]
+
+        # Stage 3: trim to budget if needed.
+        result = self._trim_to_budget(cleaned)
+
+        # Stage 4 (optional): verify against the actual emission size,
+        # refine if our per-event estimate undershot. Per-event
+        # estimation is imprecise because emission overhead varies by
+        # source/target combination; this pass gives a hard guarantee.
+        if self._emission_estimator is not None:
+            result = self._refine_against_emission(result, original=cleaned)
+
+        return result
+
+    def _refine_against_emission(
+        self, candidate: list[Event], *, original: list[Event],
+    ) -> list[Event]:
+        """If the actual emission exceeds budget, drop more events
+        from the start of the body until it fits or we hit the pass
+        limit. Each pass drops ~20% of remaining body events.
+
+        We don't touch the prepended SessionStart or the summary
+        message on refinement passes — only the verbatim-kept events.
+        The summary still accurately describes the originally-dropped
+        portion; events newly dropped on refinement won't appear in
+        the summary, but they're a small fraction of the total drop.
+        """
+        del original  # unused; signature kept for future re-summarization
+        budget = self.budget.usable
+        for pass_num in range(self._max_refinement_passes):
+            assert self._emission_estimator is not None
+            actual = self._emission_estimator(candidate)
+            if actual <= budget:
+                if pass_num > 0:
+                    log.info(
+                        "compactor refinement: settled at %d tokens (budget %d) after %d pass(es)",
+                        actual, budget, pass_num,
+                    )
+                return candidate
+
+            # Over budget. Find the start of the body — skip
+            # SessionStart at the head and any summary message.
+            body_start = 0
+            for ev in candidate:
+                if ev.type == "session_start":
+                    body_start += 1
+                else:
+                    break
+            if (body_start < len(candidate)
+                    and getattr(candidate[body_start], "synthesized", False)
+                    and "session summary" in getattr(candidate[body_start], "text", "").lower()):
+                body_start += 1
+
+            body = candidate[body_start:]
+            if not body:
+                log.warning("compactor refinement: no body events left to drop")
+                return candidate
+
+            drop_count = max(1, len(body) // 5)
+            candidate = candidate[:body_start] + body[drop_count:]
+
+        log.warning(
+            "compactor: budget %d not reachable after %d passes; returning best effort",
+            budget, self._max_refinement_passes,
+        )
+        return candidate
+
+    # ------------------------------------------------------------------ #
+    # Stages                                                               #
+    # ------------------------------------------------------------------ #
+
+    def _drop_noise(self, events: list[Event]) -> list[Event]:
+        out: list[Event] = []
+        c = self.cfg
+        for ev in events:
+            if c.drop_attachments and isinstance(ev, Attachment):
+                continue
+            if c.drop_lifecycle and isinstance(ev, Lifecycle):
+                continue
+            if c.drop_reasoning and isinstance(ev, AssistantReasoning):
+                continue
+            if c.drop_opaque and isinstance(ev, OpaqueEvent):
+                continue
+            if c.drop_token_usage and ev.type == "token_usage":
+                continue
+            out.append(ev)
+        return out
+
+    def _maybe_truncate_output(self, ev: Event) -> Event:
+        cap = self.cfg.max_tool_output_chars
+        if cap is None:
+            return ev
+        if not isinstance(ev, ToolResult):
+            return ev
+        if len(ev.output) <= cap:
+            return ev
+        new_text = ev.output[:cap] + self.cfg.truncation_marker
+        return ev.model_copy(update={"output": new_text})
+
+    def _trim_to_budget(self, events: list[Event]) -> list[Event]:
+        budget = self.budget.usable
+
+        # Separate the SessionStart head (always kept).
+        head: list[Event] = []
+        rest_start = 0
+        for i, ev in enumerate(events):
+            if ev.type == "session_start":
+                head.append(ev)
+                rest_start = i + 1
+            else:
+                break
+        body = events[rest_start:]
+
+        head_tokens = sum(self._estimate(e) for e in head)
+        if head_tokens >= budget:
+            # Pathological: SessionStart alone is over budget. Emit it
+            # anyway; nothing meaningful to keep otherwise.
+            log.warning("compactor: SessionStart alone exceeds budget (%d > %d)",
+                        head_tokens, budget)
+            return head
+
+        # Walk body from the end, accumulating tokens.
+        kept_reversed: list[Event] = []
+        used = head_tokens
+        # Reserve for: (a) the summary message we'll prepend if we
+        # actually drop anything (~1500 tokens for the prose), (b) the
+        # downstream cross-source synthesis SessionStart prepend
+        # (~200 tokens), (c) misc emission overhead the per-event
+        # estimator can't see. Bias generously — overflows kill resume,
+        # under-fills are free.
+        OVERHEAD_RESERVE = 2_500 if self.cfg.summarize_dropped else 1_000
+        used += OVERHEAD_RESERVE
+
+        for ev in reversed(body):
+            cost = self._estimate(ev)
+            if used + cost > budget:
+                break
+            kept_reversed.append(ev)
+            used += cost
+
+        kept = list(reversed(kept_reversed))
+        n_dropped = len(body) - len(kept)
+
+        if n_dropped == 0:
+            # Everything fit — no summary needed.
+            return head + kept
+
+        log.info(
+            "compactor: dropped %d events to fit budget (%d → %d tokens, target %d)",
+            n_dropped, sum(self._estimate(e) for e in events), used, budget,
+        )
+
+        if self.cfg.summarize_dropped:
+            dropped = body[:n_dropped]
+            summary = _build_summary_message(dropped, n_kept_events=len(kept))
+            return head + [summary] + kept
+
+        return head + kept
+
+
+# ------------------------------------------------------------------ #
+# Summary message                                                      #
+# ------------------------------------------------------------------ #
+
+
+def _build_summary_message(dropped: list[Event], *, n_kept_events: int) -> UserMessage:
+    """Construct a deterministic UserMessage summarizing dropped events.
+
+    Inserted as a regular user message so both claude and codex render
+    it without protocol changes. The text is plain prose with structure
+    the model can scan.
+    """
+    user_msgs = [e for e in dropped if e.type == "user_message"]
+    asst_msgs = [e for e in dropped if e.type == "assistant_message"]
+    tool_calls = [e for e in dropped if isinstance(e, ToolCall)]
+    tool_call_names: Counter[str] = Counter(getattr(e, "name", "") for e in tool_calls)
+
+    files: Counter[str] = Counter()
+    for tc in tool_calls:
+        inp = getattr(tc, "input", {}) or {}
+        for key in ("file_path", "path", "filepath"):
+            if isinstance(inp.get(key), str):
+                files[inp[key]] += 1
+                break
+
+    timestamps = [e.timestamp for e in dropped if e.timestamp]
+    span = ""
+    if len(timestamps) >= 2:
+        span = f"\n  • Time span: {timestamps[0][:19]} → {timestamps[-1][:19]}"
+
+    def _trunc(text: str, n: int = 120) -> str:
+        return (text[:n] + "…") if len(text) > n else text
+
+    first_user = _trunc(user_msgs[0].text) if user_msgs else ""
+    last_user = _trunc(user_msgs[-1].text) if user_msgs else ""
+
+    tool_summary = ", ".join(f"{n}×{c}" for n, c in tool_call_names.most_common(8))
+    file_summary = ", ".join(f for f, _ in files.most_common(8))
+
+    text = (
+        "[fleet-track session summary — earlier turns dropped to fit context]\n\n"
+        "This is a continuation of a longer session. The earlier conversation "
+        "is preserved in the canonical session log; only this summary + the most "
+        f"recent {n_kept_events} event(s) are loaded into your active context.\n\n"
+        f"Dropped from this resume:\n"
+        f"  • {len(user_msgs)} user messages, {len(asst_msgs)} assistant messages, "
+        f"{len(tool_calls)} tool calls"
+        f"{span}\n"
+        f"  • Tools used: {tool_summary or '(none)'}\n"
+        f"  • Files touched: {file_summary or '(none)'}\n"
+        f"  • First user message: {first_user!r}\n"
+        f"  • Most recent dropped user message: {last_user!r}\n\n"
+        f"The recent events follow verbatim."
+    )
+
+    return UserMessage(
+        source="unknown",
+        text=text,
+        synthesized=True,  # parser-derived view; not a real user message
+    )

--- a/fleet/track/compactor.py
+++ b/fleet/track/compactor.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Optional, Protocol
 
 from .unified import (
@@ -69,6 +69,7 @@ def _try_tiktoken_encoder():
     """
     try:
         import tiktoken
+
         return tiktoken.get_encoding("cl100k_base")
     except (ImportError, Exception):
         return None
@@ -180,9 +181,9 @@ KNOWN_MODELS: dict[str, int] = {
 # Default budget per target tool when the model isn't known.
 # Conservative — we'd rather drop a few turns than overflow.
 DEFAULT_TOOL_BUDGETS: dict[str, int] = {
-    "claude": 180_000,    # safe under 200K (most models); 1M-window Opus has more headroom
-    "codex": 200_000,     # safe under 256K (gpt-5)
-    "cursor": 100_000,    # conservative; cursor exposes various models
+    "claude": 180_000,  # safe under 200K (most models); 1M-window Opus has more headroom
+    "codex": 200_000,  # safe under 256K (gpt-5)
+    "cursor": 100_000,  # conservative; cursor exposes various models
     "opencode": 100_000,  # conservative
 }
 
@@ -304,7 +305,10 @@ class TruncationCompactor:
         return result
 
     def _refine_against_emission(
-        self, candidate: list[Event], *, original: list[Event],
+        self,
+        candidate: list[Event],
+        *,
+        original: list[Event],
     ) -> list[Event]:
         """If the actual emission exceeds budget, drop more events
         from the start of the body until it fits or we hit the pass
@@ -325,7 +329,9 @@ class TruncationCompactor:
                 if pass_num > 0:
                     log.info(
                         "compactor refinement: settled at %d tokens (budget %d) after %d pass(es)",
-                        actual, budget, pass_num,
+                        actual,
+                        budget,
+                        pass_num,
                     )
                 return candidate
 
@@ -337,9 +343,12 @@ class TruncationCompactor:
                     body_start += 1
                 else:
                     break
-            if (body_start < len(candidate)
-                    and getattr(candidate[body_start], "synthesized", False)
-                    and "session summary" in getattr(candidate[body_start], "text", "").lower()):
+            if (
+                body_start < len(candidate)
+                and getattr(candidate[body_start], "synthesized", False)
+                and "session summary"
+                in getattr(candidate[body_start], "text", "").lower()
+            ):
                 body_start += 1
 
             body = candidate[body_start:]
@@ -352,7 +361,8 @@ class TruncationCompactor:
 
         log.warning(
             "compactor: budget %d not reachable after %d passes; returning best effort",
-            budget, self._max_refinement_passes,
+            budget,
+            self._max_refinement_passes,
         )
         return candidate
 
@@ -406,12 +416,15 @@ class TruncationCompactor:
         if head_tokens >= budget:
             # Pathological: SessionStart alone is over budget. Emit it
             # anyway; nothing meaningful to keep otherwise.
-            log.warning("compactor: SessionStart alone exceeds budget (%d > %d)",
-                        head_tokens, budget)
+            log.warning(
+                "compactor: SessionStart alone exceeds budget (%d > %d)",
+                head_tokens,
+                budget,
+            )
             return head
 
         # Walk body from the end, accumulating tokens.
-        kept_reversed: list[Event] = []
+        kept_pairs_reversed: list[tuple[int, Event]] = []
         used = head_tokens
         # Reserve for: (a) the summary message we'll prepend if we
         # actually drop anything (~1500 tokens for the prose), (b) the
@@ -422,15 +435,18 @@ class TruncationCompactor:
         OVERHEAD_RESERVE = 2_500 if self.cfg.summarize_dropped else 1_000
         used += OVERHEAD_RESERVE
 
-        for ev in reversed(body):
+        for idx in range(len(body) - 1, -1, -1):
+            ev = body[idx]
             cost = self._estimate(ev)
             if used + cost > budget:
-                break
-            kept_reversed.append(ev)
+                continue
+            kept_pairs_reversed.append((idx, ev))
             used += cost
 
-        kept = list(reversed(kept_reversed))
-        n_dropped = len(body) - len(kept)
+        kept_indices = {idx for idx, _ in kept_pairs_reversed}
+        kept = [ev for idx, ev in enumerate(body) if idx in kept_indices]
+        dropped = [ev for idx, ev in enumerate(body) if idx not in kept_indices]
+        n_dropped = len(dropped)
 
         if n_dropped == 0:
             # Everything fit — no summary needed.
@@ -438,11 +454,13 @@ class TruncationCompactor:
 
         log.info(
             "compactor: dropped %d events to fit budget (%d → %d tokens, target %d)",
-            n_dropped, sum(self._estimate(e) for e in events), used, budget,
+            n_dropped,
+            sum(self._estimate(e) for e in events),
+            used,
+            budget,
         )
 
         if self.cfg.summarize_dropped:
-            dropped = body[:n_dropped]
             summary = _build_summary_message(dropped, n_kept_events=len(kept))
             return head + [summary] + kept
 

--- a/fleet/track/compactor.py
+++ b/fleet/track/compactor.py
@@ -439,7 +439,7 @@ class TruncationCompactor:
             ev = body[idx]
             cost = self._estimate(ev)
             if used + cost > budget:
-                continue
+                break
             kept_pairs_reversed.append((idx, ev))
             used += cost
 

--- a/fleet/track/converter.py
+++ b/fleet/track/converter.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
 
-from .sources.base import Source
+from .sources.base import Source, with_synth_meta
 from .unified import Event, SessionStart
 
 log = logging.getLogger("fleet.track.converter")
@@ -88,10 +88,16 @@ def convert(
     # Annotate each event's raw with a `_synth` meta block so the
     # target serializer's cross-source synthesizer can read coherent
     # session-wide values out of every row.
-    annotated = [_with_synth_meta(e, session_id=new_session_id,
-                                  cwd=cwd, version=version,
-                                  git_branch=git_branch)
-                 for e in events]
+    annotated = [
+        with_synth_meta(
+            e,
+            session_id=new_session_id,
+            cwd=cwd,
+            version=version,
+            git_branch=git_branch,
+        )
+        for e in events
+    ]
 
     out_bytes = to_source.serialize(annotated)
     suggested = _suggested_path_for(to_source, home, new_session_id, cwd)
@@ -139,17 +145,6 @@ def _first_git_branch(events: Iterable[Event]) -> Optional[str]:
     return None
 
 
-def _with_synth_meta(ev: Event, **synth) -> Event:
-    """Return a new event with `_synth` metadata embedded in `raw`.
-
-    Pydantic frozen events are immutable; we use model_copy with a
-    deep-merged raw dict.
-    """
-    raw = dict(ev.raw) if ev.raw else {}
-    raw["_synth"] = dict(synth)
-    return ev.model_copy(update={"raw": raw})
-
-
 def _encode_claude_cwd(cwd: str) -> str:
     """Convert `/Users/foo/.config` → `-Users-foo--config`.
 
@@ -159,15 +154,29 @@ def _encode_claude_cwd(cwd: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_-]", "-", cwd)
 
 
-def _suggested_path_for(to_source: Source, home: Path, session_id: str, cwd: str) -> Path:
+def _suggested_path_for(
+    to_source: Source, home: Path, session_id: str, cwd: str
+) -> Path:
     """Where the converted file should live so the target CLI's resume command finds it."""
     name = to_source.name
     if name == "claude":
-        return home / ".claude" / "projects" / _encode_claude_cwd(cwd) / f"{session_id}.jsonl"
+        return (
+            home
+            / ".claude"
+            / "projects"
+            / _encode_claude_cwd(cwd)
+            / f"{session_id}.jsonl"
+        )
     if name == "codex":
         # codex layout: ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
         now = _dt.datetime.now(_dt.timezone.utc)
         ts = now.strftime("%Y-%m-%dT%H-%M-%S")
         date_path = now.strftime("%Y/%m/%d")
-        return home / ".codex" / "sessions" / date_path / f"rollout-{ts}-{session_id}.jsonl"
+        return (
+            home
+            / ".codex"
+            / "sessions"
+            / date_path
+            / f"rollout-{ts}-{session_id}.jsonl"
+        )
     raise ValueError(f"Unknown target source: {name}")

--- a/fleet/track/converter.py
+++ b/fleet/track/converter.py
@@ -1,0 +1,173 @@
+"""Cross-format conversion glue.
+
+The Source classes' `parse()` and `serialize()` are pure per-event
+operations. Cross-format conversion needs *session-level* context
+(session id, cwd, model) to be threaded through every synthesized row
+so the target CLI's resume flow can find the file. This module owns
+that threading.
+
+Typical usage:
+
+    from fleet.track.sources import ClaudeSource, CodexSource
+    from fleet.track.converter import convert
+
+    out_bytes, meta = convert(
+        from_source=CodexSource(),
+        to_source=ClaudeSource(),
+        in_path=Path("~/.codex/sessions/.../rollout-...jsonl").expanduser(),
+    )
+    # `meta` carries the new-side session id + the suggested file path
+    # `claude --resume` can pick up.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .sources.base import Source
+from .unified import Event, SessionStart
+
+log = logging.getLogger("fleet.track.converter")
+
+
+@dataclass(frozen=True)
+class ConversionResult:
+    """Output of a cross-format conversion.
+
+    `bytes` is the serialized session file.
+    `session_id` is the id baked into the synthesized rows — the
+        source-side resume command uses this UUID/string to locate
+        the session.
+    `suggested_path` is the on-disk location the *target* CLI scans
+        for resumeable sessions. Caller writes `bytes` to this path
+        to make the converted session resumeable.
+    """
+
+    bytes: bytes
+    session_id: str
+    suggested_path: Path
+
+
+def convert(
+    *,
+    from_source: Source,
+    to_source: Source,
+    in_path: Path,
+    home: Optional[Path] = None,
+    new_session_id: Optional[str] = None,
+    target_cwd: Optional[str] = None,
+) -> ConversionResult:
+    """Convert a session file from one CLI's format into another's.
+
+    `home` defaults to `Path.home()`. `target_cwd` defaults to the
+    cwd recorded on the source session's first SessionStart event.
+    `new_session_id` defaults to a fresh UUID4 — supply explicitly if
+    you want determinism.
+    """
+    home = home or Path.home()
+    new_session_id = new_session_id or str(uuid.uuid4())
+
+    events = list(from_source.parse(in_path))
+    cwd = target_cwd or _first_cwd(events) or "/tmp"
+    # Resolve symlinks: macOS `/tmp` → `/private/tmp`. Both claude and
+    # codex index sessions by the resolved path, so a converter that
+    # leaves `/tmp` in the rows produces files claude/codex can't find.
+    try:
+        cwd = str(Path(cwd).resolve(strict=False))
+    except (OSError, RuntimeError):
+        pass
+    version = _first_version(events) or "0.0.0-converted"
+    git_branch = _first_git_branch(events) or ""
+
+    # Annotate each event's raw with a `_synth` meta block so the
+    # target serializer's cross-source synthesizer can read coherent
+    # session-wide values out of every row.
+    annotated = [_with_synth_meta(e, session_id=new_session_id,
+                                  cwd=cwd, version=version,
+                                  git_branch=git_branch)
+                 for e in events]
+
+    out_bytes = to_source.serialize(annotated)
+    suggested = _suggested_path_for(to_source, home, new_session_id, cwd)
+    return ConversionResult(
+        bytes=out_bytes,
+        session_id=new_session_id,
+        suggested_path=suggested,
+    )
+
+
+# ------------------------------------------------------------------ #
+# Helpers                                                              #
+# ------------------------------------------------------------------ #
+
+
+def _first_cwd(events: Iterable[Event]) -> Optional[str]:
+    for e in events:
+        if isinstance(e, SessionStart) and e.cwd:
+            return e.cwd
+        cwd = (e.raw or {}).get("cwd") if hasattr(e, "raw") else None
+        if cwd:
+            return str(cwd)
+    return None
+
+
+def _first_version(events: Iterable[Event]) -> Optional[str]:
+    for e in events:
+        v = getattr(e, "agent_version", None)
+        if v:
+            return str(v)
+        v = (e.raw or {}).get("version") if hasattr(e, "raw") else None
+        if v:
+            return str(v)
+    return None
+
+
+def _first_git_branch(events: Iterable[Event]) -> Optional[str]:
+    for e in events:
+        v = getattr(e, "git_branch", None)
+        if v:
+            return str(v)
+        v = (e.raw or {}).get("gitBranch") if hasattr(e, "raw") else None
+        if v:
+            return str(v)
+    return None
+
+
+def _with_synth_meta(ev: Event, **synth) -> Event:
+    """Return a new event with `_synth` metadata embedded in `raw`.
+
+    Pydantic frozen events are immutable; we use model_copy with a
+    deep-merged raw dict.
+    """
+    raw = dict(ev.raw) if ev.raw else {}
+    raw["_synth"] = dict(synth)
+    return ev.model_copy(update={"raw": raw})
+
+
+def _encode_claude_cwd(cwd: str) -> str:
+    """Convert `/Users/foo/.config` → `-Users-foo--config`.
+
+    Replace any character that isn't alphanumeric, `-`, or `_` with `-`.
+    Audited from production claude project directories.
+    """
+    return re.sub(r"[^a-zA-Z0-9_-]", "-", cwd)
+
+
+def _suggested_path_for(to_source: Source, home: Path, session_id: str, cwd: str) -> Path:
+    """Where the converted file should live so the target CLI's resume command finds it."""
+    name = to_source.name
+    if name == "claude":
+        return home / ".claude" / "projects" / _encode_claude_cwd(cwd) / f"{session_id}.jsonl"
+    if name == "codex":
+        # codex layout: ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+        now = _dt.datetime.now(_dt.timezone.utc)
+        ts = now.strftime("%Y-%m-%dT%H-%M-%S")
+        date_path = now.strftime("%Y/%m/%d")
+        return home / ".codex" / "sessions" / date_path / f"rollout-{ts}-{session_id}.jsonl"
+    raise ValueError(f"Unknown target source: {name}")

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -1,0 +1,373 @@
+"""Fleet track daemon.
+
+Main loop:
+  1. FSEvents/inotify watcher → debounce → queue
+  2. Upload worker pool drains queue via presigned URLs
+  3. Hourly reconciliation loop: full Merkle diff → catch FSEvents gaps
+  4. SIGTERM → drain in-flight uploads → exit cleanly
+
+Invoked by launchd/systemd as: flt track daemon
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import logging.handlers
+import os
+import signal
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from .api import TrackAPIClient, TrackAPIError
+from .drainer import QueueDrainer
+from .merkle import HashCache, MerkleTree
+from .paths import TrackPaths
+from .queue import UploadQueue
+from .reconciler import Reconciler
+from .sources import relative_to_home, source_summary
+from .status import (
+    TrackStatus,
+    clear_pid,
+    write_pid,
+    write_status,
+)
+from .uploader import UploadPool
+from .watcher import FileWatcher
+
+RECONCILE_INTERVAL = 600   # full Merkle diff every 10 minutes
+HOT_FILE_INTERVAL = 120     # active session files flushed every 2 min
+
+
+def _setup_logging(paths: TrackPaths) -> None:
+    paths.ensure_track_dir()
+    handler = logging.handlers.RotatingFileHandler(
+        paths.log_file, maxBytes=10 * 1024 * 1024, backupCount=3
+    )
+    handler.setFormatter(
+        logging.Formatter('{"time":"%(asctime)s","level":"%(levelname)s","component":"%(name)s","msg":"%(message)s"}')
+    )
+    root = logging.getLogger()
+    root.addHandler(handler)
+    root.addHandler(logging.StreamHandler())
+    root.setLevel(logging.INFO)
+
+
+log = logging.getLogger("fleet.track.daemon")
+
+
+def _make_device_id() -> str:
+    """
+    Stable human-readable device ID: {hostname}-{uuid8}.
+    e.g. "macbook-pro-a1b2c3d4"
+    """
+    import re
+    import socket
+    hostname = re.sub(r"[^a-z0-9-]", "-", socket.gethostname().lower())[:20].strip("-")
+    suffix = str(uuid.uuid4()).replace("-", "")[:8]
+    return f"{hostname}-{suffix}"
+
+
+def _load_config(paths: TrackPaths) -> dict:
+    if paths.config_file.exists():
+        return json.loads(paths.config_file.read_text())
+    config = {"device_id": _make_device_id()}
+    paths.ensure_track_dir()
+    paths.config_file.write_text(json.dumps(config, indent=2))
+    return config
+
+
+class Daemon:
+    def __init__(
+        self,
+        paths: Optional[TrackPaths] = None,
+        *,
+        queue: Optional[UploadQueue] = None,
+        cache: Optional[HashCache] = None,
+        tree: Optional[MerkleTree] = None,
+        api: Optional[TrackAPIClient] = None,
+    ) -> None:
+        self._paths = paths or TrackPaths.default()
+        self._stop = threading.Event()
+        self._status = TrackStatus(pid=os.getpid())
+        self._queue = queue or UploadQueue(self._paths)
+        self._cache = cache or HashCache(self._paths)
+        self._tree = tree or MerkleTree(self._cache)
+        self._api = api or TrackAPIClient()
+        self._pool: Optional[UploadPool] = None
+        self._reconciler = Reconciler(
+            queue=self._queue, cache=self._cache, tree=self._tree, api=self._api
+        )
+        self._drainer: Optional[QueueDrainer] = None  # built once pool exists
+        self._bytes_uploaded = 0
+        self._run_id = str(uuid.uuid4())[:8]
+        self._device_id: str = ""
+        self._identity: dict = {}
+        # confirmed_map: path → sha256 for every file we KNOW is on S3.
+        # Populated from the remote manifest at startup and updated only on
+        # successful upload callbacks. Used to build an honest manifest.json.
+        self._confirmed_map: dict[str, str] = {}
+        self._confirmed_lock = threading.Lock()
+        self._manifest_dirty = False  # set when confirmed_map gains new entries
+
+    # ------------------------------------------------------------------ #
+    # Public entry points                                                  #
+    # ------------------------------------------------------------------ #
+
+    def run_once(self, *, device_id: str = "test-device") -> "ReconcileResult":  # type: ignore[name-defined]
+        """One reconcile pass + drain. Test seam and `flt track daemon --once`.
+
+        Sets up a pool inline, runs Reconciler.reconcile, then Drainer.drain_once
+        until the queue is empty, then waits for in-flight uploads. Does NOT
+        install signal handlers or start the watcher. Caller owns paths and is
+        responsible for `paths.ensure_track_dir()`.
+        """
+        from .reconciler import ReconcileResult  # local import for the type
+
+        if self._pool is None:
+            self._pool = UploadPool(
+                on_done=self._on_upload_done,
+                on_failed=self._on_upload_failed,
+            )
+            self._drainer = QueueDrainer(
+                paths=self._paths,
+                queue=self._queue,
+                api=self._api,
+                pool=self._pool,
+            )
+
+        self._device_id = device_id
+        result: ReconcileResult = self._reconciler.reconcile(device_id)
+
+        # Drain until queue empty (or one drain returns claimed=0).
+        assert self._drainer is not None
+        while True:
+            drain = self._drainer.drain_once(device_id)
+            if drain.claimed == 0:
+                break
+
+        # Wait for in-flight uploads.
+        self._pool.drain(timeout=60)
+        return result
+
+    def run(self) -> None:
+        _setup_logging(self._paths)
+        write_pid(self._paths)
+        cfg = _load_config(self._paths)
+        self._device_id = cfg["device_id"]
+        self._identity = {
+            "user_id": cfg.get("user_id", ""),
+            "email": cfg.get("email", ""),
+            "team_id": cfg.get("team_id", ""),
+            "team_name": cfg.get("team_name", ""),
+            "device_id": self._device_id,
+            "hostname": cfg.get("hostname", ""),
+            "platform": cfg.get("platform", ""),
+        }
+        log.info("daemon starting run_id=%s pid=%s device=%s", self._run_id, os.getpid(), self._device_id)
+
+        signal.signal(signal.SIGTERM, self._handle_sigterm)
+        signal.signal(signal.SIGINT, self._handle_sigterm)
+
+        self._pool = UploadPool(
+            on_done=self._on_upload_done,
+            on_failed=self._on_upload_failed,
+        )
+        self._drainer = QueueDrainer(
+            paths=self._paths,
+            queue=self._queue,
+            api=self._api,
+            pool=self._pool,
+        )
+
+        # Start FSEvents/inotify watcher
+        try:
+            watcher = FileWatcher(callback=self._on_files_changed)
+            watcher.start()
+            log.info("file watcher started")
+        except Exception as e:
+            log.warning("file watcher unavailable (%s) — polling only", e)
+            watcher = None
+
+        # Initial full sync
+        self._reconcile()
+
+        # Main loop: reconcile hourly, reset failed items, write status
+        last_reconcile = time.monotonic()
+        last_queue_reset = time.monotonic()
+
+        while not self._stop.is_set():
+            now = time.monotonic()
+
+            if now - last_reconcile >= RECONCILE_INTERVAL:
+                self._reconcile()
+                last_reconcile = now
+
+            if now - last_queue_reset >= RECONCILE_INTERVAL:
+                reset = self._queue.reset_failed()
+                if reset:
+                    log.info("re-queued %d permanently failed items", reset)
+                self._queue.remove_done()
+                last_queue_reset = now
+
+            self._drain_queue()
+            # Write manifest once all pending uploads have drained.
+            if self._manifest_dirty:
+                stats = self._queue.stats()
+                if stats.get("pending", 0) == 0 and stats.get("in_flight", 0) == 0:
+                    self._upload_manifest()
+                    self._manifest_dirty = False
+            self._write_status()
+            self._stop.wait(timeout=10)
+
+        # Graceful shutdown
+        log.info("shutting down — draining uploads")
+        if self._pool:
+            self._pool.drain(timeout=60)
+            self._pool.shutdown()
+        if self._manifest_dirty:
+            self._upload_manifest()
+        if watcher:
+            watcher.stop()
+        self._queue.close()
+        self._cache.close()
+        clear_pid(self._paths)
+        log.info("daemon stopped")
+
+    # ------------------------------------------------------------------ #
+    # FSEvents callback                                                    #
+    # ------------------------------------------------------------------ #
+
+    def _on_files_changed(self, paths: list[Path]) -> None:
+        items = []
+        for path in paths:
+            if not path.exists():
+                continue
+            digest = self._cache.get_or_compute(path)
+            if digest:
+                rel = relative_to_home(path)
+                items.append((rel, digest))
+
+        if items:
+            self._queue.enqueue_batch(items)
+            log.debug("queued %d changed files", len(items))
+            self._drain_queue()
+
+    # ------------------------------------------------------------------ #
+    # Reconciliation (full Merkle diff)                                   #
+    # ------------------------------------------------------------------ #
+
+    def _reconcile(self) -> None:
+        run_id = str(uuid.uuid4())[:8]
+        log.info("reconcile start run_id=%s", run_id)
+        self._status.state = "syncing"
+        self._write_status()
+
+        try:
+            result = self._reconciler.reconcile(self._device_id)
+        except TrackAPIError as e:
+            log.warning("reconcile: %s", e)
+            self._status.state = "error"
+            self._status.errors = [str(e)]
+            return
+
+        # Seed confirmed_map from S3 — these are files we know are safely stored.
+        with self._confirmed_lock:
+            for path, digest in result.remote_map.items():
+                self._confirmed_map.setdefault(path, digest)
+
+        self._status.files_total = len(result.local_map)
+        self._status.last_sync = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        self._status.state = "idle"
+
+        if not result.in_sync:
+            self._drain_queue()
+
+        log.info("reconcile done run_id=%s changed=%d", run_id, len(result.changed_paths))
+
+    def _upload_manifest(self) -> None:
+        """PUT manifest.json reflecting only files confirmed uploaded to S3.
+
+        We never write an optimistic manifest based on local state — only files
+        with a confirmed S3 PUT success are included. This means a failed upload
+        won't be silently skipped on the next reconcile.
+        """
+        with self._confirmed_lock:
+            confirmed = dict(self._confirmed_map)
+
+        root = MerkleTree.compute_root(confirmed)
+        manifest = json.dumps({
+            "root_hash": root,
+            **self._identity,
+            "files": confirmed,
+        }, separators=(",", ":"))
+        try:
+            url_map = self._api.get_upload_urls(self._device_id, ["manifest.json"])
+            url = url_map.get("manifest.json")
+            if not url:
+                log.warning("manifest upload: no presigned URL returned")
+                return
+            import httpx
+            resp = httpx.put(url, content=manifest.encode(), headers={"Content-Type": "application/octet-stream"}, timeout=30)
+            if resp.status_code not in (200, 204):
+                log.warning("manifest upload failed: HTTP %s", resp.status_code)
+            else:
+                log.info("manifest uploaded root=%s files=%d", root[:12], len(confirmed))
+        except Exception as e:
+            log.warning("manifest upload error: %s", e)
+
+    # ------------------------------------------------------------------ #
+    # Queue draining                                                       #
+    # ------------------------------------------------------------------ #
+
+    def _drain_queue(self) -> None:
+        """Delegate to QueueDrainer; one pass."""
+        if self._drainer is None:
+            return
+        self._drainer.drain_once(self._device_id)
+
+    # ------------------------------------------------------------------ #
+    # Upload callbacks                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _on_upload_done(self, rel_path: str, sha256: str) -> None:
+        self._queue.mark_done(rel_path, sha256)
+        self._status.files_synced += 1
+        # Record this file as confirmed on S3 using the hash we originally computed.
+        digest = self._cache.get_stored_digest(rel_path)
+        if digest:
+            with self._confirmed_lock:
+                self._confirmed_map[rel_path] = digest
+            self._manifest_dirty = True
+
+    def _on_upload_failed(self, rel_path: str, sha256: str, error: str) -> None:
+        self._queue.mark_failed(rel_path, sha256, error)
+        log.warning("upload failed %s: %s", rel_path, error)
+
+    # ------------------------------------------------------------------ #
+    # Status                                                               #
+    # ------------------------------------------------------------------ #
+
+    def _write_status(self) -> None:
+        stats = self._queue.stats()
+        self._status.pid = os.getpid()
+        self._status.queue_depth = stats.get("pending", 0) + stats.get("in_flight", 0)
+        self._status.bytes_uploaded_session = self._bytes_uploaded
+        self._status.sources = source_summary()
+        write_status(self._paths, self._status)
+
+    # ------------------------------------------------------------------ #
+    # Signal handling                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _handle_sigterm(self, signum, frame) -> None:
+        log.info("received signal %s — stopping", signum)
+        self._stop.set()
+
+
+def main() -> None:
+    Daemon().run()

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -1,17 +1,20 @@
 """Fleet track daemon.
 
+V1 is intentionally simple: periodic full reconciliation is the source of truth.
+The daemon scans local session files, diffs them against the remote manifest,
+uploads whole changed files, then uploads a new manifest after successful PUTs.
+
 Main loop:
-  1. FSEvents/inotify watcher → debounce → queue
-  2. Upload worker pool drains queue via presigned URLs
-  3. Hourly reconciliation loop: full Merkle diff → catch FSEvents gaps
-  4. SIGTERM → drain in-flight uploads → exit cleanly
+  1. Initial full reconcile on startup.
+  2. Upload worker pool drains queue via presigned URLs.
+  3. Reconciliation loop: full Merkle diff every RECONCILE_INTERVAL.
+  4. SIGTERM → drain in-flight uploads → exit cleanly.
 
 Invoked by launchd/systemd as: flt track daemon
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import logging.handlers
@@ -20,8 +23,7 @@ import signal
 import threading
 import time
 import uuid
-from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from .api import TrackAPIClient, TrackAPIError
 from .drainer import QueueDrainer
@@ -29,18 +31,19 @@ from .merkle import HashCache, MerkleTree
 from .paths import TrackPaths
 from .queue import UploadQueue
 from .reconciler import Reconciler
-from .sources import relative_to_home, source_summary
+from .sources import source_summary
 from .status import (
     TrackStatus,
     clear_pid,
     write_pid,
     write_status,
 )
-from .uploader import UploadPool
-from .watcher import FileWatcher
+from .uploader import HttpxTransport, Transport, UploadPool
 
-RECONCILE_INTERVAL = 600   # full Merkle diff every 10 minutes
-HOT_FILE_INTERVAL = 120     # active session files flushed every 2 min
+if TYPE_CHECKING:
+    from .reconciler import ReconcileResult
+
+RECONCILE_INTERVAL = 600  # full Merkle diff every 10 minutes
 
 
 def _setup_logging(paths: TrackPaths) -> None:
@@ -49,7 +52,9 @@ def _setup_logging(paths: TrackPaths) -> None:
         paths.log_file, maxBytes=10 * 1024 * 1024, backupCount=3
     )
     handler.setFormatter(
-        logging.Formatter('{"time":"%(asctime)s","level":"%(levelname)s","component":"%(name)s","msg":"%(message)s"}')
+        logging.Formatter(
+            '{"time":"%(asctime)s","level":"%(levelname)s","component":"%(name)s","msg":"%(message)s"}'
+        )
     )
     root = logging.getLogger()
     root.addHandler(handler)
@@ -67,6 +72,7 @@ def _make_device_id() -> str:
     """
     import re
     import socket
+
     hostname = re.sub(r"[^a-z0-9-]", "-", socket.gethostname().lower())[:20].strip("-")
     suffix = str(uuid.uuid4()).replace("-", "")[:8]
     return f"{hostname}-{suffix}"
@@ -81,6 +87,18 @@ def _load_config(paths: TrackPaths) -> dict:
     return config
 
 
+def _identity_from_config(cfg: dict, device_id: str) -> dict:
+    return {
+        "user_id": cfg.get("user_id", ""),
+        "email": cfg.get("email", ""),
+        "team_id": cfg.get("team_id", ""),
+        "team_name": cfg.get("team_name", ""),
+        "device_id": device_id,
+        "hostname": cfg.get("hostname", ""),
+        "platform": cfg.get("platform", ""),
+    }
+
+
 class Daemon:
     def __init__(
         self,
@@ -90,6 +108,7 @@ class Daemon:
         cache: Optional[HashCache] = None,
         tree: Optional[MerkleTree] = None,
         api: Optional[TrackAPIClient] = None,
+        upload_transport: Optional[Transport] = None,
     ) -> None:
         self._paths = paths or TrackPaths.default()
         self._stop = threading.Event()
@@ -98,6 +117,7 @@ class Daemon:
         self._cache = cache or HashCache(self._paths)
         self._tree = tree or MerkleTree(self._cache)
         self._api = api or TrackAPIClient()
+        self._upload_transport = upload_transport
         self._pool: Optional[UploadPool] = None
         self._reconciler = Reconciler(
             queue=self._queue, cache=self._cache, tree=self._tree, api=self._api
@@ -118,20 +138,25 @@ class Daemon:
     # Public entry points                                                  #
     # ------------------------------------------------------------------ #
 
-    def run_once(self, *, device_id: str = "test-device") -> "ReconcileResult":  # type: ignore[name-defined]
+    def run_once(self, *, device_id: Optional[str] = None) -> "ReconcileResult":  # type: ignore[name-defined]
         """One reconcile pass + drain. Test seam and `flt track daemon --once`.
 
         Sets up a pool inline, runs Reconciler.reconcile, then Drainer.drain_once
-        until the queue is empty, then waits for in-flight uploads. Does NOT
-        install signal handlers or start the watcher. Caller owns paths and is
-        responsible for `paths.ensure_track_dir()`.
+        until the queue is empty, waits for in-flight uploads, then uploads the
+        manifest if any files were confirmed. Does NOT install signal handlers.
         """
-        from .reconciler import ReconcileResult  # local import for the type
+        if device_id is None:
+            cfg = _load_config(self._paths)
+            device_id = cfg["device_id"]
+            self._identity = _identity_from_config(cfg, device_id)
+        elif not self._identity:
+            self._identity = {"device_id": device_id}
 
         if self._pool is None:
             self._pool = UploadPool(
                 on_done=self._on_upload_done,
                 on_failed=self._on_upload_failed,
+                transport=self._upload_transport,
             )
             self._drainer = QueueDrainer(
                 paths=self._paths,
@@ -152,6 +177,12 @@ class Daemon:
 
         # Wait for in-flight uploads.
         self._pool.drain(timeout=60)
+        if self._manifest_dirty:
+            self._upload_manifest()
+            self._manifest_dirty = False
+        self._pool.shutdown()
+        self._pool = None
+        self._drainer = None
         return result
 
     def run(self) -> None:
@@ -159,16 +190,13 @@ class Daemon:
         write_pid(self._paths)
         cfg = _load_config(self._paths)
         self._device_id = cfg["device_id"]
-        self._identity = {
-            "user_id": cfg.get("user_id", ""),
-            "email": cfg.get("email", ""),
-            "team_id": cfg.get("team_id", ""),
-            "team_name": cfg.get("team_name", ""),
-            "device_id": self._device_id,
-            "hostname": cfg.get("hostname", ""),
-            "platform": cfg.get("platform", ""),
-        }
-        log.info("daemon starting run_id=%s pid=%s device=%s", self._run_id, os.getpid(), self._device_id)
+        self._identity = _identity_from_config(cfg, self._device_id)
+        log.info(
+            "daemon starting run_id=%s pid=%s device=%s",
+            self._run_id,
+            os.getpid(),
+            self._device_id,
+        )
 
         signal.signal(signal.SIGTERM, self._handle_sigterm)
         signal.signal(signal.SIGINT, self._handle_sigterm)
@@ -176,6 +204,7 @@ class Daemon:
         self._pool = UploadPool(
             on_done=self._on_upload_done,
             on_failed=self._on_upload_failed,
+            transport=self._upload_transport,
         )
         self._drainer = QueueDrainer(
             paths=self._paths,
@@ -184,19 +213,12 @@ class Daemon:
             pool=self._pool,
         )
 
-        # Start FSEvents/inotify watcher
-        try:
-            watcher = FileWatcher(callback=self._on_files_changed)
-            watcher.start()
-            log.info("file watcher started")
-        except Exception as e:
-            log.warning("file watcher unavailable (%s) — polling only", e)
-            watcher = None
-
         # Initial full sync
         self._reconcile()
 
-        # Main loop: reconcile hourly, reset failed items, write status
+        # Main loop: reconcile periodically, reset failed items, write status.
+        # V1 intentionally avoids watcher-driven whole-file uploads; changed
+        # files are discovered by reconciliation.
         last_reconcile = time.monotonic()
         last_queue_reset = time.monotonic()
 
@@ -231,31 +253,10 @@ class Daemon:
             self._pool.shutdown()
         if self._manifest_dirty:
             self._upload_manifest()
-        if watcher:
-            watcher.stop()
         self._queue.close()
         self._cache.close()
         clear_pid(self._paths)
         log.info("daemon stopped")
-
-    # ------------------------------------------------------------------ #
-    # FSEvents callback                                                    #
-    # ------------------------------------------------------------------ #
-
-    def _on_files_changed(self, paths: list[Path]) -> None:
-        items = []
-        for path in paths:
-            if not path.exists():
-                continue
-            digest = self._cache.get_or_compute(path)
-            if digest:
-                rel = relative_to_home(path)
-                items.append((rel, digest))
-
-        if items:
-            self._queue.enqueue_batch(items)
-            log.debug("queued %d changed files", len(items))
-            self._drain_queue()
 
     # ------------------------------------------------------------------ #
     # Reconciliation (full Merkle diff)                                   #
@@ -287,7 +288,9 @@ class Daemon:
         if not result.in_sync:
             self._drain_queue()
 
-        log.info("reconcile done run_id=%s changed=%d", run_id, len(result.changed_paths))
+        log.info(
+            "reconcile done run_id=%s changed=%d", run_id, len(result.changed_paths)
+        )
 
     def _upload_manifest(self) -> None:
         """PUT manifest.json reflecting only files confirmed uploaded to S3.
@@ -300,23 +303,36 @@ class Daemon:
             confirmed = dict(self._confirmed_map)
 
         root = MerkleTree.compute_root(confirmed)
-        manifest = json.dumps({
-            "root_hash": root,
-            **self._identity,
-            "files": confirmed,
-        }, separators=(",", ":"))
+        manifest = json.dumps(
+            {
+                "root_hash": root,
+                **self._identity,
+                "files": confirmed,
+            },
+            separators=(",", ":"),
+        )
         try:
             url_map = self._api.get_upload_urls(self._device_id, ["manifest.json"])
             url = url_map.get("manifest.json")
             if not url:
                 log.warning("manifest upload: no presigned URL returned")
                 return
-            import httpx
-            resp = httpx.put(url, content=manifest.encode(), headers={"Content-Type": "application/octet-stream"}, timeout=30)
-            if resp.status_code not in (200, 204):
-                log.warning("manifest upload failed: HTTP %s", resp.status_code)
+            owned_transport = None
+            transport = self._upload_transport
+            if transport is None:
+                owned_transport = HttpxTransport()
+                transport = owned_transport
+            try:
+                status = transport.put(url, manifest.encode())
+            finally:
+                if owned_transport is not None:
+                    owned_transport.close()
+            if status not in (200, 204):
+                log.warning("manifest upload failed: HTTP %s", status)
             else:
-                log.info("manifest uploaded root=%s files=%d", root[:12], len(confirmed))
+                log.info(
+                    "manifest uploaded root=%s files=%d", root[:12], len(confirmed)
+                )
         except Exception as e:
             log.warning("manifest upload error: %s", e)
 
@@ -369,5 +385,9 @@ class Daemon:
         self._stop.set()
 
 
-def main() -> None:
-    Daemon().run()
+def main(*, once: bool = False) -> None:
+    daemon = Daemon()
+    if once:
+        daemon.run_once()
+        return
+    daemon.run()

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -38,6 +38,7 @@ from .status import (
     write_pid,
     write_status,
 )
+from .store import session_from_native_path
 from .uploader import HttpxTransport, Transport, UploadPool
 
 if TYPE_CHECKING:
@@ -133,6 +134,10 @@ class Daemon:
         self._confirmed_map: dict[str, str] = {}
         self._confirmed_lock = threading.Lock()
         self._manifest_dirty = False  # set when confirmed_map gains new entries
+        # path -> sha256 for rows this process has successfully registered
+        # in the orchestrator metadata index.
+        self._metadata_indexed: dict[str, str] = {}
+        self._metadata_lock = threading.Lock()
 
     # ------------------------------------------------------------------ #
     # Public entry points                                                  #
@@ -277,9 +282,14 @@ class Daemon:
             return
 
         # Seed confirmed_map from S3 — these are files we know are safely stored.
+        confirmed_existing: dict[str, str] = {}
         with self._confirmed_lock:
             for path, digest in result.remote_map.items():
                 self._confirmed_map.setdefault(path, digest)
+                if result.local_map.get(path) == digest:
+                    confirmed_existing[path] = digest
+
+        self._upsert_metadata_for_paths(confirmed_existing)
 
         self._status.files_total = len(result.local_map)
         self._status.last_sync = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
@@ -354,15 +364,54 @@ class Daemon:
         self._queue.mark_done(rel_path, sha256)
         self._status.files_synced += 1
         # Record this file as confirmed on S3 using the hash we originally computed.
-        digest = self._cache.get_stored_digest(rel_path)
-        if digest:
-            with self._confirmed_lock:
-                self._confirmed_map[rel_path] = digest
-            self._manifest_dirty = True
+        with self._confirmed_lock:
+            self._confirmed_map[rel_path] = sha256
+        self._manifest_dirty = True
+        self._upsert_session_metadata(rel_path, sha256)
 
     def _on_upload_failed(self, rel_path: str, sha256: str, error: str) -> None:
         self._queue.mark_failed(rel_path, sha256, error)
         log.warning("upload failed %s: %s", rel_path, error)
+
+    # ------------------------------------------------------------------ #
+    # Metadata index                                                       #
+    # ------------------------------------------------------------------ #
+
+    def _upsert_metadata_for_paths(self, file_map: dict[str, str]) -> None:
+        for rel_path, digest in file_map.items():
+            self._upsert_session_metadata(rel_path, digest)
+
+    def _upsert_session_metadata(self, rel_path: str, sha256: str) -> None:
+        """Best-effort metadata index update for a confirmed S3 object.
+
+        The v1 syncer's correctness still comes from S3 bytes + manifest. The
+        metadata index is a read-side accelerator for listing/resume, so a
+        transient failure here should be retried on a later reconcile rather
+        than marking the file upload failed.
+        """
+        if rel_path == "manifest.json":
+            return
+        with self._metadata_lock:
+            if self._metadata_indexed.get(rel_path) == sha256:
+                return
+
+        abs_path = self._paths.home / rel_path
+        session = session_from_native_path(abs_path, home=self._paths.home)
+        if session is None:
+            return
+
+        try:
+            self._api.upsert_session(
+                device_id=self._device_id,
+                path=rel_path,
+                session=session,
+            )
+        except Exception as e:
+            log.warning("metadata upsert failed %s: %s", rel_path, e)
+            return
+
+        with self._metadata_lock:
+            self._metadata_indexed[rel_path] = sha256
 
     # ------------------------------------------------------------------ #
     # Status                                                               #

--- a/fleet/track/drainer.py
+++ b/fleet/track/drainer.py
@@ -1,0 +1,89 @@
+"""Queue drainer.
+
+Pulls a batch from the upload queue, requests presigned URLs from the
+track API, and hands each item to the upload pool. One pass is one
+`drain_once()` call — the Daemon loop just calls this on a cadence.
+
+Pulled out of `Daemon` so tests can:
+  - assert "claim_batch was called with n ≤ 100" without timing
+  - assert "items with no presigned URL got marked_failed"
+  - drive the drain step against a fake pool that records submissions
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from .api import TrackAPIClient, TrackAPIError
+from .paths import TrackPaths
+from .queue import UploadQueue
+from .uploader import UploadPool
+
+log = logging.getLogger("fleet.track.drainer")
+
+# Server caps /v1/track/upload-urls at 100 paths per request. Match it
+# here to avoid a 400 if a single drain claims more.
+DEFAULT_BATCH_SIZE = 32
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    claimed: int
+    submitted: int
+    failed: int  # items marked failed (e.g. no presigned URL returned)
+
+
+class QueueDrainer:
+    def __init__(
+        self,
+        *,
+        paths: TrackPaths,
+        queue: UploadQueue,
+        api: TrackAPIClient,
+        pool: UploadPool,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self._paths = paths
+        self._queue = queue
+        self._api = api
+        self._pool = pool
+        self._batch_size = batch_size
+
+    def drain_once(self, device_id: str) -> DrainResult:
+        """Claim up to `batch_size` items and submit them to the pool.
+
+        Network failure on the upload-urls call marks every claimed item
+        failed (so they retry with backoff), then returns. We do not
+        retry inside this call — the daemon's main loop will run us
+        again on its next tick.
+        """
+        items = self._queue.claim_batch(n=self._batch_size)
+        if not items:
+            return DrainResult(claimed=0, submitted=0, failed=0)
+
+        rel_paths = [item.path for item in items]
+
+        try:
+            url_map = self._api.get_upload_urls(device_id, rel_paths)
+        except TrackAPIError as e:
+            log.warning("drain: failed to get upload URLs: %s", e)
+            for item in items:
+                self._queue.mark_failed(item.path, item.sha256, str(e))
+            return DrainResult(claimed=len(items), submitted=0, failed=len(items))
+
+        home = self._paths.home
+        submitted = 0
+        failed = 0
+        for item in items:
+            url = url_map.get(item.path)
+            if not url:
+                self._queue.mark_failed(item.path, item.sha256, "no presigned URL returned")
+                failed += 1
+                continue
+            abs_path: Path = home / item.path
+            self._pool.submit(item.path, item.sha256, abs_path, url)
+            submitted += 1
+
+        return DrainResult(claimed=len(items), submitted=submitted, failed=failed)

--- a/fleet/track/install.py
+++ b/fleet/track/install.py
@@ -1,0 +1,203 @@
+"""Install / uninstall the fleet track daemon as an OS service.
+
+Mac:   ~/Library/LaunchAgents/io.fleet.track.plist  (launchd)
+Linux: ~/.config/systemd/user/fleet-track.service   (systemd --user)
+
+Each plist/unit refers to the daemon's log file via `TrackPaths`, so tests
+that build a `TrackPaths.under(tmp_path)` get a deterministic rendered
+unit string they can snapshot without ever shelling out.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .paths import TrackPaths
+
+PLIST_LABEL = "io.fleet.track"
+SYSTEMD_SERVICE = "fleet-track"
+
+
+def flt_executable() -> str:
+    """Return the absolute path to the `flt` script the OS service should run.
+
+    Prefer the script co-located with the current Python interpreter (same
+    venv) so launchd/systemd don't need to activate the venv themselves.
+    """
+    candidate = Path(sys.executable).parent / "flt"
+    if candidate.exists():
+        return str(candidate)
+    exe = shutil.which("flt")
+    if exe:
+        return exe
+    return str(candidate)
+
+
+# ------------------------------------------------------------------ #
+# Public API                                                           #
+# ------------------------------------------------------------------ #
+
+
+def install(paths: Optional[TrackPaths] = None) -> None:
+    paths = paths or TrackPaths.default()
+    system = platform.system()
+    if system == "Darwin":
+        _install_launchd(paths)
+    elif system == "Linux":
+        _install_systemd(paths)
+    else:
+        raise RuntimeError(f"Unsupported platform: {system}")
+
+
+def uninstall() -> None:
+    system = platform.system()
+    if system == "Darwin":
+        _uninstall_launchd()
+    elif system == "Linux":
+        _uninstall_systemd()
+
+
+def is_installed() -> bool:
+    system = platform.system()
+    if system == "Darwin":
+        return _launchd_plist_path().exists()
+    elif system == "Linux":
+        return _systemd_service_path().exists()
+    return False
+
+
+# ------------------------------------------------------------------ #
+# Plist / unit string rendering — pure functions, snapshot-testable    #
+# ------------------------------------------------------------------ #
+
+
+def render_launchd_plist(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
+    """Return the plist XML body. Pure: no filesystem side-effects."""
+    extra_env = ""
+    if os.environ.get("FLEET_TRACK_BASE_URL"):
+        extra_env = (
+            f"<key>FLEET_TRACK_BASE_URL</key>"
+            f"<string>{os.environ['FLEET_TRACK_BASE_URL']}</string>"
+        )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{PLIST_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{flt_path}</string>
+        <string>track</string>
+        <string>daemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{paths.log_file}</string>
+    <key>StandardErrorPath</key>
+    <string>{paths.log_file}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{env_path}</string>
+        <key>HOME</key>
+        <string>{paths.home}</string>
+        {extra_env}
+    </dict>
+</dict>
+</plist>
+"""
+
+
+def render_systemd_unit(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
+    """Return the systemd service unit body. Pure: no filesystem side-effects."""
+    extra_env = ""
+    if os.environ.get("FLEET_TRACK_BASE_URL"):
+        extra_env = f"Environment=FLEET_TRACK_BASE_URL={os.environ['FLEET_TRACK_BASE_URL']}"
+    return f"""[Unit]
+Description=Fleet track daemon — AI session sync
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart={flt_path} track daemon
+Restart=always
+RestartSec=5
+StandardOutput=append:{paths.log_file}
+StandardError=append:{paths.log_file}
+Environment=PATH={env_path}
+{extra_env}
+
+[Install]
+WantedBy=default.target
+"""
+
+
+# ------------------------------------------------------------------ #
+# macOS launchd                                                        #
+# ------------------------------------------------------------------ #
+
+
+def _launchd_plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{PLIST_LABEL}.plist"
+
+
+def _install_launchd(paths: TrackPaths) -> None:
+    paths.ensure_track_dir()
+    body = render_launchd_plist(
+        paths,
+        flt_executable(),
+        env_path=os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+    )
+    plist_path = _launchd_plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text(body)
+
+    subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+
+
+def _uninstall_launchd() -> None:
+    plist_path = _launchd_plist_path()
+    if plist_path.exists():
+        subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+        plist_path.unlink()
+
+
+# ------------------------------------------------------------------ #
+# Linux systemd --user                                                 #
+# ------------------------------------------------------------------ #
+
+
+def _systemd_service_path() -> Path:
+    return Path.home() / ".config" / "systemd" / "user" / f"{SYSTEMD_SERVICE}.service"
+
+
+def _install_systemd(paths: TrackPaths) -> None:
+    paths.ensure_track_dir()
+    body = render_systemd_unit(
+        paths,
+        flt_executable(),
+        env_path=os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+    )
+    service_path = _systemd_service_path()
+    service_path.parent.mkdir(parents=True, exist_ok=True)
+    service_path.write_text(body)
+
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
+    subprocess.run(["systemctl", "--user", "enable", "--now", SYSTEMD_SERVICE], check=True)
+
+
+def _uninstall_systemd() -> None:
+    subprocess.run(["systemctl", "--user", "disable", "--now", SYSTEMD_SERVICE], capture_output=True)
+    _systemd_service_path().unlink(missing_ok=True)
+    subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True)

--- a/fleet/track/merkle.py
+++ b/fleet/track/merkle.py
@@ -1,0 +1,174 @@
+"""Merkle tree for efficient sync state comparison.
+
+The "tree" is a flat {relative_path: sha256} map.
+Root hash = sha256(canonical JSON of sorted map).
+
+Hash cache in SQLite avoids re-reading unchanged files.
+Cache key: (path, mtime, size) — if both match, reuse cached sha256.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .paths import TrackPaths
+from .sources import iter_source_files, relative_to_home
+
+
+def _sha256_file(path: Path) -> Optional[str]:
+    """SHA256 of file content. Reads only complete bytes — safe for active JSONL files."""
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            while chunk := f.read(65536):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _open_db(state_db: Path) -> sqlite3.Connection:
+    state_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(state_db, timeout=10, check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS file_hashes (
+            path TEXT PRIMARY KEY,
+            mtime REAL NOT NULL,
+            size INTEGER NOT NULL,
+            sha256 TEXT NOT NULL,
+            last_seen INTEGER NOT NULL
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+class HashCache:
+    """SQLite-backed cache mapping path → (mtime, size, sha256)."""
+
+    def __init__(self, paths: Optional[TrackPaths] = None) -> None:
+        self._paths = paths or TrackPaths.default()
+        self._conn = _open_db(self._paths.state_db)
+
+    def get_or_compute(self, path: Path) -> Optional[str]:
+        """Return sha256 for path, using cache if mtime+size match."""
+        rel = relative_to_home(path, self._paths.home)
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+
+        mtime, size = stat.st_mtime, stat.st_size
+
+        row = self._conn.execute(
+            "SELECT mtime, size, sha256 FROM file_hashes WHERE path = ?", (rel,)
+        ).fetchone()
+
+        if row and abs(row[0] - mtime) < 0.001 and row[1] == size:
+            # Cache hit — stat matches, no need to read file
+            self._conn.execute(
+                "UPDATE file_hashes SET last_seen = ? WHERE path = ?",
+                (int(time.time()), rel),
+            )
+            self._conn.commit()
+            return row[2]
+
+        # Cache miss — read and hash the file
+        digest = _sha256_file(path)
+        if digest is None:
+            return None
+
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO file_hashes (path, mtime, size, sha256, last_seen)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (rel, mtime, size, digest, int(time.time())),
+        )
+        self._conn.commit()
+        return digest
+
+    def invalidate(self, path: Path) -> None:
+        rel = relative_to_home(path, self._paths.home)
+        self._conn.execute("DELETE FROM file_hashes WHERE path = ?", (rel,))
+        self._conn.commit()
+
+    def get_stored_digest(self, rel_path: str) -> Optional[str]:
+        """Return the cached sha256 for a relative path, or None if not cached."""
+        row = self._conn.execute(
+            "SELECT sha256 FROM file_hashes WHERE path = ?", (rel_path,)
+        ).fetchone()
+        return row[0] if row else None
+
+    def all_hashes(self) -> dict[str, str]:
+        rows = self._conn.execute("SELECT path, sha256 FROM file_hashes").fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+class MerkleTree:
+    """Builds a Merkle root from a file iterator + a HashCache."""
+
+    def __init__(
+        self,
+        cache: HashCache,
+        file_iter: Optional[Iterable[Path]] = None,
+    ) -> None:
+        self._cache = cache
+        # Default file iterator preserves today's behavior. Tests can pass
+        # a custom iterator (or a callable returning one) to walk a fixture
+        # tree instead of `iter_source_files()`.
+        self._file_iter = file_iter
+
+    def build(self) -> tuple[dict[str, str], str]:
+        """Walk all source files, compute hashes via cache.
+
+        Returns (flat_map, root_hash).
+        root_hash = sha256 of canonical JSON of sorted {path: sha256} map.
+        """
+        files = self._file_iter if self._file_iter is not None else iter_source_files()
+        file_map: dict[str, str] = {}
+        for path in files:
+            digest = self._cache.get_or_compute(path)
+            if digest:
+                file_map[relative_to_home(path, self._cache._paths.home)] = digest
+
+        root = self._compute_root(file_map)
+        return file_map, root
+
+    def diff(
+        self,
+        local_map: dict[str, str],
+        remote_map: dict[str, str],
+    ) -> list[str]:
+        """Return relative paths that differ between local and remote.
+
+        Includes new files (in local, not remote) and changed files.
+        """
+        changed = []
+        for path, local_hash in local_map.items():
+            if remote_map.get(path) != local_hash:
+                changed.append(path)
+        return changed
+
+    @staticmethod
+    def _compute_root(file_map: dict[str, str]) -> str:
+        canonical = json.dumps(dict(sorted(file_map.items())), separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
+    @staticmethod
+    def compute_root(file_map: dict[str, str]) -> str:
+        return MerkleTree._compute_root(file_map)

--- a/fleet/track/paths.py
+++ b/fleet/track/paths.py
@@ -1,0 +1,59 @@
+"""Filesystem layout for the track daemon.
+
+All on-disk paths flow through a `TrackPaths` instance. Production code
+calls `TrackPaths.default()`; tests pass `TrackPaths.under(tmp_path)` so
+no test ever touches the real `~/.fleet/track`.
+
+Why a dataclass instead of module globals: every module that reads
+`Path.home()` at import time forces tests to monkeypatch before import,
+which fights pytest's collection order and prevents parallel test runs
+that would otherwise share the same `~/.fleet/track`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TrackPaths:
+    """All on-disk locations the daemon reads or writes."""
+
+    home: Path
+    track_dir: Path
+    state_db: Path
+    status_file: Path
+    pid_file: Path
+    log_file: Path
+    config_file: Path
+    credentials_file: Path
+
+    @classmethod
+    def default(cls) -> "TrackPaths":
+        """Production layout under the real `$HOME`."""
+        return cls.under(Path.home())
+
+    @classmethod
+    def under(cls, home: Path) -> "TrackPaths":
+        """Same layout rooted at an arbitrary directory.
+
+        Used by tests with `pytest.tmp_path`. The directories are *not*
+        created here — callers create them lazily, matching today's
+        behavior where `TRACK_DIR.mkdir(...)` happens at write time.
+        """
+        track_dir = home / ".fleet" / "track"
+        return cls(
+            home=home,
+            track_dir=track_dir,
+            state_db=track_dir / "state.db",
+            status_file=track_dir / "status.json",
+            pid_file=track_dir / "daemon.pid",
+            log_file=track_dir / "daemon.log",
+            config_file=track_dir / "config.json",
+            credentials_file=home / ".fleet" / "credentials.json",
+        )
+
+    def ensure_track_dir(self) -> None:
+        """Create `track_dir` if it doesn't exist. Idempotent."""
+        self.track_dir.mkdir(parents=True, exist_ok=True)

--- a/fleet/track/picker.py
+++ b/fleet/track/picker.py
@@ -21,8 +21,14 @@ object without parsing the human-readable parts.
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, Optional
 
 from .store import Session
@@ -120,15 +126,66 @@ def _format_tool_line(tool: str, source_tool: str) -> str:
     return f"{tool:<10}  {label}"
 
 
+@dataclass(frozen=True)
+class PageState:
+    """Initial state for cursor-paged fzf picking. Persists to a temp
+    file so fzf's reload-bound subcommand can advance / rewind / re-query
+    across keypresses.
+
+    The same struct serializes to the JSON state file consumed by
+    `fleet.track._picker_page` — keep field names aligned.
+    """
+
+    source: str        # `--source` value the parent picker was opened with
+    tool: Optional[str] = None
+    cwd: Optional[str] = None
+    since: Optional[str] = None
+    query: str = ""
+    limit: int = 20
+
+    def to_state(self, *, current_index: int = 0,
+                 cursors: Optional[list] = None) -> dict:
+        return {
+            "source": self.source,
+            "tool": self.tool,
+            "cwd": self.cwd,
+            "since": self.since,
+            "query": self.query,
+            "limit": self.limit,
+            "current_index": current_index,
+            "cursors": cursors or [None],
+        }
+
+
+def _terminal_page_size(*, min_size: int = 8, max_size: int = 50) -> int:
+    """Derive a sensible page size from the current terminal height.
+
+    Reserve room for fzf's chrome (header line, prompt, status, a few
+    rows of breathing space). Falls back to a sane default when stdout
+    isn't a tty (`shutil.get_terminal_size()` returns the env defaults
+    in that case, which is fine).
+    """
+    rows = shutil.get_terminal_size((80, 24)).lines
+    return max(min_size, min(rows - 6, max_size))
+
+
 def pick_session(
     sessions: Iterable[Session],
     *,
     header: Optional[str] = None,
     prompt: str = "session> ",
+    page_state: Optional[PageState] = None,
 ) -> Optional[Session]:
     """Show an fzf picker; return the chosen Session, or None if cancelled.
 
     Raises `FzfNotInstalled` if fzf isn't on PATH.
+
+    `page_state`: opt-in cursor pagination. When provided, right-arrow
+    advances to the next page and left-arrow steps back. fzf's normal
+    right/left = move-cursor-in-query is overridden in that case;
+    pressing them while typing a query reloads to the next/previous
+    page. When omitted, the full `sessions` iterable is buffered eagerly
+    (existing behavior).
     """
     if not fzf_available():
         raise FzfNotInstalled()
@@ -145,12 +202,40 @@ def pick_session(
     if header:
         args.extend(["--header", header])
 
-    result = subprocess.run(
-        args,
-        input="\n".join(lines),
-        capture_output=True,
-        text=True,
-    )
+    state_path: Optional[Path] = None
+    if page_state is not None:
+        # Server-side search pattern: fzf is `--disabled` (no native
+        # filtering); every keystroke triggers `change:reload` which
+        # re-queries the store with the new query string. Right/left
+        # arrows page within the current query. Pages are sized for the
+        # terminal so the user never has to scroll within a page.
+        state_path = _make_state_file(page_state)
+        helper = (
+            f'{_shell_quote(sys.executable)} -m fleet.track._picker_page '
+            f'--state-file {_shell_quote(str(state_path))}'
+        )
+        args.extend([
+            "--disabled",
+            "--bind", f"change:reload({helper} --direction query --query {{q}})",
+            "--bind", f"right:reload({helper} --direction next)",
+            "--bind", f"left:reload({helper} --direction prev)",
+            "--bind", f"alt-h:reload({helper} --direction first)",
+        ])
+
+    try:
+        result = subprocess.run(
+            args,
+            input="\n".join(lines),
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        if state_path is not None:
+            try:
+                state_path.unlink()
+            except OSError:
+                pass
+
     if result.returncode != 0:
         # 1 = no match, 130 = ctrl-c. Either way, user cancelled.
         return None
@@ -162,29 +247,76 @@ def pick_session(
     # First column is the session id (8-char prefix kept in line for
     # disambiguation); we look it up by exact id from the line.
     chosen_id = chosen.split(None, 1)[0]
-    # The id printed is a prefix; resolve back via prefix match in our
-    # local lookup.
+    # The id printed is a prefix; the chosen row may have come from a
+    # later page that isn't in our local lookup. Best-effort: try the
+    # in-memory map first; fall back to letting the caller resolve via
+    # store.get(prefix). To avoid false positives, return None and let
+    # the resume flow handle it.
     for sid, s in by_id.items():
         if sid.startswith(chosen_id):
             return s
-    return None
+    # Synthesize a minimal Session from the picked id so the caller can
+    # resolve via store.get(). The CLI does that anyway and provides a
+    # better error if not found.
+    return Session(id=chosen_id, tool="?")
+
+
+def _make_state_file(page_state: "PageState") -> Path:
+    """Write the initial paging state to a tempfile and return its path.
+    Caller is responsible for unlinking when fzf exits."""
+    fd, name = tempfile.mkstemp(prefix="flt-track-picker-", suffix=".json")
+    os.close(fd)
+    path = Path(name)
+    path.write_text(json.dumps(page_state.to_state()))
+    return path
+
+
+def _shell_quote(s: str) -> str:
+    """Quote a single argument for inclusion in a shell command string.
+    fzf's `--bind ...:reload(<cmd>)` parses <cmd> as a shell command, so
+    paths with spaces need quoting. Single quotes work for everything
+    except literal single quotes themselves."""
+    if not s:
+        return "''"
+    if "'" not in s:
+        return f"'{s}'"
+    # Escape embedded single quotes the POSIX way.
+    return "'" + s.replace("'", "'\\''") + "'"
 
 
 def _format_line(s: Session) -> str:
     """Render one fzf row.
 
-    Format: `<short-id>  <tool:7>  <when:14>  <cwd-basename:30>  <events>e  <preview>`
+    Format: `<short-id>  <tool:7>  <when:14>  <cwd-basename:30>  <events>e  <title>`
 
     Stays under 200 chars so fzf rendering is snappy. The first
     whitespace-delimited token is the short id; the picker uses it to
     map back to the Session object.
+
+    Title comes from `s.metadata.get("title")` — server-populated. We
+    deliberately avoid fetching from S3 or scanning native session files
+    at list time; an empty title is fine until the daemon learns to
+    write it through the metadata index.
     """
     short_id = (s.id or "?")[:8]
     tool = (s.tool or "?")[:7].ljust(7)
     when = _human_when(s.last_active or s.started_at)
     cwd_short = _short_cwd(s.cwd)
     fork_marker = " ↳" if s.forked_from else "  "
-    return f"{short_id}  {tool}  {when:>14}  {cwd_short:<30}{fork_marker} {s.event_count}e"
+    title = _short_title(s.metadata.get("title") if isinstance(s.metadata, dict) else None)
+    line = f"{short_id}  {tool}  {when:>14}  {cwd_short:<30}{fork_marker} {s.event_count:>4}e  {title}"
+    return line.rstrip()  # no trailing whitespace; keeps stream-compare tests honest
+
+
+def _short_title(title: Optional[str], *, max_len: int = 60) -> str:
+    """Single-line, length-capped rendering for the picker. Newlines and
+    runs of whitespace collapse to one space so titles don't break the row."""
+    if not title:
+        return ""
+    flattened = " ".join(title.split())
+    if len(flattened) > max_len:
+        return flattened[: max_len - 1] + "…"
+    return flattened
 
 
 def _short_cwd(cwd: Optional[str]) -> str:

--- a/fleet/track/picker.py
+++ b/fleet/track/picker.py
@@ -1,0 +1,158 @@
+"""fzf-based session picker.
+
+We hard-require fzf (per design decision). If it's not installed, the
+picker raises a helpful error suggesting `brew install fzf`. Building a
+fallback Python TUI was considered and rejected — fzf is mature, fast,
+and ubiquitous; the maintenance cost of a second picker isn't worth the
+edge case.
+
+Usage:
+
+    from fleet.track.picker import pick_session
+    selected = pick_session(sessions, header="Resume which session?")
+    if selected is None:
+        return  # user cancelled
+
+The picker streams a one-line-per-session summary into fzf's stdin and
+reads the user's choice back from stdout. Each line carries a stable
+prefix (the session id) so we can map the choice back to a `Session`
+object without parsing the human-readable parts.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Iterable, Optional
+
+from .store import Session
+
+
+class FzfNotInstalled(RuntimeError):
+    """Raised when fzf is required but not on PATH."""
+
+    DEFAULT_HINT = (
+        "fzf is required for the interactive picker. Install with "
+        "`brew install fzf` (mac) or `apt install fzf` (debian/ubuntu), "
+        "or pass an explicit session id (e.g. `flt track resume <id>`)."
+    )
+
+    def __init__(self, message: Optional[str] = None) -> None:
+        super().__init__(message or self.DEFAULT_HINT)
+
+
+def fzf_available() -> bool:
+    return shutil.which("fzf") is not None
+
+
+def pick_session(
+    sessions: Iterable[Session],
+    *,
+    header: Optional[str] = None,
+    prompt: str = "session> ",
+) -> Optional[Session]:
+    """Show an fzf picker; return the chosen Session, or None if cancelled.
+
+    Raises `FzfNotInstalled` if fzf isn't on PATH.
+    """
+    if not fzf_available():
+        raise FzfNotInstalled()
+
+    # Build picker lines + a parallel index back to the Session objects.
+    sessions_list = list(sessions)
+    if not sessions_list:
+        return None
+
+    lines = [_format_line(s) for s in sessions_list]
+    by_id = {s.id: s for s in sessions_list}
+
+    args = ["fzf", "--prompt", prompt, "--ansi", "--no-multi"]
+    if header:
+        args.extend(["--header", header])
+
+    result = subprocess.run(
+        args,
+        input="\n".join(lines),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # 1 = no match, 130 = ctrl-c. Either way, user cancelled.
+        return None
+
+    chosen = result.stdout.strip()
+    if not chosen:
+        return None
+
+    # First column is the session id (8-char prefix kept in line for
+    # disambiguation); we look it up by exact id from the line.
+    chosen_id = chosen.split(None, 1)[0]
+    # The id printed is a prefix; resolve back via prefix match in our
+    # local lookup.
+    for sid, s in by_id.items():
+        if sid.startswith(chosen_id):
+            return s
+    return None
+
+
+def _format_line(s: Session) -> str:
+    """Render one fzf row.
+
+    Format: `<short-id>  <tool:7>  <when:14>  <cwd-basename:30>  <events>e  <preview>`
+
+    Stays under 200 chars so fzf rendering is snappy. The first
+    whitespace-delimited token is the short id; the picker uses it to
+    map back to the Session object.
+    """
+    short_id = (s.id or "?")[:8]
+    tool = (s.tool or "?")[:7].ljust(7)
+    when = _human_when(s.last_active or s.started_at)
+    cwd_short = _short_cwd(s.cwd)
+    fork_marker = " ↳" if s.forked_from else "  "
+    return f"{short_id}  {tool}  {when:>14}  {cwd_short:<30}{fork_marker} {s.event_count}e"
+
+
+def _short_cwd(cwd: Optional[str]) -> str:
+    """`/Users/me/git/fleet-sdk` → `fleet-sdk`. None or empty → '?'."""
+    if not cwd:
+        return "?"
+    parts = [p for p in cwd.rstrip("/").split("/") if p]
+    if not parts:
+        return "?"
+    last = parts[-1]
+    return last[:30] if len(last) > 30 else last
+
+
+def _human_when(ts: Optional[str]) -> str:
+    """Render an ISO-8601 timestamp as `5m ago` / `2h ago` / etc.
+
+    Returns the raw string if we can't parse it; never raises.
+    """
+    if not ts:
+        return ""
+    from datetime import datetime, timezone
+
+    try:
+        # Tolerate `Z` suffix and `+00:00` form.
+        s = ts.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return ts[:14]
+
+    now = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = now - dt
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        return "future"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    if seconds < 86400:
+        return f"{seconds // 3600}h ago"
+    days = seconds // 86400
+    if days < 30:
+        return f"{days}d ago"
+    return ts[:10]

--- a/fleet/track/picker.py
+++ b/fleet/track/picker.py
@@ -45,6 +45,81 @@ def fzf_available() -> bool:
     return shutil.which("fzf") is not None
 
 
+# Tool-name → binary-name map for `installed_tools()` PATH detection.
+# Order is the canonical sort order in the picker when no source is set.
+_TOOL_BINARIES: list[tuple[str, str]] = [
+    ("claude", "claude"),
+    ("codex", "codex"),
+    ("cursor", "cursor"),
+    ("opencode", "opencode"),
+]
+
+
+def installed_tools() -> list[str]:
+    """Return the names of supported AI CLIs whose binary is on `PATH`.
+
+    Used by the second-stage picker to hide tools the user couldn't actually
+    launch into. Order matches `_TOOL_BINARIES` (claude, codex, cursor,
+    opencode) so the picker is deterministic regardless of $PATH ordering.
+    """
+    return [name for name, binary in _TOOL_BINARIES if shutil.which(binary)]
+
+
+def pick_tool(
+    source_tool: str,
+    *,
+    available: Optional[list[str]] = None,
+    header: Optional[str] = None,
+    runner=None,
+) -> Optional[str]:
+    """Show a second-stage fzf picker for the target tool.
+
+    `source_tool` highlights as the default (`(same as source)`); the rest
+    are labelled `cross-tool: lossy` so the user knows the conversion is
+    best-effort. Returns the chosen tool name, or None on cancel.
+
+    `available` defaults to `installed_tools()`. `runner` is the
+    subprocess-style callable injected by tests (defaults to
+    `subprocess.run`); kept narrow because we only need stdin/stdout/return.
+    """
+    if not fzf_available():
+        raise FzfNotInstalled()
+
+    tools = available if available is not None else installed_tools()
+    if not tools:
+        return None
+
+    # Source-tool first if installed; rest in canonical order.
+    if source_tool in tools:
+        ordered = [source_tool] + [t for t in tools if t != source_tool]
+    else:
+        ordered = list(tools)
+
+    lines = [_format_tool_line(t, source_tool) for t in ordered]
+
+    args = ["fzf", "--prompt", "tool> ", "--ansi", "--no-multi"]
+    if header:
+        args.extend(["--header", header])
+
+    run = runner or subprocess.run
+    result = run(args, input="\n".join(lines), capture_output=True, text=True)
+    if result.returncode != 0:
+        return None
+
+    chosen = result.stdout.strip()
+    if not chosen:
+        return None
+    # First whitespace-delimited token is the tool name.
+    return chosen.split(None, 1)[0]
+
+
+def _format_tool_line(tool: str, source_tool: str) -> str:
+    """One row in the tool picker. First token is the tool name (used to
+    map back to a string after fzf returns)."""
+    label = "(same as source)" if tool == source_tool else "cross-tool: lossy"
+    return f"{tool:<10}  {label}"
+
+
 def pick_session(
     sessions: Iterable[Session],
     *,

--- a/fleet/track/picker_textual.py
+++ b/fleet/track/picker_textual.py
@@ -1,0 +1,567 @@
+"""Textual-based session picker.
+
+Replaces the fzf + reload-helper subprocess dance with a single in-process
+Textual app:
+
+  - `Input` on top: types into the search box and re-queries the store on
+    every keystroke (server-side filter, same as the old `--disabled +
+    change:reload` pattern).
+  - `DataTable` below: shows the current page of rows. Up/down move the
+    row cursor.
+  - `pgdn` / `pgup` page next/back. Cursors are stacked so re-walking is
+    free (matches the old `_picker_page.py` state machine).
+  - `enter` selects the highlighted row, returning the Session.
+  - `escape` cancels, returning None.
+
+The store contract is unchanged — we just call `store.page()` directly
+instead of marshaling args through a tempfile + subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widgets import DataTable, Footer, Input, Static
+from textual.widgets._data_table import CellDoesNotExist
+
+from .store import Session
+
+
+# How long to wait after a keystroke before applying the new query.
+# In the snapshot model the filter is in-memory so this can be 0; we
+# keep a small value as a safety net for very fast typists on huge
+# session sets. Tests override with 0.
+SEARCH_DEBOUNCE_S: float = 0.0
+
+# How many sessions to pull on mount. Big enough to cover any realistic
+# user, small enough to fit in memory without ceremony. Walking the
+# native session files on disk is ~O(N) disk reads per session — so we
+# want to pay that cost ONCE per picker open, not per keystroke.
+SNAPSHOT_LIMIT: int = 2000
+
+
+class SessionPickerApp(App):
+    """The picker. Built on top of a `SessionStore` (any backend works
+    — local stub, native files, chained, future remote)."""
+
+    CSS = """
+    #search {
+        dock: top;
+        height: 3;
+        border: tall $accent;
+    }
+    #status {
+        dock: bottom;
+        height: 1;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    DataTable {
+        height: 1fr;
+    }
+    """
+
+    # Both ←/→ and pgup/pgdn page; the user can use either. ←/→ are
+    # bound at app level with `priority=True` so the search Input doesn't
+    # eat them as cursor-movement keystrokes — typing in the search box
+    # is short and rarely needs intra-text navigation, and stealing those
+    # keys is the price of having them page.
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+        Binding("up", "cursor_up", "Up", show=False, priority=True),
+        Binding("down", "cursor_down", "Down", show=False, priority=True),
+        Binding("right", "next_page", "Next", show=True, priority=True),
+        Binding("left", "prev_page", "Prev", show=True, priority=True),
+        Binding("pagedown", "next_page", "Next", show=False, priority=True),
+        Binding("pageup", "prev_page", "Prev", show=False, priority=True),
+        Binding("enter", "submit", "Open", show=True, priority=True),
+    ]
+
+    def __init__(
+        self,
+        store,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = 20,
+        header: str = "",
+        debounce_s: float = SEARCH_DEBOUNCE_S,
+        snapshot_limit: int = SNAPSHOT_LIMIT,
+    ) -> None:
+        super().__init__()
+        self.store = store
+        self.tool = tool
+        self.cwd = cwd
+        self.since = since
+        self.limit = limit
+        self.header_text = header
+        self.debounce_s = debounce_s
+        self.snapshot_limit = snapshot_limit
+
+        # In-memory snapshot of (up to) `snapshot_limit` sessions, fetched
+        # once on mount. None = not yet loaded. Filtering on every
+        # keystroke walks this list in-process; we never re-hit the store
+        # on a search. The store's `page()` walks ~O(N_files * disk-reads)
+        # for native sessions — too slow per keystroke.
+        #
+        # Live mode (`_mode == "live"`) is used when the store has more
+        # rows than the snapshot can hold — typically a remote backend.
+        # In live mode we don't keep `_snapshot`; every keystroke + page
+        # action calls `store.page(query=..., cursor=...)` directly.
+        self._mode: str = "loading"  # "snapshot" | "live" | "loading"
+        self._snapshot: Optional[list[Session]] = None
+
+        # Cursor stack for live mode (analogous to `_picker_page.py`'s
+        # state file). cursors[i] is the cursor used to fetch page i.
+        self._live_cursors: list[Optional[str]] = [None]
+
+        # Page index. In snapshot mode, indexes into the filtered list.
+        # In live mode, indexes into `_live_cursors`.
+        self.current_index = 0
+
+        # Live query string. Empty = no filter.
+        # NB: named `query_text` (not `query`) to avoid shadowing
+        # `App.query()` — the DOM-query method we use to look up widgets.
+        self.query_text = ""
+
+        # Map from session id → Session for the currently rendered page,
+        # so submit() can look up the highlighted row in O(1).
+        self.sessions_by_id: dict[str, Session] = {}
+
+    # -- compose / mount --------------------------------------------- #
+
+    def compose(self) -> ComposeResult:
+        yield Input(placeholder="search…", id="search")
+        yield DataTable(id="rows", cursor_type="row", zebra_stripes=True)
+        yield Static("", id="status")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.add_columns("id", "tool", "when", "project", "#events", "title")
+        self.query_one(Input).focus()
+        self.query_one("#status", Static).update("loading sessions…")
+        self._populate_snapshot()
+
+    # -- input / events ---------------------------------------------- #
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "search":
+            return
+        # Update local state synchronously so the Input renders the
+        # character immediately.
+        self.query_text = event.value
+        self.current_index = 0
+        if self._mode == "live":
+            # Reset cursor stack on every query change — cursors are
+            # scoped to a particular filter set, so prev cursors are
+            # invalid against the new query.
+            self._live_cursors = [None]
+            self._live_search()
+        else:
+            # Snapshot mode: filter in-memory. Microseconds for
+            # thousands of rows; no worker needed.
+            if self.debounce_s > 0:
+                self._render_filtered_debounced()
+            else:
+                self._render_filtered()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Pressing Enter inside the Input fires `Input.Submitted` instead
+        # of routing to the app-level `enter` binding. Forward to submit.
+        if event.input.id == "search":
+            self.action_submit()
+
+    # -- actions ------------------------------------------------------ #
+
+    def action_cursor_up(self) -> None:
+        self.query_one(DataTable).action_cursor_up()
+
+    def action_cursor_down(self) -> None:
+        self.query_one(DataTable).action_cursor_down()
+
+    def action_next_page(self) -> None:
+        if self._mode == "live":
+            self._live_advance()
+            return
+        if self._snapshot is None:
+            return
+        if (self.current_index + 1) * self.limit >= len(self._filtered()):
+            return  # already at last page
+        self.current_index += 1
+        self._render_filtered()
+
+    def action_prev_page(self) -> None:
+        if self.current_index == 0:
+            return
+        self.current_index -= 1
+        if self._mode == "live":
+            self._live_search()  # re-fetch page at new index
+        else:
+            self._render_filtered()
+
+    def action_cancel(self) -> None:
+        self.exit(None)
+
+    def action_submit(self) -> None:
+        table = self.query_one(DataTable)
+        if table.row_count == 0:
+            return
+        try:
+            cell_key = table.coordinate_to_cell_key(table.cursor_coordinate)
+        except CellDoesNotExist:
+            return
+        sid = cell_key.row_key.value
+        if sid is None:
+            return
+        chosen = self.sessions_by_id.get(sid)
+        if chosen is not None:
+            self.exit(chosen)
+
+    # -- workers / snapshot ------------------------------------------ #
+
+    @work(exclusive=True, group="snapshot")
+    async def _populate_snapshot(self) -> None:
+        """One-shot fetch of up to `snapshot_limit` sessions, off-thread.
+
+        Auto-detects which mode to operate in:
+          - `next_cursor is None` → snapshot mode. All rows fit in
+            memory; every keystroke filters in-process.
+          - `next_cursor is not None` → live mode. The store has more
+            rows than fit; every keystroke (and page action) hits the
+            store with `query=...` so server-side filtering can scale.
+
+        For local backends with <2000 sessions this is always snapshot
+        mode. RemoteSessionStore against a real user with 10k+ sessions
+        will fall into live mode automatically.
+        """
+        loop = asyncio.get_running_loop()
+        items, next_cursor = await loop.run_in_executor(
+            None,
+            lambda: self.store.page(
+                tool=self.tool,
+                cwd=self.cwd,
+                since=self.since,
+                limit=self.snapshot_limit,
+            ),
+        )
+        if next_cursor is None:
+            self._mode = "snapshot"
+            self._snapshot = items
+            self._render_filtered()
+        else:
+            # More rows than the snapshot holds — defer to the store on
+            # every interaction. The snapshot fetch used `snapshot_limit`
+            # only to detect overflow, so fetch the real first page using
+            # the UI page size before rendering.
+            self._mode = "live"
+            items, next_cursor = await loop.run_in_executor(
+                None,
+                lambda: self.store.page(
+                    tool=self.tool,
+                    cwd=self.cwd,
+                    since=self.since,
+                    query=self.query_text or None,
+                    limit=self.limit,
+                    cursor=None,
+                ),
+            )
+            self._live_cursors = [None]
+            if next_cursor is not None:
+                self._live_cursors.append(next_cursor)
+            self._render_live(items, next_cursor)
+
+    @work(exclusive=True, group="search")
+    async def _render_filtered_debounced(self) -> None:
+        """Debounced wrapper around `_render_filtered`. Only used when
+        `debounce_s > 0` (default 0 — filtering is fast enough that we
+        can render on every keystroke)."""
+        await asyncio.sleep(self.debounce_s)
+        self._render_filtered()
+
+    @work(exclusive=True, group="live")
+    async def _live_search(self) -> None:
+        """Live-mode equivalent of `_render_filtered`: fetch the current
+        page from the store with the current query, render it. Debounced
+        so fast typists don't queue up redundant fetches."""
+        if self.debounce_s > 0:
+            await asyncio.sleep(self.debounce_s)
+        loop = asyncio.get_running_loop()
+        cursor = (
+            self._live_cursors[self.current_index]
+            if (0 <= self.current_index < len(self._live_cursors))
+            else None
+        )
+        items, next_cursor = await loop.run_in_executor(
+            None,
+            lambda: self.store.page(
+                tool=self.tool,
+                cwd=self.cwd,
+                since=self.since,
+                query=self.query_text or None,
+                limit=self.limit,
+                cursor=cursor,
+            ),
+        )
+        # Cache the next cursor so a subsequent next-page is O(1).
+        if next_cursor is not None and self.current_index + 1 == len(
+            self._live_cursors
+        ):
+            self._live_cursors.append(next_cursor)
+        self._render_live(items, next_cursor)
+
+    @work(exclusive=True, group="live")
+    async def _live_advance(self) -> None:
+        """Move to the next page in live mode. If we don't yet know the
+        next cursor (last cached page), fetch the current page just to
+        learn it; then move forward and fetch the next."""
+        if self.current_index + 1 < len(self._live_cursors):
+            self.current_index += 1
+            self._live_search()
+            return
+        loop = asyncio.get_running_loop()
+        cursor = self._live_cursors[self.current_index]
+        _, next_cursor = await loop.run_in_executor(
+            None,
+            lambda: self.store.page(
+                tool=self.tool,
+                cwd=self.cwd,
+                since=self.since,
+                query=self.query_text or None,
+                limit=self.limit,
+                cursor=cursor,
+            ),
+        )
+        if next_cursor is None:
+            return  # already at last page
+        self._live_cursors.append(next_cursor)
+        self.current_index += 1
+        self._live_search()
+
+    # -- filter / render --------------------------------------------- #
+
+    def _filtered(self) -> list[Session]:
+        """Apply the current query against the snapshot. Empty snapshot
+        before mount-fetch completes; empty list when no rows match."""
+        if self._snapshot is None:
+            return []
+        if not self.query_text:
+            return self._snapshot
+        # `_matches_query` is the same predicate the server uses, kept
+        # in store.py so wire and in-memory filters stay aligned.
+        from .store import _matches_query
+
+        q = self.query_text
+        return [s for s in self._snapshot if _matches_query(s, q)]
+
+    def _render_filtered(self) -> None:
+        """Snapshot mode: slice the in-memory filtered list."""
+        filtered = self._filtered()
+        start = self.current_index * self.limit
+        end = start + self.limit
+        items = filtered[start:end]
+        has_more = end < len(filtered)
+        # Status: "page X · K of M rows" when loaded; "loading…" otherwise.
+        if self._snapshot is None:
+            status = "loading sessions…"
+        else:
+            page_num = self.current_index + 1
+            more = "+" if has_more else ""
+            prefix = f"{self.header_text} · " if self.header_text else ""
+            status = (
+                f"{prefix}page {page_num}{more} · "
+                f"{len(items)} of {len(filtered)} rows"
+            )
+        self._render_table(items, status)
+
+    def _render_live(self, items: list[Session], next_cursor: Optional[str]) -> None:
+        """Live mode: render whatever the store just returned."""
+        page_num = self.current_index + 1
+        more = "+" if next_cursor else ""
+        prefix = f"{self.header_text} · live · " if self.header_text else "live · "
+        status = f"{prefix}page {page_num}{more} · {len(items)} rows"
+        self._render_table(items, status)
+
+    def _render_table(self, items: list[Session], status: str) -> None:
+        """Common DataTable update. Both render paths share this."""
+        table = self.query_one(DataTable)
+        table.clear()
+        self.sessions_by_id = {s.id: s for s in items}
+        for s in items:
+            table.add_row(*_row_for(s), key=s.id)
+        if table.row_count > 0:
+            table.move_cursor(row=0)
+        self.query_one("#status", Static).update(status)
+
+
+# ------------------------------------------------------------------ #
+# Row formatting (cell-by-cell so DataTable can align columns nicely)  #
+# ------------------------------------------------------------------ #
+
+
+def _row_for(s: Session) -> tuple[str, str, str, str, str, str]:
+    """Return the six cells we render per row.
+
+    Mirrors the data shown by `picker._format_line` but split into cells
+    so DataTable can size columns. Title comes from server-populated
+    metadata; we never reach into S3 / native files at list time.
+
+    The "project" column shows `repo · subpath` (cross-machine portable)
+    when `metadata.repo_url` is set; falls back to a short cwd otherwise.
+    """
+    from .picker import _human_when, _short_title
+
+    short_id = (s.id or "?")[:8]
+    tool = (s.tool or "?")[:7]
+    when = _human_when(s.last_active or s.started_at)
+    project = _project_label(s)
+    events = str(s.event_count)
+    title = _short_title(
+        s.metadata.get("title") if isinstance(s.metadata, dict) else None
+    )
+    return short_id, tool, when, project, events, title
+
+
+def _project_label(s: Session) -> str:
+    """Format the project column. Prefers repo identity; falls back to cwd.
+
+    Examples:
+      `fleet-sdk · fleet/track`   — repo with subpath
+      `fleet-sdk`                 — repo at root
+      `fleet-sdk`                 — fallback when no repo metadata (cwd basename)
+      `?`                         — unknown
+    """
+    from .picker import _short_cwd
+
+    md = s.metadata if isinstance(s.metadata, dict) else {}
+    repo_url = md.get("repo_url") if isinstance(md, dict) else None
+    if isinstance(repo_url, str) and repo_url:
+        repo_name = repo_url.rsplit("/", 1)[-1]  # "github.com/org/repo" → "repo"
+        subpath = md.get("repo_subpath") if isinstance(md, dict) else None
+        if isinstance(subpath, str) and subpath:
+            return f"{repo_name} · {subpath}"
+        return repo_name
+    return _short_cwd(s.cwd)
+
+
+# ------------------------------------------------------------------ #
+# Public entrypoint                                                    #
+# ------------------------------------------------------------------ #
+
+
+def pick_session_textual(
+    store,
+    *,
+    tool: Optional[str] = None,
+    cwd: Optional[str] = None,
+    since: Optional[str] = None,
+    limit: Optional[int] = None,
+    header: Optional[str] = None,
+) -> Optional[Session]:
+    """Open the picker. Returns the chosen `Session`, or None on cancel.
+
+    `limit` defaults to a terminal-readable page size so the user never
+    has to scroll within a page. Other filters (`tool`, `cwd`, `since`)
+    pass straight to `store.page()`.
+    """
+    from .picker import _terminal_page_size
+
+    if limit is None:
+        limit = _terminal_page_size()
+    app = SessionPickerApp(
+        store=store,
+        tool=tool,
+        cwd=cwd,
+        since=since,
+        limit=limit,
+        header=header or "",
+    )
+    return app.run()
+
+
+# ------------------------------------------------------------------ #
+# Tool picker (stage 2 of resume)                                      #
+# ------------------------------------------------------------------ #
+
+
+class ToolPickerApp(App):
+    """Tiny picker for the second stage of `flt track resume` — choose
+    which CLI to launch the resumed session in."""
+
+    CSS = """
+    #header { dock: top; height: auto; padding: 1; color: $text-muted; }
+    OptionList { height: 1fr; }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+    ]
+
+    def __init__(
+        self,
+        tools: list[str],
+        *,
+        source_tool: str,
+        header: str = "",
+    ) -> None:
+        super().__init__()
+        self.tools = tools
+        self.source_tool = source_tool
+        self.header_text = header
+
+    def compose(self) -> ComposeResult:
+        from textual.widgets import OptionList
+        from textual.widgets.option_list import Option
+
+        if self.header_text:
+            yield Static(self.header_text, id="header")
+        opts = []
+        for t in self.tools:
+            label = "(same as source)" if t == self.source_tool else "cross-tool: lossy"
+            opts.append(Option(f"{t:<10}  {label}", id=t))
+        yield OptionList(*opts, id="tools")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        from textual.widgets import OptionList
+
+        ol = self.query_one(OptionList)
+        ol.focus()
+        # Pre-highlight source tool (it's index 0 by construction).
+        if self.source_tool in self.tools:
+            ol.highlighted = self.tools.index(self.source_tool)
+
+    def on_option_list_option_selected(self, event) -> None:
+        self.exit(event.option.id)
+
+    def action_cancel(self) -> None:
+        self.exit(None)
+
+
+def pick_tool_textual(
+    source_tool: str,
+    *,
+    available: Optional[list[str]] = None,
+    header: Optional[str] = None,
+) -> Optional[str]:
+    """Open the tool picker. Returns the chosen tool name, or None on cancel.
+
+    Keeps source_tool first when present so Enter resumes in the same CLI.
+    """
+    from .picker import installed_tools
+
+    tools = available if available is not None else installed_tools()
+    if not tools:
+        return None
+    # Source-tool first if installed; rest in the canonical order.
+    if source_tool in tools:
+        ordered = [source_tool] + [t for t in tools if t != source_tool]
+    else:
+        ordered = list(tools)
+    app = ToolPickerApp(tools=ordered, source_tool=source_tool, header=header or "")
+    return app.run()

--- a/fleet/track/queue.py
+++ b/fleet/track/queue.py
@@ -1,0 +1,237 @@
+"""WAL-backed SQLite upload queue.
+
+Survives daemon crashes. Items transition: pending → in_flight → done/failed.
+Failed items are retried with exponential backoff.
+
+All paths flow through `TrackPaths` so tests can target a tmp dir.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .paths import TrackPaths
+
+log = logging.getLogger("fleet.track.queue")
+
+MAX_ATTEMPTS = 10
+BASE_BACKOFF_SECS = 0.5
+MAX_BACKOFF_SECS = 1800  # 30 min
+
+
+def _backoff(attempts: int) -> float:
+    return min(BASE_BACKOFF_SECS * (2 ** attempts), MAX_BACKOFF_SECS)
+
+
+@dataclass
+class QueueItem:
+    path: str        # relative to $HOME
+    sha256: str
+    attempts: int
+    last_error: Optional[str]
+
+
+class UploadQueue:
+    def __init__(self, paths: Optional[TrackPaths] = None) -> None:
+        self._paths = paths or TrackPaths.default()
+        self._paths.ensure_track_dir()
+        self._lock = threading.Lock()
+        self._conn = self._open_conn()
+
+    def _open_conn(self, _retry: bool = False) -> sqlite3.Connection:
+        try:
+            conn = sqlite3.connect(self._paths.state_db, timeout=10, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS queue (
+                    path TEXT NOT NULL,
+                    sha256 TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    attempts INTEGER DEFAULT 0,
+                    last_error TEXT,
+                    next_attempt_at INTEGER NOT NULL DEFAULT 0,
+                    enqueued_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    UNIQUE(path, sha256)
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS queue_status ON queue(status, next_attempt_at)")
+            conn.commit()
+
+            result = conn.execute("PRAGMA integrity_check").fetchone()
+            if result[0] != "ok":
+                raise sqlite3.DatabaseError(f"integrity_check returned: {result[0]}")
+            return conn
+        except sqlite3.DatabaseError:
+            # Either the file isn't a sqlite db, the schema is damaged, or
+            # integrity_check failed. One retry after wiping; re-raise on the
+            # second attempt so we don't loop forever on a parent-dir issue.
+            if _retry:
+                raise
+            try:
+                conn.close()  # type: ignore[possibly-undefined]
+            except Exception:
+                pass
+            self._wipe_and_reinit()
+            return self._open_conn(_retry=True)
+
+    def _wipe_and_reinit(self) -> None:
+        """Delete corrupt database files and start fresh. Queue items are lost but
+        the next reconcile will re-enqueue anything not yet on S3."""
+        log.warning("queue database is corrupt — wiping and reinitialising (next reconcile will re-upload missing files)")
+        for suffix in ("", "-shm", "-wal"):
+            p = Path(str(self._paths.state_db) + suffix)
+            if p.exists():
+                p.unlink(missing_ok=True)
+
+    def enqueue(self, path: str, sha256: str) -> None:
+        """Add path to the queue. Idempotent: same (path, sha256) is a no-op."""
+        now = int(time.time())
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO queue (path, sha256, status, next_attempt_at, enqueued_at, updated_at)
+                VALUES (?, ?, 'pending', 0, ?, ?)
+                """,
+                (path, sha256, now, now),
+            )
+            self._conn.commit()
+
+    def enqueue_batch(self, items: list[tuple[str, str]]) -> None:
+        now = int(time.time())
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT OR IGNORE INTO queue (path, sha256, status, next_attempt_at, enqueued_at, updated_at)
+                VALUES (?, ?, 'pending', 0, ?, ?)
+                """,
+                [(path, sha256, now, now) for path, sha256 in items],
+            )
+            self._conn.commit()
+
+    def claim_batch(self, n: int = 16) -> list[QueueItem]:
+        """Atomically claim up to n pending items for upload."""
+        now = int(time.time())
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT path, sha256, attempts, last_error FROM queue
+                WHERE status = 'pending' AND next_attempt_at <= ?
+                ORDER BY enqueued_at ASC
+                LIMIT ?
+                """,
+                (now, n),
+            ).fetchall()
+
+            if not rows:
+                return []
+
+            # Match on (path, sha256) — the natural key — so we never transition a
+            # row that wasn't in the SELECT result. Two rows can share a path with
+            # different sha256 values; path-only matching would orphan the extra row
+            # (set to in_flight with no upload attempted and no callback to resolve it).
+            placeholders = ",".join("(?,?)" for _ in rows)
+            pairs = [v for r in rows for v in (r[0], r[1])]
+            self._conn.execute(
+                f"UPDATE queue SET status = 'in_flight', updated_at = ? WHERE status = 'pending' AND (path, sha256) IN ({placeholders})",
+                [now] + pairs,
+            )
+            self._conn.commit()
+
+        return [QueueItem(r[0], r[1], r[2], r[3]) for r in rows]
+
+    def mark_done(self, path: str, sha256: str) -> None:
+        now = int(time.time())
+        with self._lock:
+            self._conn.execute(
+                "UPDATE queue SET status = 'done', updated_at = ? WHERE path = ? AND sha256 = ?",
+                (now, path, sha256),
+            )
+            # Prune rows for the same path that were enqueued *strictly before*
+            # this one — they are older versions superseded by this upload.
+            # Strict `<` matters: enqueued_at is second-resolution, so two
+            # versions enqueued the same second would otherwise prune each
+            # other. When timestamps tie we err toward keeping data; the next
+            # upload pass will resolve the duplicate.
+            self._conn.execute(
+                """
+                DELETE FROM queue
+                WHERE path = ? AND sha256 != ? AND status IN ('failed', 'pending')
+                  AND enqueued_at < (
+                      SELECT enqueued_at FROM queue WHERE path = ? AND sha256 = ?
+                  )
+                """,
+                (path, sha256, path, sha256),
+            )
+            self._conn.commit()
+
+    def mark_failed(self, path: str, sha256: str, error: str) -> None:
+        now = int(time.time())
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT attempts FROM queue WHERE path = ? AND sha256 = ?", (path, sha256)
+            ).fetchone()
+            attempts = (row[0] if row else 0) + 1
+            status = "failed" if attempts >= MAX_ATTEMPTS else "pending"
+            next_attempt = now + int(_backoff(attempts))
+            self._conn.execute(
+                """
+                UPDATE queue
+                SET status = ?, attempts = ?, last_error = ?, next_attempt_at = ?, updated_at = ?
+                WHERE path = ? AND sha256 = ?
+                """,
+                (status, attempts, error[:500], next_attempt, now, path, sha256),
+            )
+            self._conn.commit()
+
+    def reset_failed(self) -> int:
+        """Re-queue permanently failed items (used by reconciliation loop)."""
+        now = int(time.time())
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE queue SET status = 'pending', attempts = 0, next_attempt_at = 0, updated_at = ? WHERE status = 'failed'",
+                (now,),
+            )
+            self._conn.commit()
+        return cur.rowcount
+
+    def remove_done(self) -> None:
+        """Purge successfully uploaded items older than 24h."""
+        cutoff = int(time.time()) - 86400
+        with self._lock:
+            self._conn.execute("DELETE FROM queue WHERE status = 'done' AND updated_at < ?", (cutoff,))
+            self._conn.commit()
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT status, COUNT(*) FROM queue GROUP BY status"
+            ).fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def oldest_pending_age(self) -> Optional[int]:
+        """Return seconds since the oldest pending/in-flight item was enqueued, or None if empty.
+
+        Used by `flt track doctor` to detect a wedged uploader.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT MIN(enqueued_at) FROM queue
+                WHERE status IN ('pending', 'in_flight')
+                """
+            ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return int(time.time()) - int(row[0])
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()

--- a/fleet/track/reconciler.py
+++ b/fleet/track/reconciler.py
@@ -1,0 +1,85 @@
+"""Full Merkle reconciliation pass.
+
+Orchestrates: fetch remote manifest → build local merkle → diff → enqueue.
+Pulled out of `Daemon` so a test can drive a single pass against a
+`MockTransport` and a fixture filesystem and assert exactly which files
+got enqueued, without spinning up the daemon thread.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from .api import TrackAPIClient
+from .merkle import HashCache, MerkleTree
+from .queue import UploadQueue
+
+log = logging.getLogger("fleet.track.reconciler")
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    in_sync: bool
+    changed_paths: tuple[str, ...]
+    local_map: dict[str, str]
+    remote_map: dict[str, str]
+    local_root: str
+    remote_root: str
+
+
+class Reconciler:
+    """One full sync pass."""
+
+    def __init__(
+        self,
+        *,
+        queue: UploadQueue,
+        cache: HashCache,
+        tree: MerkleTree,
+        api: TrackAPIClient,
+    ) -> None:
+        self._queue = queue
+        self._cache = cache
+        self._tree = tree
+        self._api = api
+
+    def reconcile(self, device_id: str) -> ReconcileResult:
+        """Fetch remote manifest, build local merkle, enqueue diff.
+
+        Idempotent: calling twice in a row when nothing has changed is a no-op
+        (returns `in_sync=True` and enqueues nothing).
+        """
+        remote_map = self._api.get_manifest(device_id)
+        local_map, local_root = self._tree.build()
+        remote_root = MerkleTree.compute_root(remote_map)
+
+        if local_root == remote_root:
+            log.info("reconcile in sync (root=%s)", local_root[:12])
+            return ReconcileResult(
+                in_sync=True,
+                changed_paths=(),
+                local_map=local_map,
+                remote_map=remote_map,
+                local_root=local_root,
+                remote_root=remote_root,
+            )
+
+        changed = self._tree.diff(local_map, remote_map)
+        log.info("reconcile: %d files to upload", len(changed))
+        items = [(p, local_map[p]) for p in changed]
+        self._queue.enqueue_batch(items)
+
+        return ReconcileResult(
+            in_sync=False,
+            changed_paths=tuple(changed),
+            local_map=local_map,
+            remote_map=remote_map,
+            local_root=local_root,
+            remote_root=remote_root,
+        )
+
+    def confirmed_seed(self, remote_map: dict[str, str]) -> dict[str, str]:
+        """Initial seed for the Daemon's `confirmed_map`: every file the
+        remote manifest already has is treated as confirmed-on-S3."""
+        return dict(remote_map)

--- a/fleet/track/repos.py
+++ b/fleet/track/repos.py
@@ -1,0 +1,583 @@
+"""Repo identity + local checkout discovery.
+
+Cross-machine resume needs to map a `repo_url` (canonical key) to a
+local checkout path. The local cwd a session was created in
+(`/Users/trent/git/fleet-sdk`) doesn't survive crossing machines —
+the same repo lives at different absolute paths on different
+hosts. So we key on `repo_url` instead and resolve to a local path
+at resume time.
+
+Three pieces:
+
+  1. **Capture** — `capture_repo(cwd)` shells to git to learn the
+     remote URL and repo root for a given directory. Used by
+     ingest paths (NativeFilesSessionStore, daemon) to stamp
+     `metadata.repo_url` / `repo_subpath` / `origin_cwd` on
+     sessions.
+
+  2. **Registry** — `RepoRegistry` (file-backed at
+     `~/.fleet/track/repos.json`) caches `repo_url → [local
+     checkout paths]`. Self-warms via every `capture_repo()`
+     call; self-survives across daemon restarts.
+
+  3. **Scan** — `scan_for_repo(url)` walks default and
+     auto-discovered roots looking for a local checkout when
+     the registry doesn't have one cached. Last resort; cached
+     on hit.
+
+URL normalization is the load-bearing detail: `git@github.com:org/repo.git`,
+`https://github.com/org/repo`, and `ssh://git@github.com/org/repo` are
+all the same repo and must collapse to the same key. See
+`normalize_repo_url`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .paths import TrackPaths
+
+log = logging.getLogger("fleet.track.repos")
+
+
+# ------------------------------------------------------------------ #
+# Repo capture                                                         #
+# ------------------------------------------------------------------ #
+
+
+@dataclass(frozen=True)
+class RepoInfo:
+    """What we learn about the git repo a cwd lives in.
+
+    `url` — normalized canonical key (see `normalize_repo_url`). None
+        when the cwd isn't in any git repo, or when the repo has no
+        `origin` remote (rare for modern workflows).
+    `root` — absolute path to the repo's top-level directory.
+    `subpath` — cwd relative to `root`, posix-style. Empty string when
+        cwd == root.
+    `origin_cwd` — the absolute cwd that was passed in. Kept verbatim
+        for fallback resolution and forensics.
+    """
+
+    url: Optional[str]
+    root: Optional[str]
+    subpath: str
+    origin_cwd: str
+
+
+# Module-level cache so repeated `capture_repo()` calls (one per session
+# during a snapshot fetch) only shell out once per cwd.
+_capture_cache: dict[str, RepoInfo] = {}
+_capture_lock = threading.Lock()
+
+
+def capture_repo(cwd: str, *, registry: Optional["RepoRegistry"] = None) -> RepoInfo:
+    """Run `git` once on `cwd` to learn its repo identity.
+
+    Cached per process (thread-safe). When `registry` is supplied, also
+    upserts the discovered `(url, root)` pair so future resume lookups
+    find this checkout without scanning.
+
+    Never raises — git missing or not-a-git-repo just returns a
+    `RepoInfo(url=None, root=None, subpath="", origin_cwd=cwd)`.
+    """
+    cwd = os.fspath(cwd)
+    with _capture_lock:
+        cached = _capture_cache.get(cwd)
+    if cached is not None:
+        if registry is not None and cached.url and cached.root:
+            registry.upsert(cached.url, cached.root)
+        return cached
+
+    info = _capture_uncached(cwd)
+    with _capture_lock:
+        _capture_cache[cwd] = info
+    if registry is not None and info.url and info.root:
+        registry.upsert(info.url, info.root)
+    return info
+
+
+def _capture_uncached(cwd: str) -> RepoInfo:
+    if not os.path.isdir(cwd):
+        return RepoInfo(url=None, root=None, subpath="", origin_cwd=cwd)
+
+    root = _git(["rev-parse", "--show-toplevel"], cwd=cwd)
+    if not root:
+        return RepoInfo(url=None, root=None, subpath="", origin_cwd=cwd)
+
+    raw_url = _git(["remote", "get-url", "origin"], cwd=cwd)
+    url = normalize_repo_url(raw_url) if raw_url else None
+
+    try:
+        subpath = os.path.relpath(cwd, root)
+    except ValueError:
+        subpath = ""
+    if subpath in (".", ""):
+        subpath_norm = ""
+    else:
+        subpath_norm = subpath.replace(os.sep, "/")
+
+    return RepoInfo(url=url, root=root, subpath=subpath_norm, origin_cwd=cwd)
+
+
+def _git(args: list[str], *, cwd: str) -> Optional[str]:
+    """Run a git command, return stripped stdout or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
+# ------------------------------------------------------------------ #
+# URL normalization                                                    #
+# ------------------------------------------------------------------ #
+
+
+# `git@host:org/repo(.git)?` — the SCP-style ssh shorthand git uses.
+_GIT_SCP_RE = re.compile(r"^(?P<user>[^@]+)@(?P<host>[^:]+):(?P<path>.+)$")
+
+
+def normalize_repo_url(url: str) -> str:
+    """Canonicalize a git remote URL.
+
+    Goal: any of the three forms below should map to the same key.
+
+      git@github.com:fleet-ai/fleet-sdk.git
+      ssh://git@github.com/fleet-ai/fleet-sdk.git
+      https://github.com/fleet-ai/fleet-sdk
+
+    Output format: `<host>/<path-without-trailing-.git>`, all
+    lowercase, host stripped of any `git@` prefix, scheme dropped.
+    The leading `git@` user is dropped because it's host-conventional
+    (always `git` on github/gitlab/bitbucket); preserving it just
+    multiplies keys without adding identity.
+
+    Returns the input verbatim (lowercased and `.git`-stripped) when
+    we can't recognize a structure — better to under-canonicalize
+    than to mangle a valid URL into the wrong key.
+    """
+    if not url:
+        return ""
+    s = url.strip()
+
+    # Form 1: SCP-style (`git@host:path`).
+    m = _GIT_SCP_RE.match(s)
+    if m:
+        host = m.group("host").lower()
+        path = m.group("path")
+        return f"{host}/{_strip_git_suffix(path).lower().lstrip('/')}"
+
+    # Form 2 / 3: URI with scheme.
+    if "://" in s:
+        scheme, rest = s.split("://", 1)
+        # Drop user-info if any (`git@host` → `host`).
+        if "@" in rest.split("/", 1)[0]:
+            _user, rest = rest.split("@", 1)
+        # `host[:port]/path...` — split host + path.
+        if "/" in rest:
+            host, path = rest.split("/", 1)
+        else:
+            host, path = rest, ""
+        return f"{host.lower()}/{_strip_git_suffix(path).lower().lstrip('/')}"
+
+    # Plain `host/org/repo` form (rare). Lowercase + strip .git.
+    return _strip_git_suffix(s).lower()
+
+
+def _strip_git_suffix(s: str) -> str:
+    return s[:-4] if s.endswith(".git") else s
+
+
+# ------------------------------------------------------------------ #
+# Registry — file-backed cache of url → list of local checkouts        #
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class RegistryEntry:
+    path: str
+    last_seen: str  # ISO-8601
+
+
+class RepoRegistry:
+    """Persistent cache of `repo_url → [local checkout paths]`.
+
+    Stored at `~/.fleet/track/repos.json` (or under a `TrackPaths`
+    instance for tests). Self-warms via `capture_repo()` calls.
+
+    Multiple checkouts per repo are explicitly supported (worktrees,
+    side-by-side clones). `lookup()` returns them ordered by
+    last_seen DESC; the resumer prefers the most recently used one
+    matching origin_cwd, falling back to the most recent.
+
+    File format (json):
+
+        {
+          "version": 1,
+          "repos": {
+            "github.com/fleet-ai/fleet-sdk": [
+              {"path": "/Users/trent/git/fleet-sdk",
+               "last_seen": "2026-05-04T17:00:00+00:00"},
+              ...
+            ],
+            ...
+          }
+        }
+    """
+
+    SCHEMA_VERSION: int = 1
+
+    def __init__(self, *, paths: Optional[TrackPaths] = None) -> None:
+        self._paths = paths or TrackPaths.default()
+        self._lock = threading.Lock()
+        self._loaded = False
+        self._data: dict[str, list[RegistryEntry]] = {}
+
+    # -- public api -------------------------------------------------- #
+
+    def lookup(self, url: str) -> list[Path]:
+        """Return cached checkout paths for `url`, freshest first.
+        Filters out entries whose path no longer exists on disk."""
+        if not url:
+            return []
+        with self._lock:
+            self._load_locked()
+            entries = list(self._data.get(url, []))
+        entries.sort(key=lambda e: e.last_seen, reverse=True)
+        out: list[Path] = []
+        for e in entries:
+            p = Path(e.path)
+            if p.is_dir():
+                out.append(p)
+        return out
+
+    def upsert(self, url: str, path: str | Path) -> None:
+        """Record (url, path) as a known checkout. Idempotent.
+        Updates `last_seen` on each call so freshness ordering reflects
+        actual usage."""
+        if not url or not path:
+            return
+        path_str = os.fspath(path)
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            self._load_locked()
+            entries = self._data.setdefault(url, [])
+            for e in entries:
+                if e.path == path_str:
+                    e.last_seen = now
+                    self._save_locked()
+                    return
+            entries.append(RegistryEntry(path=path_str, last_seen=now))
+            self._save_locked()
+
+    def all_urls(self) -> list[str]:
+        with self._lock:
+            self._load_locked()
+            return list(self._data.keys())
+
+    def known_paths(self) -> list[Path]:
+        """Every path the registry has ever seen, regardless of url.
+        Used by `default_scan_roots` to seed the search with directories
+        the user is already known to keep code in."""
+        with self._lock:
+            self._load_locked()
+            paths: list[Path] = []
+            for entries in self._data.values():
+                for e in entries:
+                    p = Path(e.path)
+                    if p.is_dir():
+                        paths.append(p)
+        return paths
+
+    # -- io ---------------------------------------------------------- #
+
+    def _registry_path(self) -> Path:
+        return self._paths.track_dir / "repos.json"
+
+    def _load_locked(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        path = self._registry_path()
+        if not path.exists():
+            return
+        try:
+            blob = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning("repos.json unreadable, starting fresh: %s", e)
+            return
+        if not isinstance(blob, dict):
+            return
+        repos = blob.get("repos", {})
+        if not isinstance(repos, dict):
+            return
+        for url, entries in repos.items():
+            if not isinstance(entries, list):
+                continue
+            cleaned: list[RegistryEntry] = []
+            for e in entries:
+                if not isinstance(e, dict):
+                    continue
+                p = e.get("path")
+                ls = e.get("last_seen", "")
+                if isinstance(p, str) and p:
+                    cleaned.append(
+                        RegistryEntry(path=p, last_seen=ls if isinstance(ls, str) else "")
+                    )
+            if cleaned:
+                self._data[url] = cleaned
+
+    def _save_locked(self) -> None:
+        path = self._registry_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        blob = {
+            "version": self.SCHEMA_VERSION,
+            "repos": {
+                url: [{"path": e.path, "last_seen": e.last_seen} for e in entries]
+                for url, entries in self._data.items()
+            },
+        }
+        # Write+rename for atomicity. Don't fail loudly if the directory
+        # is unwritable — the registry is a cache, not a source of truth.
+        tmp = path.with_suffix(".json.tmp")
+        try:
+            tmp.write_text(json.dumps(blob, indent=2))
+            os.replace(tmp, path)
+        except OSError as e:
+            log.warning("failed to persist repos.json: %s", e)
+
+
+# ------------------------------------------------------------------ #
+# Filesystem scan                                                      #
+# ------------------------------------------------------------------ #
+
+
+# Roots we walk on demand. Users who keep code elsewhere will get
+# auto-discovered roots prepended via `default_scan_roots()` (parents of
+# anything the registry already knows about).
+_DEFAULT_ROOT_NAMES: tuple[str, ...] = (
+    "git", "code", "projects", "work", "dev", "src",
+)
+
+# Directory names we never descend into during a scan. Big and almost
+# never contain a project root.
+_SCAN_IGNORE: frozenset[str] = frozenset({
+    ".git", ".hg", ".svn",
+    "node_modules", "venv", ".venv", "env", ".env",
+    "target", "dist", "build", "out",
+    "__pycache__", ".pytest_cache", ".mypy_cache", ".tox", ".cache",
+    "Pods", "DerivedData",
+})
+
+_SCAN_DEPTH: int = 4
+_SCAN_LIMIT_DIRS: int = 5000  # circuit breaker; never walk more than this
+
+
+def default_scan_roots(registry: Optional[RepoRegistry] = None) -> list[Path]:
+    """Pick scan roots intelligently.
+
+    1. Standard names under `$HOME` (`~/git`, `~/code`, etc.) that exist.
+    2. Parents of any path the registry has ever seen — picks up your
+       actual layout without configuration.
+
+    De-duped, ordered by explicit-name first then auto-discovered.
+    """
+    home = Path.home()
+    roots: list[Path] = []
+    seen: set[Path] = set()
+
+    for name in _DEFAULT_ROOT_NAMES:
+        p = home / name
+        if p.is_dir() and p not in seen:
+            roots.append(p)
+            seen.add(p)
+
+    if registry is not None:
+        for known in registry.known_paths():
+            parent = known.parent
+            if parent.is_dir() and parent not in seen:
+                roots.append(parent)
+                seen.add(parent)
+
+    # Fall back to $HOME itself if we found nothing — better than
+    # returning an empty list and silently never finding anything.
+    if not roots and home.is_dir():
+        roots.append(home)
+
+    return roots
+
+
+def scan_for_repo(
+    url: str,
+    *,
+    registry: Optional[RepoRegistry] = None,
+    roots: Optional[Iterable[Path]] = None,
+    max_depth: int = _SCAN_DEPTH,
+) -> Optional[Path]:
+    """Walk known roots looking for a checkout of `url`. Returns the
+    first match (and caches it in the registry); None if nothing found.
+
+    Each candidate dir is checked by running `git remote get-url
+    origin` and normalizing the result against `url`. Depth-limited
+    and ignore-listed (skips node_modules etc.) so the walk is bounded
+    even on a deep filesystem.
+    """
+    if not url:
+        return None
+
+    if roots is None:
+        roots = default_scan_roots(registry)
+
+    walked = 0
+    for root in roots:
+        for candidate in _walk_for_repos(root, max_depth=max_depth):
+            walked += 1
+            if walked > _SCAN_LIMIT_DIRS:
+                log.warning(
+                    "scan_for_repo: hit dir-limit (%d) without finding %s",
+                    _SCAN_LIMIT_DIRS, url,
+                )
+                return None
+            raw = _git(["remote", "get-url", "origin"], cwd=str(candidate))
+            if not raw:
+                continue
+            if normalize_repo_url(raw) == url:
+                if registry is not None:
+                    registry.upsert(url, candidate)
+                return candidate
+    return None
+
+
+def _walk_for_repos(root: Path, *, max_depth: int):
+    """Yield every directory at-or-under `root` that looks like a git
+    repo (contains a `.git` entry — file or dir, the latter for
+    worktrees). Skips ignored names and bounds depth."""
+    if not root.is_dir():
+        return
+
+    # BFS with explicit depth so we can prune cleanly.
+    stack: list[tuple[Path, int]] = [(root, 0)]
+    while stack:
+        current, depth = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+
+        # If this dir IS a repo, yield it and stop descending. Nested
+        # repos (submodules) will still be reached if the root walk
+        # passes their parent dir without recognizing it as a repo.
+        if any(e.name == ".git" for e in entries):
+            yield current
+            continue
+
+        if depth >= max_depth:
+            continue
+
+        for e in entries:
+            if not e.is_dir():
+                continue
+            if e.name.startswith(".") and e.name not in {".config"}:
+                continue
+            if e.name in _SCAN_IGNORE:
+                continue
+            stack.append((e, depth + 1))
+
+
+# ------------------------------------------------------------------ #
+# Resolve cwd from a Session's metadata                                #
+# ------------------------------------------------------------------ #
+
+
+def resolve_repo_cwd(
+    *,
+    repo_url: Optional[str],
+    repo_subpath: Optional[str],
+    origin_cwd: Optional[str],
+    registry: Optional[RepoRegistry] = None,
+    allow_scan: bool = True,
+) -> Optional[str]:
+    """Map session metadata to a local cwd we can launch a CLI in.
+
+    Order:
+      1. registry hit for `repo_url` (preferring an entry whose
+         absolute path matches `origin_cwd` if multiple, else the
+         most recent).
+      2. filesystem scan, if allowed and no registry hit.
+      3. `origin_cwd` itself, if it exists on disk.
+      4. None — caller should print a clone hint.
+    """
+    if registry is None and repo_url:
+        registry = RepoRegistry()
+
+    subpath = (repo_subpath or "").strip("/").replace("\\", "/")
+
+    if repo_url and registry is not None:
+        candidates = registry.lookup(repo_url)
+        if candidates:
+            # Prefer an exact-match repo root that lines up with origin_cwd.
+            preferred = _prefer_origin_match(candidates, origin_cwd)
+            chosen = preferred or candidates[0]
+            return _join_subpath(chosen, subpath)
+
+    if repo_url and allow_scan:
+        hit = scan_for_repo(repo_url, registry=registry)
+        if hit is not None:
+            return _join_subpath(hit, subpath)
+
+    if origin_cwd and os.path.isdir(origin_cwd):
+        return origin_cwd
+
+    return None
+
+
+def _prefer_origin_match(candidates: list[Path], origin_cwd: Optional[str]) -> Optional[Path]:
+    """Of N checkouts of the same repo, pick the one whose root sits
+    under or above `origin_cwd`. Otherwise None (caller picks freshest)."""
+    if not origin_cwd:
+        return None
+    try:
+        origin = Path(origin_cwd).resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+    for c in candidates:
+        try:
+            cr = c.resolve(strict=False)
+        except (OSError, RuntimeError):
+            continue
+        if cr == origin or cr in origin.parents or origin in cr.parents:
+            return c
+    return None
+
+
+def _join_subpath(repo_root: Path, subpath: str) -> str:
+    """Combine repo root with subpath; verify the result exists, else
+    fall back to repo root. Subpath may legitimately not exist on a
+    different machine (rename, moved sub-dir) — landing at the repo
+    root is still useful."""
+    if not subpath:
+        return str(repo_root)
+    candidate = repo_root / subpath
+    if candidate.is_dir():
+        return str(candidate)
+    return str(repo_root)

--- a/fleet/track/resumer.py
+++ b/fleet/track/resumer.py
@@ -31,6 +31,7 @@ from .compactor import Compactor, TruncationCompactor, budget_for
 from .converter import _encode_claude_cwd
 from .paths import TrackPaths
 from .sources import ClaudeSource, CodexSource
+from .sources.base import with_synth_meta
 from .store import Session, SessionStore
 from .unified import Event, SessionStart
 
@@ -112,7 +113,9 @@ def resume_session(
     # we map repo_url → a local checkout via the registry/scan.
     target_cwd_local = _resolve_local_cwd(session)
     if target_cwd_local is None:
-        repo_url = (session.metadata or {}).get("repo_url") if session.metadata else None
+        repo_url = (
+            (session.metadata or {}).get("repo_url") if session.metadata else None
+        )
         if repo_url:
             raise RepoNotLocalError(
                 f"Session was created in {repo_url!r} but no local checkout "
@@ -136,11 +139,14 @@ def resume_session(
     # the cross-source synthesizer's wrapper overhead varies by target.
     if compactor is None:
         from .compactor import estimate_tokens
+
         target_source = _source_for(target_tool, home=paths.home)
 
         def _emission_tokens(evs: list[Event]) -> int:
             try:
-                return estimate_tokens(target_source.serialize(evs).decode("utf-8", errors="replace"))
+                return estimate_tokens(
+                    target_source.serialize(evs).decode("utf-8", errors="replace")
+                )
             except Exception:
                 # If serialization fails for any reason, treat it as
                 # over-budget so the compactor keeps trimming.
@@ -152,8 +158,11 @@ def resume_session(
         )
 
     checkout = _create_checkout(
-        store=store, session=session, target_tool=target_tool,
-        paths=paths, compactor=compactor,
+        store=store,
+        session=session,
+        target_tool=target_tool,
+        paths=paths,
+        compactor=compactor,
     )
     # The checkout file lives under the resolved-target-cwd's project dir
     # (see `_checkout_path`); launch the CLI from there so its project
@@ -209,7 +218,8 @@ def _create_checkout(
         events = list(compactor.compact(events))
         log.info(
             "checkout compaction: %d → %d events (%.1f%% reduction)",
-            before, len(events),
+            before,
+            len(events),
             100.0 * (1 - len(events) / max(1, before)),
         )
 
@@ -233,13 +243,16 @@ def _create_checkout(
         # reproduce the lineage.
 
     # Use the existing per-source serializer with synth metadata pre-baked.
-    annotated = [_with_synth_meta(
-        ev,
-        session_id=ephemeral_id,
-        cwd=target_cwd,
-        version=session.metadata.get("version", "0.0.0-fleet-checkout"),
-        git_branch=session.metadata.get("git_branch", ""),
-    ) for ev in events]
+    annotated = [
+        with_synth_meta(
+            ev,
+            session_id=ephemeral_id,
+            cwd=target_cwd,
+            version=session.metadata.get("version", "0.0.0-fleet-checkout"),
+            git_branch=session.metadata.get("git_branch", ""),
+        )
+        for ev in events
+    ]
 
     target_source = _source_for(target_tool, home=paths.home)
     target_bytes = target_source.serialize(annotated)
@@ -263,10 +276,17 @@ def _create_checkout(
     if target_tool == "claude":
         # Claude's reader is permissive about extra row types; emit
         # the header as a comment-style `system` row so it's ignored.
-        body = (json.dumps({"_fleet_meta": header,
-                             "type": "system",
-                             "content": "fleet-track checkout"}, separators=(",", ":"))
-                + "\n").encode("utf-8")
+        body = (
+            json.dumps(
+                {
+                    "_fleet_meta": header,
+                    "type": "system",
+                    "content": "fleet-track checkout",
+                },
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
     elif target_tool == "codex":
         # codex's session_meta MUST be the first row; we can't put a
         # custom header above it without breaking resume. Embed the
@@ -279,7 +299,11 @@ def _create_checkout(
 
     log.info(
         "checkout created tool=%s ephemeral_id=%s forked_from=%s fork_point=%d path=%s",
-        target_tool, ephemeral_id, session.id, fork_point, out_path,
+        target_tool,
+        ephemeral_id,
+        session.id,
+        fork_point,
+        out_path,
     )
 
     return CheckoutInfo(
@@ -306,11 +330,13 @@ def _checkout_path(target_tool: str, cwd: str, ephemeral_id: str, home: Path) ->
         return home / ".claude" / "projects" / encoded / f"{ephemeral_id}.jsonl"
     if target_tool == "codex":
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc)
         ts = now.strftime("%Y-%m-%dT%H-%M-%S")
         date = now.strftime("%Y/%m/%d")
-        return (home / ".codex" / "sessions" / date
-                / f"rollout-{ts}-{ephemeral_id}.jsonl")
+        return (
+            home / ".codex" / "sessions" / date / f"rollout-{ts}-{ephemeral_id}.jsonl"
+        )
     raise ValueError(f"Unknown target tool: {target_tool}")
 
 
@@ -320,15 +346,6 @@ def _source_for(tool: str, *, home: Path):
     if tool == "codex":
         return CodexSource(home=home)
     raise ValueError(f"Unknown tool: {tool}")
-
-
-def _with_synth_meta(ev, **synth):
-    """Embed `_synth` metadata into an event's `raw` so the cross-source
-    serializer can produce coherent rows. (Same logic as
-    converter._with_synth_meta but local so we don't import a private name.)"""
-    raw = dict(ev.raw) if ev.raw else {}
-    raw["_synth"] = dict(synth)
-    return ev.model_copy(update={"raw": raw})
 
 
 def _resolve_cwd(cwd: str) -> str:
@@ -491,4 +508,5 @@ def _is_fleet_checkout(path: Path) -> bool:
 
 def _seconds_now() -> float:
     import time
+
     return time.time()

--- a/fleet/track/resumer.py
+++ b/fleet/track/resumer.py
@@ -1,0 +1,401 @@
+"""Resume orchestration: SessionStore → checkout file → native CLI.
+
+The flow:
+
+  1. Materialize the session's full event chain (walks `forked_from`).
+  2. If the target tool matches the source, just dispatch native
+     resume directly against the source's own native session — no
+     conversion, no checkout. Cleanest path; no pollution.
+  3. Otherwise: synthesize a fresh ephemeral session id, convert
+     events to the target's native format, write to
+     `~/.<target>/.../.fleet-checkouts/<ephemeral-id>.jsonl`, and
+     `exec` the target's native resume command.
+
+Checkouts are tagged with their `forked_from` lineage as a header
+row; the track daemon uses this on upload to record the branch
+relation server-side. Track daemon GCs the `.fleet-checkouts/`
+namespace at 24h.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .compactor import Compactor, TruncationCompactor, budget_for
+from .converter import _encode_claude_cwd
+from .paths import TrackPaths
+from .sources import ClaudeSource, CodexSource
+from .store import Session, SessionStore
+from .unified import Event, SessionStart
+
+log = logging.getLogger("fleet.track.resumer")
+
+
+# Tool registry — what the SDK currently knows how to resume into.
+SUPPORTED_TOOLS: frozenset[str] = frozenset({"claude", "codex"})
+
+
+# Compaction lives in `fleet.track.compactor` (see TruncationCompactor +
+# CompactionConfig). Resumer composes a Compactor — never reaches into
+# its internals.
+
+
+@dataclass(frozen=True)
+class CheckoutInfo:
+    ephemeral_id: str
+    path: Path
+    target_tool: str
+    forked_from: str
+    fork_point: int
+
+
+def resume_session(
+    *,
+    store: SessionStore,
+    session: Session,
+    target_tool: str,
+    prompt: Optional[str] = None,
+    paths: Optional[TrackPaths] = None,
+    compactor: Optional[Compactor] = None,
+    target_model: Optional[str] = None,
+) -> int:
+    """Resume `session` in `target_tool`. Returns the target CLI's exit code.
+
+    If the target_tool matches the session's tool, dispatches the
+    native resume command against the original session (no conversion,
+    no checkout, no compaction — would be destructive of user history).
+
+    Cross-tool: creates a checkout via the supplied `compactor` (default:
+    a `TruncationCompactor` sized to the target tool/model's typical
+    context window). Dispatches on the new ephemeral id.
+
+    Future strategies (LLM summarization, recall-tool injection) plug
+    in by passing a different `compactor`. The interface is the seam.
+
+    Raises NotImplementedError if `target_tool` isn't supported yet
+    (cursor / opencode).
+    """
+    if target_tool not in SUPPORTED_TOOLS:
+        raise NotImplementedError(
+            f"Resume into '{target_tool}' isn't implemented yet. "
+            f"Supported: {sorted(SUPPORTED_TOOLS)}"
+        )
+
+    paths = paths or TrackPaths.default()
+
+    if session.tool == target_tool:
+        return _exec_native_resume(target_tool, session.id, prompt=prompt)
+
+    # Cross-tool: pick a default compactor sized to the target. Pass an
+    # `emission_estimator` so the compactor can verify post-serialization
+    # size against the budget — per-event estimation is imprecise because
+    # the cross-source synthesizer's wrapper overhead varies by target.
+    if compactor is None:
+        from .compactor import estimate_tokens
+        target_source = _source_for(target_tool, home=paths.home)
+
+        def _emission_tokens(evs: list[Event]) -> int:
+            try:
+                return estimate_tokens(target_source.serialize(evs).decode("utf-8", errors="replace"))
+            except Exception:
+                # If serialization fails for any reason, treat it as
+                # over-budget so the compactor keeps trimming.
+                return 10_000_000
+
+        compactor = TruncationCompactor(
+            budget=budget_for(target_tool, target_model),
+            emission_estimator=_emission_tokens,
+        )
+
+    checkout = _create_checkout(
+        store=store, session=session, target_tool=target_tool,
+        paths=paths, compactor=compactor,
+    )
+    return _exec_native_resume(target_tool, checkout.ephemeral_id, prompt=prompt)
+
+
+# ------------------------------------------------------------------ #
+# Checkout creation                                                    #
+# ------------------------------------------------------------------ #
+
+
+def _create_checkout(
+    *,
+    store: SessionStore,
+    session: Session,
+    target_tool: str,
+    paths: TrackPaths,
+    compactor: Optional[Compactor] = None,
+) -> CheckoutInfo:
+    """Convert `session`'s events into target-tool format and write to
+    `~/.<target>/.../<ephemeral-id>.jsonl` (flat, marked by `_fleet_meta`).
+
+    `compactor` (when supplied) projects the event stream into a
+    context-fitting view before serialization. None means "ship the
+    full history" — useful when the source is small enough to fit.
+    """
+    ephemeral_id = str(uuid.uuid4())
+
+    # Resolve cwd for the target. The session's recorded cwd is the
+    # original — resolve symlinks (mac /tmp → /private/tmp) so the
+    # target CLI's resume scan finds it.
+    target_cwd = _resolve_cwd(session.cwd or "/tmp")
+
+    # Walk parents, gather events; the converter then emits target-format
+    # bytes. We embed `_synth` metadata so cross-source synthesizers
+    # produce coherent rows (matching session id, cwd, etc.).
+    events = list(store.events(session.id))
+    fork_point = len(events)
+
+    # Apply compaction BEFORE prepending SessionStart and annotating —
+    # compaction operates on the source semantic events, not on the
+    # serializer's helper rows.
+    if compactor is not None:
+        before = len(events)
+        events = list(compactor.compact(events))
+        log.info(
+            "checkout compaction: %d → %d events (%.1f%% reduction)",
+            before, len(events),
+            100.0 * (1 - len(events) / max(1, before)),
+        )
+
+    # Both target tools need a "start of session" marker on output.
+    #   - codex requires `session_meta` as the first row, period.
+    #   - claude is forgiving but the SessionStart helps consumers.
+    # If the input event stream doesn't already start with a
+    # SessionStart, prepend one so the serializer emits the marker
+    # row in cross-source mode.
+    if not events or events[0].type != "session_start":
+        synthetic_start = SessionStart(
+            source=session.tool,
+            id=session.id,
+            cwd=target_cwd,
+            agent_version=session.metadata.get("version", "0.0.0-fleet-checkout"),
+            user_instructions=session.metadata.get("user_instructions"),
+        )
+        events = [synthetic_start] + events
+        # fork_point still measures the source session's event count
+        # (excluding our synthetic start), so the daemon can faithfully
+        # reproduce the lineage.
+
+    # Use the existing per-source serializer with synth metadata pre-baked.
+    annotated = [_with_synth_meta(
+        ev,
+        session_id=ephemeral_id,
+        cwd=target_cwd,
+        version=session.metadata.get("version", "0.0.0-fleet-checkout"),
+        git_branch=session.metadata.get("git_branch", ""),
+    ) for ev in events]
+
+    target_source = _source_for(target_tool, home=paths.home)
+    target_bytes = target_source.serialize(annotated)
+
+    # Where does it go?
+    out_path = _checkout_path(target_tool, target_cwd, ephemeral_id, paths.home)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Header row first (fleet-managed metadata, ignored by the target CLI
+    # because it's not a recognized row type).
+    header = {
+        "_fleet": "checkout-meta",
+        "schema_version": 1,
+        "ephemeral_id": ephemeral_id,
+        "forked_from": session.id,
+        "fork_point": fork_point,
+        "source_tool": session.tool,
+        "target_tool": target_tool,
+    }
+    body = b""
+    if target_tool == "claude":
+        # Claude's reader is permissive about extra row types; emit
+        # the header as a comment-style `system` row so it's ignored.
+        body = (json.dumps({"_fleet_meta": header,
+                             "type": "system",
+                             "content": "fleet-track checkout"}, separators=(",", ":"))
+                + "\n").encode("utf-8")
+    elif target_tool == "codex":
+        # codex's session_meta MUST be the first row; we can't put a
+        # custom header above it without breaking resume. Embed the
+        # checkout meta inside the session_meta payload as a sub-key.
+        # The converter already emits session_meta first; we'll
+        # post-process to inject the meta there.
+        target_bytes = _inject_codex_checkout_meta(target_bytes, header)
+
+    out_path.write_bytes(body + target_bytes)
+
+    log.info(
+        "checkout created tool=%s ephemeral_id=%s forked_from=%s fork_point=%d path=%s",
+        target_tool, ephemeral_id, session.id, fork_point, out_path,
+    )
+
+    return CheckoutInfo(
+        ephemeral_id=ephemeral_id,
+        path=out_path,
+        target_tool=target_tool,
+        forked_from=session.id,
+        fork_point=fork_point,
+    )
+
+
+def _checkout_path(target_tool: str, cwd: str, ephemeral_id: str, home: Path) -> Path:
+    """Where the checkout file lives in the target tool's namespace.
+
+    Layout decision: checkouts live FLAT alongside native sessions, NOT
+    in a `.fleet-checkouts/` subdir. claude's resume scanner only looks
+    one level deep under `<encoded-cwd>/`, so a subdir would render the
+    file invisible. Same flat layout for codex for consistency. The
+    daemon distinguishes checkouts from native sessions by reading the
+    first row's `_fleet_meta` marker — fast and reliable.
+    """
+    if target_tool == "claude":
+        encoded = _encode_claude_cwd(cwd)
+        return home / ".claude" / "projects" / encoded / f"{ephemeral_id}.jsonl"
+    if target_tool == "codex":
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        ts = now.strftime("%Y-%m-%dT%H-%M-%S")
+        date = now.strftime("%Y/%m/%d")
+        return (home / ".codex" / "sessions" / date
+                / f"rollout-{ts}-{ephemeral_id}.jsonl")
+    raise ValueError(f"Unknown target tool: {target_tool}")
+
+
+def _source_for(tool: str, *, home: Path):
+    if tool == "claude":
+        return ClaudeSource(home=home)
+    if tool == "codex":
+        return CodexSource(home=home)
+    raise ValueError(f"Unknown tool: {tool}")
+
+
+def _with_synth_meta(ev, **synth):
+    """Embed `_synth` metadata into an event's `raw` so the cross-source
+    serializer can produce coherent rows. (Same logic as
+    converter._with_synth_meta but local so we don't import a private name.)"""
+    raw = dict(ev.raw) if ev.raw else {}
+    raw["_synth"] = dict(synth)
+    return ev.model_copy(update={"raw": raw})
+
+
+def _resolve_cwd(cwd: str) -> str:
+    """Resolve symlinks. macOS `/tmp` → `/private/tmp` etc."""
+    try:
+        return str(Path(cwd).resolve(strict=False))
+    except (OSError, RuntimeError):
+        return cwd
+
+
+def _inject_codex_checkout_meta(body: bytes, meta: dict) -> bytes:
+    """Add a `_fleet_meta` field inside the first session_meta row's
+    payload so the daemon can read fork lineage on upload."""
+    text = body.decode("utf-8")
+    lines = text.splitlines(keepends=False)
+    if not lines:
+        return body
+    try:
+        first = json.loads(lines[0])
+    except json.JSONDecodeError:
+        return body
+    if first.get("type") == "session_meta":
+        payload = first.get("payload") or {}
+        payload["_fleet_meta"] = meta
+        first["payload"] = payload
+        lines[0] = json.dumps(first, ensure_ascii=False, separators=(",", ":"))
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+# ------------------------------------------------------------------ #
+# Native CLI dispatch                                                  #
+# ------------------------------------------------------------------ #
+
+
+def _exec_native_resume(tool: str, session_id: str, *, prompt: Optional[str]) -> int:
+    """Run the tool's native resume command. Returns the exit code.
+
+    Inherits stdio so the user can interact (TUI). For non-interactive
+    use (testing), pass `--print` for claude or use `codex exec resume`
+    — but those are choices for the caller of `resume_session` to
+    pre-bake into the prompt argument."""
+    if tool == "claude":
+        cmd = ["claude", "--resume", session_id]
+        if prompt:
+            cmd.extend(["--print", prompt])
+        return subprocess.call(cmd)
+    if tool == "codex":
+        cmd = ["codex"]
+        if prompt:
+            cmd.extend(["exec", "--skip-git-repo-check", "resume", session_id, prompt])
+        else:
+            cmd.extend(["resume", session_id])
+        return subprocess.call(cmd)
+    raise ValueError(f"Unknown tool: {tool}")
+
+
+# ------------------------------------------------------------------ #
+# Cleanup (called by track daemon's hourly maintenance loop)           #
+# ------------------------------------------------------------------ #
+
+
+def gc_checkouts(*, home: Optional[Path] = None, max_age_hours: int = 24) -> int:
+    """Delete fleet-managed checkout files older than `max_age_hours`.
+
+    A file is identified as a checkout by inspecting its first line for
+    the `_fleet_meta` marker (or `payload._fleet_meta` for codex's
+    session_meta layout). Native sessions never carry that key, so this
+    is non-destructive on user data.
+
+    Returns the number of files removed. Idempotent. Safe to run
+    concurrently with active resumes — only files older than the
+    threshold get touched, and a session in active use has a fresh
+    mtime.
+    """
+    home = home or Path.home()
+    cutoff = _seconds_now() - max_age_hours * 3600
+    removed = 0
+    for tool_root in (home / ".claude" / "projects", home / ".codex" / "sessions"):
+        if not tool_root.is_dir():
+            continue
+        for f in tool_root.glob("**/*.jsonl"):
+            try:
+                st = f.stat()
+                if st.st_mtime >= cutoff:
+                    continue  # too fresh
+                if not _is_fleet_checkout(f):
+                    continue  # native session, leave alone
+                f.unlink()
+                removed += 1
+            except OSError as e:
+                log.warning("checkout gc: failed to inspect/remove %s: %s", f, e)
+    return removed
+
+
+def _is_fleet_checkout(path: Path) -> bool:
+    """True if the file's first row carries fleet's checkout marker."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            line = f.readline()
+        if not line:
+            return False
+        d = json.loads(line)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(d, dict):
+        return False
+    if "_fleet_meta" in d:
+        return True
+    payload = d.get("payload")
+    if isinstance(payload, dict) and "_fleet_meta" in payload:
+        return True
+    return False
+
+
+def _seconds_now() -> float:
+    import time
+    return time.time()

--- a/fleet/track/resumer.py
+++ b/fleet/track/resumer.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -40,6 +39,23 @@ log = logging.getLogger("fleet.track.resumer")
 
 # Tool registry — what the SDK currently knows how to resume into.
 SUPPORTED_TOOLS: frozenset[str] = frozenset({"claude", "codex"})
+
+
+class RepoNotLocalError(Exception):
+    """Raised when a session's repo isn't checked out anywhere local.
+
+    Surfaced to the CLI which prints the message (which already includes
+    a `git clone <url>` hint) and exits non-zero. Lower-level than a
+    plain RuntimeError so the CLI can distinguish missing-repo from
+    other resume failures."""
+
+
+def _url_to_clone_form(normalized: str) -> str:
+    """Turn a normalized url back into a clone-able form. Best-effort —
+    we don't know whether the user prefers ssh or https, so we default
+    to https because it works without auth setup. The user can rewrite
+    to ssh form themselves."""
+    return f"https://{normalized}.git" if normalized else ""
 
 
 # Compaction lives in `fleet.track.compactor` (see TruncationCompactor +
@@ -90,8 +106,29 @@ def resume_session(
 
     paths = paths or TrackPaths.default()
 
+    # Resolve the local cwd to launch the CLI in. Both claude and codex
+    # scope `--resume <id>` to the current project, so we have to land
+    # in the right directory. For cross-machine resume, this is where
+    # we map repo_url → a local checkout via the registry/scan.
+    target_cwd_local = _resolve_local_cwd(session)
+    if target_cwd_local is None:
+        repo_url = (session.metadata or {}).get("repo_url") if session.metadata else None
+        if repo_url:
+            raise RepoNotLocalError(
+                f"Session was created in {repo_url!r} but no local checkout "
+                f"of that repo was found. Clone it locally and retry:\n"
+                f"  git clone {_url_to_clone_form(repo_url)}"
+            )
+        # No repo metadata; honor the original cwd if we can.
+        target_cwd_local = _resolve_cwd(session.cwd) if session.cwd else None
+
     if session.tool == target_tool:
-        return _exec_native_resume(target_tool, session.id, prompt=prompt)
+        return _exec_native_resume(
+            target_tool,
+            session.id,
+            prompt=prompt,
+            cwd=target_cwd_local,
+        )
 
     # Cross-tool: pick a default compactor sized to the target. Pass an
     # `emission_estimator` so the compactor can verify post-serialization
@@ -118,7 +155,15 @@ def resume_session(
         store=store, session=session, target_tool=target_tool,
         paths=paths, compactor=compactor,
     )
-    return _exec_native_resume(target_tool, checkout.ephemeral_id, prompt=prompt)
+    # The checkout file lives under the resolved-target-cwd's project dir
+    # (see `_checkout_path`); launch the CLI from there so its project
+    # scan picks the file up.
+    return _exec_native_resume(
+        target_tool,
+        checkout.ephemeral_id,
+        prompt=prompt,
+        cwd=target_cwd_local,
+    )
 
 
 # ------------------------------------------------------------------ #
@@ -143,10 +188,12 @@ def _create_checkout(
     """
     ephemeral_id = str(uuid.uuid4())
 
-    # Resolve cwd for the target. The session's recorded cwd is the
-    # original — resolve symlinks (mac /tmp → /private/tmp) so the
-    # target CLI's resume scan finds it.
-    target_cwd = _resolve_cwd(session.cwd or "/tmp")
+    # Resolve where the checkout should live on THIS machine. For sessions
+    # captured on another device, `session.cwd` is meaningless absolute
+    # path; the resolver maps `metadata.repo_url` → local checkout via
+    # the registry / scan and falls back to `session.cwd` only if a
+    # local path actually exists there.
+    target_cwd = _resolve_local_cwd(session) or _resolve_cwd(session.cwd or "/tmp")
 
     # Walk parents, gather events; the converter then emits target-format
     # bytes. We embed `_synth` metadata so cross-source synthesizers
@@ -292,6 +339,40 @@ def _resolve_cwd(cwd: str) -> str:
         return cwd
 
 
+def _resolve_local_cwd(session: Session) -> Optional[str]:
+    """Map a Session to a local cwd we can launch a CLI in.
+
+    Honours `metadata.repo_url` first (the cross-machine key) so a
+    session captured on another device still finds the right local
+    checkout. Falls back to `session.cwd` when no repo metadata or no
+    matching local checkout exists.
+
+    Returns None when nothing usable was found — the caller should
+    print a clone hint or surface a clear error rather than launching
+    in some random cwd that won't have the project files.
+    """
+    from .repos import RepoRegistry, resolve_repo_cwd
+
+    md = session.metadata or {}
+    repo_url = md.get("repo_url")
+    repo_subpath = md.get("repo_subpath")
+    origin_cwd = md.get("origin_cwd") or session.cwd
+
+    if not repo_url and not origin_cwd:
+        return None
+
+    registry = RepoRegistry() if repo_url else None
+    resolved = resolve_repo_cwd(
+        repo_url=repo_url,
+        repo_subpath=repo_subpath,
+        origin_cwd=origin_cwd,
+        registry=registry,
+    )
+    if resolved is None:
+        return None
+    return _resolve_cwd(resolved)
+
+
 def _inject_codex_checkout_meta(body: bytes, meta: dict) -> bytes:
     """Add a `_fleet_meta` field inside the first session_meta row's
     payload so the daemon can read fork lineage on upload."""
@@ -316,25 +397,37 @@ def _inject_codex_checkout_meta(body: bytes, meta: dict) -> bytes:
 # ------------------------------------------------------------------ #
 
 
-def _exec_native_resume(tool: str, session_id: str, *, prompt: Optional[str]) -> int:
+def _exec_native_resume(
+    tool: str,
+    session_id: str,
+    *,
+    prompt: Optional[str],
+    cwd: Optional[str] = None,
+) -> int:
     """Run the tool's native resume command. Returns the exit code.
 
     Inherits stdio so the user can interact (TUI). For non-interactive
     use (testing), pass `--print` for claude or use `codex exec resume`
     — but those are choices for the caller of `resume_session` to
-    pre-bake into the prompt argument."""
+    pre-bake into the prompt argument.
+
+    `cwd`, when set, is the project directory the CLI should run in.
+    Both claude and codex scope their resume lookup to the current
+    project, so resuming a session that was created in a different
+    directory requires launching from there.
+    """
     if tool == "claude":
         cmd = ["claude", "--resume", session_id]
         if prompt:
             cmd.extend(["--print", prompt])
-        return subprocess.call(cmd)
+        return subprocess.call(cmd, cwd=cwd)
     if tool == "codex":
         cmd = ["codex"]
         if prompt:
             cmd.extend(["exec", "--skip-git-repo-check", "resume", session_id, prompt])
         else:
             cmd.extend(["resume", session_id])
-        return subprocess.call(cmd)
+        return subprocess.call(cmd, cwd=cwd)
     raise ValueError(f"Unknown tool: {tool}")
 
 

--- a/fleet/track/scrubber.py
+++ b/fleet/track/scrubber.py
@@ -1,0 +1,153 @@
+"""Client-side PII / secret scrubbing before upload.
+
+Pure regex replacement. No parsing, no models. Structure-preserving:
+scrubbing a JSONL line still produces valid JSON.
+
+Each rule has a name. `scrub` returns a `ScrubResult` carrying both the
+scrubbed text and a list of `Hit` records — tests assert "the AWS rule
+fired on this input" instead of fragile substring matches, and the
+future `flt track inspect <file>` command formats the hits per line.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Sequence, Union
+
+Replacement = Union[str, Callable[[re.Match], str]]
+
+
+@dataclass(frozen=True)
+class Rule:
+    name: str
+    pattern: re.Pattern
+    replacement: Replacement
+
+
+@dataclass(frozen=True)
+class Hit:
+    """One match of a rule. Line is 1-indexed for human-readable output."""
+
+    rule: str
+    line: int
+    matched: str
+
+
+@dataclass(frozen=True)
+class ScrubResult:
+    text: str
+    hits: tuple[Hit, ...] = field(default_factory=tuple)
+
+    @property
+    def fired_rules(self) -> set[str]:
+        return {h.rule for h in self.hits}
+
+
+# Order matters: more-specific rules run first so that, e.g. AKIA keys
+# aren't first redacted by the generic API-key rule and lose their name.
+DEFAULT_RULES: tuple[Rule, ...] = (
+    Rule("aws_access_key_id", re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED_AWS_KEY]"),
+    Rule(
+        "aws_secret_access_key",
+        re.compile(r"(?i)(aws_secret_access_key|aws_secret)\s*[=:]\s*['\"]?[A-Za-z0-9/+=]{40}"),
+        "[REDACTED_AWS_SECRET]",
+    ),
+    Rule(
+        "anthropic_api_key",
+        re.compile(r"sk-ant-[A-Za-z0-9\-]{20,}"),
+        "[REDACTED_ANTHROPIC_KEY]",
+    ),
+    Rule(
+        "openai_api_key",
+        re.compile(r"sk-[A-Za-z0-9]{20,}"),
+        "[REDACTED_OPENAI_KEY]",
+    ),
+    Rule(
+        "github_token",
+        re.compile(r"ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{82}"),
+        "[REDACTED_GITHUB_TOKEN]",
+    ),
+    Rule(
+        "slack_token",
+        re.compile(r"xox[bpras]-[A-Za-z0-9\-]{10,}"),
+        "[REDACTED_SLACK_TOKEN]",
+    ),
+    Rule(
+        "jwt",
+        re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_\-]{10,}"),
+        "[REDACTED_JWT]",
+    ),
+    Rule(
+        "private_key_block",
+        re.compile(r"-----BEGIN [A-Z ]+ PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+ PRIVATE KEY-----"),
+        "[REDACTED_PRIVATE_KEY]",
+    ),
+    Rule(
+        "connection_string",
+        re.compile(r"(?i)(postgres|mysql|mongodb(\+srv)?|redis|amqp)://[^\s'\"]+"),
+        "[REDACTED_CONNECTION_STRING]",
+    ),
+    Rule(
+        "ssh_public_key",
+        re.compile(r"(?i)(ssh-rsa|ssh-ed25519)\s+[A-Za-z0-9+/=]{40,}"),
+        "[REDACTED_SSH_KEY]",
+    ),
+    Rule(
+        "generic_api_key_assignment",
+        re.compile(
+            r"(?i)(api[_-]?key|apikey|api[_-]?token|auth[_-]?token|secret[_-]?key|access[_-]?token)"
+            r"\s*[=:]\s*['\"]?[A-Za-z0-9_\-]{20,}"
+        ),
+        "[REDACTED_API_KEY]",
+    ),
+    Rule(
+        "bearer_token",
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9_\-\.]{20,}"),
+        "Bearer [REDACTED_TOKEN]",
+    ),
+    Rule(
+        "env_assignment_long_value",
+        re.compile(r"(?m)^[A-Z_]{2,}=(?!.*REDACTED)[^\n]{20,}$"),
+        lambda m: m.group(0).split("=")[0] + "=[REDACTED]",
+    ),
+    Rule("home_path_macos", re.compile(r"/Users/[a-zA-Z0-9._-]+"), "/Users/[user]"),
+    Rule("home_path_linux", re.compile(r"/home/[a-zA-Z0-9._-]+"), "/home/[user]"),
+)
+
+
+def scrub(text: str, rules: Iterable[Rule] = DEFAULT_RULES) -> ScrubResult:
+    """Apply rules in order. Returns scrubbed text + per-hit metadata.
+
+    Hits are recorded against the *original* text's line numbers so that
+    `flt track inspect` can point at the line the user can find in their
+    on-disk session file.
+    """
+    rule_list: Sequence[Rule] = tuple(rules)
+    hits: list[Hit] = []
+
+    # First pass: enumerate hits against the *original* text so line
+    # numbers don't shift when subsequent rules rewrite content.
+    for rule in rule_list:
+        for m in rule.pattern.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            hits.append(Hit(rule=rule.name, line=line, matched=m.group(0)))
+
+    # Second pass: actual substitution. We re-run regexes here rather than
+    # building offsets, because subs in earlier rules can change later
+    # rules' match positions (e.g. a long secret becoming "[REDACTED]"
+    # could expose a substring that looks like another secret).
+    for rule in rule_list:
+        text = rule.pattern.sub(rule.replacement, text)
+
+    return ScrubResult(text=text, hits=tuple(hits))
+
+
+def scrub_bytes(data: bytes, rules: Iterable[Rule] = DEFAULT_RULES) -> bytes:
+    """Scrub raw bytes (decoded as UTF-8, re-encoded). Backward-compatible
+    wrapper for the upload path that just wants the scrubbed payload."""
+    try:
+        text = data.decode("utf-8", errors="replace")
+        return scrub(text, rules).text.encode("utf-8")
+    except Exception:
+        return data

--- a/fleet/track/sources/__init__.py
+++ b/fleet/track/sources/__init__.py
@@ -1,0 +1,90 @@
+"""Sources package.
+
+Public surface:
+    Source                 — abstract base class
+    SourceSummary          — reportable view of one source
+    ClaudeSource, CursorSource, CodexSource — concrete impls
+    default_sources(home)  — list of standard sources for a given home
+    relative_to_home       — shared util
+
+Backward-compat (will be removed once consumers migrate):
+    iter_source_files()    — flat iterator over default_sources()
+    source_summary()       — dict view across default_sources()
+    detect_sources()       — list of Source instances
+    EXCLUDE_PATTERNS, WATCH_ROOTS
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator, Optional
+
+from .base import (
+    DEFAULT_EXCLUDE_PATTERNS,
+    Source,
+    SourceSummary,
+    relative_to_home,
+)
+from .claude import ClaudeSource
+from .codex import CodexSource
+from .cursor import CursorSource
+
+__all__ = [
+    "Source",
+    "SourceSummary",
+    "ClaudeSource",
+    "CursorSource",
+    "CodexSource",
+    "default_sources",
+    "relative_to_home",
+    # Backward-compat:
+    "iter_source_files",
+    "source_summary",
+    "detect_sources",
+    "EXCLUDE_PATTERNS",
+    "WATCH_ROOTS",
+]
+
+
+def default_sources(home: Optional[Path] = None) -> list[Source]:
+    """The standard set of sources we sync from. Tests pass a tmp home."""
+    return [
+        ClaudeSource(home=home),
+        CursorSource(home=home),
+        CodexSource(home=home),
+    ]
+
+
+# ------------------------------------------------------------------ #
+# Backward-compat module-level shims                                   #
+# ------------------------------------------------------------------ #
+
+EXCLUDE_PATTERNS = DEFAULT_EXCLUDE_PATTERNS
+
+# Computed lazily via a function so tests don't anchor on import-time
+# Path.home(); but exposed as a module attribute for legacy callers.
+WATCH_ROOTS = [
+    Path.home() / ".claude" / "projects",
+    Path.home() / ".cursor" / "projects",
+    Path.home() / ".codex",
+]
+
+
+def iter_source_files() -> Iterator[Path]:
+    """Yield every file every default source wants to sync."""
+    for source in default_sources():
+        yield from source.iter_files()
+
+
+def source_summary() -> dict[str, dict]:
+    """Return per-agent summary as the legacy dict shape used by status.json."""
+    out: dict[str, dict] = {}
+    for source in default_sources():
+        s = source.summary()
+        out[s.name] = {"found": s.found, "files": s.files}
+    return out
+
+
+def detect_sources() -> list[Source]:
+    """Return the default source list. Callers can ask `is_present()`."""
+    return default_sources()

--- a/fleet/track/sources/base.py
+++ b/fleet/track/sources/base.py
@@ -182,3 +182,23 @@ def _walk_glob(root: Path, glob: str, exclude: frozenset[str]) -> Iterator[Path]
         if any(excl in path.parts for excl in exclude):
             continue
         yield path
+
+
+# Keys that the resumer pre-injects into `raw` for cross-source synthesis.
+# An event whose `raw` carries only these annotations isn't a real source row.
+_RAW_SYNTHETIC_KEYS: frozenset[str] = frozenset({"_synth"})
+
+
+def has_substantive_raw(raw: Any) -> bool:
+    """True when `raw` carries an actual source row, not just synthesis
+    annotations. The resumer pre-injects `_synth` metadata into every
+    event's raw so cross-source synthesis can read session-wide context
+    out of any row; that annotation alone shouldn't cause the serializer
+    to think there's a real row to emit.
+
+    Centralized here so future synthetic keys (beyond `_synth`) only need
+    to be added in one place.
+    """
+    if not raw:
+        return False
+    return any(k not in _RAW_SYNTHETIC_KEYS for k in raw.keys())

--- a/fleet/track/sources/base.py
+++ b/fleet/track/sources/base.py
@@ -1,0 +1,184 @@
+"""Source ABC.
+
+A `Source` represents one AI tool whose session files we sync. Today the
+file-shape (jsonl + a few extensions) is all the daemon cares about. Soon
+each source will also implement `parse(path)` → events and
+`serialize(events)` → bytes for the unified-format pipeline; those
+methods raise `NotImplementedError` here and ship in the format PR.
+
+Each concrete source is constructed with a `home: Path` so tests can
+point at a fixture directory instead of the real `$HOME`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar, Iterable, Iterator, Optional
+
+
+# Files we never sync, regardless of which source surfaced them.
+# This is the *client*-side guard. The server enforces a strictly larger
+# blocklist (see orchestrator/public_api/track.py); the client list is
+# best-effort to skip uploads that the server would reject anyway.
+DEFAULT_EXCLUDE_PATTERNS: frozenset[str] = frozenset({
+    "session-env",          # Claude Code env vars
+    "auth.json",            # Codex credentials
+    "config.toml",          # Codex config
+    "shell_snapshots",      # Codex shell env
+})
+
+
+@dataclass(frozen=True)
+class SourceSummary:
+    """Reportable view of one source — for `flt track sources` and status.json."""
+
+    name: str
+    found: bool
+    files: int = 0
+    bytes: int = 0
+    newest_mtime: Optional[float] = None
+
+
+def relative_to_home(path: Path, home: Optional[Path] = None) -> str:
+    """Return ``path`` relative to ``home`` as a POSIX string.
+
+    ``home`` defaults to ``Path.home()`` for production callers; tests pass a
+    ``tmp_path`` so the merkle/queue/uploader code can reason about files
+    under a fixture root without fighting the real filesystem.
+    """
+    return str(path.relative_to(home if home is not None else Path.home()))
+
+
+class Source(ABC):
+    """One AI tool's session-file directory and how to read it.
+
+    Subclasses set `name` (used as the agent label in summaries and S3
+    paths) and override `root` and `iter_files`. The default
+    `read_for_upload` is fine for most cases; override for format-specific
+    quirks (e.g. JSONL trailing-line trim).
+    """
+
+    name: ClassVar[str] = ""
+
+    def __init__(self, home: Optional[Path] = None) -> None:
+        self._home = home or Path.home()
+
+    # ------------------------------------------------------------------ #
+    # Filesystem layout                                                    #
+    # ------------------------------------------------------------------ #
+
+    @property
+    @abstractmethod
+    def root(self) -> Path:
+        """The directory we recursively scan for session files."""
+
+    @property
+    def watch_roots(self) -> list[Path]:
+        """Directories the FS watcher should monitor for this source.
+
+        Defaults to `[self.root]` but overridable: e.g. CodexSource watches
+        `~/.codex` so newly-created `sessions/` and `archived_sessions/`
+        subdirs are picked up without restarting the daemon.
+        """
+        return [self.root]
+
+    @property
+    def exclude_patterns(self) -> frozenset[str]:
+        """Path-fragment substrings to skip on this source. Defaults to the
+        global set; subclasses extend if they have format-specific exclusions."""
+        return DEFAULT_EXCLUDE_PATTERNS
+
+    # ------------------------------------------------------------------ #
+    # Discovery                                                            #
+    # ------------------------------------------------------------------ #
+
+    def is_present(self) -> bool:
+        return self.root.is_dir()
+
+    @abstractmethod
+    def iter_files(self) -> Iterator[Path]:
+        """Yield every file this source wants to sync. Must skip
+        `exclude_patterns` and non-files."""
+
+    def summary(self) -> SourceSummary:
+        if not self.is_present():
+            return SourceSummary(name=self.name, found=False)
+
+        files = list(self.iter_files())
+        if not files:
+            return SourceSummary(name=self.name, found=True)
+
+        total_bytes = 0
+        newest = 0.0
+        for f in files:
+            try:
+                st = f.stat()
+                total_bytes += st.st_size
+                if st.st_mtime > newest:
+                    newest = st.st_mtime
+            except OSError:
+                continue
+        return SourceSummary(
+            name=self.name,
+            found=True,
+            files=len(files),
+            bytes=total_bytes,
+            newest_mtime=newest if newest > 0 else None,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Read for upload                                                      #
+    # ------------------------------------------------------------------ #
+
+    def read_for_upload(self, path: Path) -> Optional[bytes]:
+        """Read bytes ready for upload. Returns None on read failure.
+
+        Default: whole file. Override for format-specific quirks.
+        """
+        try:
+            return path.read_bytes()
+        except OSError:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Unified-format conversion (Phase 0 in the format PR)                 #
+    # ------------------------------------------------------------------ #
+
+    def parse(self, path: Path) -> Iterable[Any]:
+        """Parse a session file into the unified `Event` stream.
+
+        Stub raising `NotImplementedError`; concrete impls land alongside
+        `fleet/track/unified.py` in the format PR. Once implemented:
+        - never raises on malformed input (unknown types → OpaqueEvent)
+        - yields events ordered as they appear in the file
+        """
+        raise NotImplementedError(f"{self.name}.parse() not implemented yet")
+
+    def serialize(self, events: Iterable[Any]) -> bytes:
+        """Serialize a stream of unified `Event`s back into this source's native format.
+
+        Stub raising `NotImplementedError`. Once implemented, must be
+        round-trip robust: `serialize(parse(file))` produces a valid file
+        the source can re-parse.
+        """
+        raise NotImplementedError(f"{self.name}.serialize() not implemented yet")
+
+
+# ------------------------------------------------------------------ #
+# Helpers shared by subclasses                                         #
+# ------------------------------------------------------------------ #
+
+
+def _walk_glob(root: Path, glob: str, exclude: frozenset[str]) -> Iterator[Path]:
+    """Walk a glob, skipping non-files and any path containing an excluded
+    fragment."""
+    if not root.is_dir():
+        return
+    for path in root.glob(glob):
+        if not path.is_file():
+            continue
+        if any(excl in path.parts for excl in exclude):
+            continue
+        yield path

--- a/fleet/track/sources/base.py
+++ b/fleet/track/sources/base.py
@@ -22,12 +22,14 @@ from typing import Any, ClassVar, Iterable, Iterator, Optional
 # This is the *client*-side guard. The server enforces a strictly larger
 # blocklist (see orchestrator/public_api/track.py); the client list is
 # best-effort to skip uploads that the server would reject anyway.
-DEFAULT_EXCLUDE_PATTERNS: frozenset[str] = frozenset({
-    "session-env",          # Claude Code env vars
-    "auth.json",            # Codex credentials
-    "config.toml",          # Codex config
-    "shell_snapshots",      # Codex shell env
-})
+DEFAULT_EXCLUDE_PATTERNS: frozenset[str] = frozenset(
+    {
+        "session-env",  # Claude Code env vars
+        "auth.json",  # Codex credentials
+        "config.toml",  # Codex config
+        "shell_snapshots",  # Codex shell env
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -202,3 +204,10 @@ def has_substantive_raw(raw: Any) -> bool:
     if not raw:
         return False
     return any(k not in _RAW_SYNTHETIC_KEYS for k in raw.keys())
+
+
+def with_synth_meta(ev: Any, **synth: Any) -> Any:
+    """Return a copy of an event with serializer synthesis metadata attached."""
+    raw = dict(ev.raw) if ev.raw else {}
+    raw["_synth"] = dict(synth)
+    return ev.model_copy(update={"raw": raw})

--- a/fleet/track/sources/claude.py
+++ b/fleet/track/sources/claude.py
@@ -65,7 +65,7 @@ from ..unified import (
     ToolResult,
     UserMessage,
 )
-from .base import Source, _walk_glob
+from .base import Source, _walk_glob, has_substantive_raw
 
 log = logging.getLogger("fleet.track.sources.claude")
 
@@ -359,17 +359,6 @@ def _parse_assistant(doc: dict, common: dict) -> Iterator[Event]:
 # ------------------------------------------------------------------ #
 
 
-def _has_substantive_raw(raw) -> bool:
-    """True when `raw` carries an actual source row, not just our
-    `_synth` annotation. The resumer pre-injects `_synth` metadata into
-    every event's raw so cross-source synthesis can read session-wide
-    context out of any row; that annotation alone shouldn't cause the
-    serializer to think there's a real row to emit."""
-    if not raw:
-        return False
-    return any(k != "_synth" for k in raw.keys())
-
-
 def _serialize_event_for_claude(ev: Event, seen_row_ids: set[str]) -> Optional[str]:
     """Return one JSONL line for `ev`, or None to skip.
 
@@ -383,7 +372,7 @@ def _serialize_event_for_claude(ev: Event, seen_row_ids: set[str]) -> Optional[s
     if ev.source == "claude":
         if ev.synthesized:
             return None  # parser-synthesized view; no original row to emit
-        if not _has_substantive_raw(ev.raw):
+        if not has_substantive_raw(ev.raw):
             # Same-source bare event (e.g. seeded into a SessionStore
             # without raw context — raw is empty or only carries
             # `_synth` metadata). Synthesize a native row from kernel

--- a/fleet/track/sources/claude.py
+++ b/fleet/track/sources/claude.py
@@ -1,0 +1,568 @@
+"""ClaudeSource — `~/.claude/projects/**/*.jsonl`.
+
+Serialization strategy
+----------------------
+
+`serialize()` has two modes, chosen per event:
+
+  1. **Same-source** (`event.source == "claude"` and `event.raw` is non-empty):
+     emit the original row from `event.raw`. Sub-events derived from the
+     same row (id contains `#`) are skipped — the parent row already
+     captured them. This gives a near-byte-identical round-trip
+     (modulo JSON key order).
+
+  2. **Cross-source** (event came from codex / cursor / opencode):
+     synthesize a claude-shaped row from the kernel fields. Lossy by
+     construction. We emit only the events claude can render
+     (user/assistant messages, tool calls/results); other events
+     become `system`-typed comment rows so they're not silently lost.
+
+Format notes (cataloged from real session files):
+
+  Top-level row types observed:
+    - `user` / `assistant` / `system`              — conversation
+    - `attachment`                                  — user attached files
+    - `last-prompt`                                 — pre-call prompt snapshot
+    - `permission-mode`                             — agent perm-mode change
+    - `file-history-snapshot`                       — file edit snapshot
+    - `ai-title`                                    — generated session title
+    - `queue-operation`                             — internal queue events
+    - `pr-link`                                     — emitted PR URLs
+
+  Each row carries: uuid, parentUuid, sessionId, timestamp, cwd,
+  gitBranch, version, userType, isSidechain, entrypoint, requestId.
+  parent_uuid + uuid form a tree (multiple children of same parent =
+  conversation branch).
+
+  `assistant.message.content` is a list of blocks:
+    - `text`        — visible response text
+    - `tool_use`    — tool invocation { id, name, input }
+    - `thinking`    — chain-of-thought; { thinking: text }
+
+  `user.message.content` is either a string OR a list of blocks:
+    - `tool_result` — { tool_use_id, content, is_error? }
+    - `text`        — additional text after a tool result
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+from ..unified import (
+    AssistantMessage,
+    AssistantReasoning,
+    Attachment,
+    Event,
+    FileEdit,
+    Lifecycle,
+    OpaqueEvent,
+    Operator,
+    SessionStart,
+    ToolCall,
+    ToolResult,
+    UserMessage,
+)
+from .base import Source, _walk_glob
+
+log = logging.getLogger("fleet.track.sources.claude")
+
+
+class ClaudeSource(Source):
+    name = "claude"
+
+    @property
+    def root(self) -> Path:
+        return self._home / ".claude" / "projects"
+
+    def iter_files(self) -> Iterator[Path]:
+        yield from _walk_glob(self.root, "**/*.jsonl", self.exclude_patterns)
+
+    def read_for_upload(self, path: Path) -> bytes | None:
+        """Trim partial trailing JSONL line so we never upload a half-written record."""
+        try:
+            data = path.read_bytes()
+        except OSError:
+            return None
+
+        if data and not data.endswith(b"\n"):
+            last_nl = data.rfind(b"\n")
+            if last_nl > 0:
+                data = data[: last_nl + 1]
+        return data
+
+    # ------------------------------------------------------------------ #
+    # Serialize                                                            #
+    # ------------------------------------------------------------------ #
+
+    def serialize(self, events: Iterable[Event]) -> bytes:
+        """Convert a stream of unified events to claude JSONL bytes.
+
+        Self-format round-trip is exact (modulo JSON key order). Cross-format
+        events are synthesized into claude-shaped rows; lossy.
+        """
+        out_lines: list[str] = []
+        seen_row_ids: set[str] = set()  # de-dup parent rows when sub-events share raw
+
+        for ev in events:
+            line = _serialize_event_for_claude(ev, seen_row_ids)
+            if line is not None:
+                out_lines.append(line)
+
+        return ("\n".join(out_lines) + ("\n" if out_lines else "")).encode("utf-8")
+
+    # ------------------------------------------------------------------ #
+    # Parse                                                                #
+    # ------------------------------------------------------------------ #
+
+    def parse(self, path: Path) -> Iterable[Event]:
+        """Yield unified Events. Never raises on malformed input.
+
+        We emit one event per *content block*, not per row, so an
+        assistant row with [text, tool_use, thinking] becomes three
+        Events sharing the same `parent_id` and a suffixed `id`.
+
+        Rows without a `uuid` (e.g. permission-mode, last-prompt) get
+        a synthesized id of `L{line_no}` so the (parent_id, id) chain
+        and the serializer's row-dedup logic both work.
+        """
+        first = True
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                for line_no, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        doc = json.loads(line)
+                    except json.JSONDecodeError as e:
+                        log.debug("claude.parse: skip malformed line %d in %s: %s", line_no, path, e)
+                        continue
+
+                    # Synthesize one SessionStart from the first row that
+                    # carries the metadata.
+                    if first and isinstance(doc, dict):
+                        first = False
+                        ss = _maybe_session_start(doc)
+                        if ss is not None:
+                            yield ss
+
+                    if not isinstance(doc, dict):
+                        continue
+                    yield from _parse_row(doc, line_no=line_no)
+        except OSError as e:
+            log.warning("claude.parse: cannot read %s: %s", path, e)
+            return
+
+
+# ------------------------------------------------------------------ #
+# Per-row dispatch                                                     #
+# ------------------------------------------------------------------ #
+
+
+def _maybe_session_start(doc: dict) -> Optional[SessionStart]:
+    """Return a SessionStart if the row carries enough session metadata."""
+    if not any(k in doc for k in ("cwd", "gitBranch", "version", "sessionId")):
+        return None
+    return SessionStart(
+        source="claude",
+        id=doc.get("sessionId"),
+        timestamp=doc.get("timestamp"),
+        cwd=doc.get("cwd"),
+        agent_version=doc.get("version"),
+        git_branch=doc.get("gitBranch"),
+        raw={},  # the SessionStart synthesis is deliberately metadata-only.
+        synthesized=True,  # don't re-emit on self-roundtrip
+    )
+
+
+def _parse_row(doc: dict, line_no: int = 0) -> Iterator[Event]:
+    common = _common_fields(doc, line_no=line_no)
+    rtype = doc.get("type", "")
+
+    if rtype == "user":
+        yield from _parse_user(doc, common)
+    elif rtype == "assistant":
+        yield from _parse_assistant(doc, common)
+    elif rtype == "system":
+        yield Lifecycle(name="system", **common)
+    elif rtype == "attachment":
+        yield from _parse_attachment_row(doc, common)
+    elif rtype == "last-prompt":
+        yield Lifecycle(name="last_prompt", **common)
+    elif rtype == "permission-mode":
+        # Claude's permission-mode rows record a user-driven mode change
+        # (default / acceptEdits / bypassPermissions / plan / etc.).
+        # That's a human-in-the-loop intervention → Operator.
+        yield Operator(
+            action="permission_mode",
+            detail=str(doc.get("permissionMode", "")),
+            metadata={k: v for k, v in doc.items() if k in ("permissionMode",)},
+            **common,
+        )
+    elif rtype == "ai-title":
+        yield Lifecycle(name="ai_title", **common)
+    elif rtype == "custom-title":
+        yield Lifecycle(name="custom_title", **common)
+    elif rtype == "agent-name":
+        yield Lifecycle(name="agent_name", **common)
+    elif rtype == "queue-operation":
+        yield Lifecycle(name="queue_operation", **common)
+    elif rtype == "pr-link":
+        yield Lifecycle(name="pr_link", **common)
+    elif rtype == "progress":
+        yield Lifecycle(name="progress", **common)
+    elif rtype == "file-history-snapshot":
+        yield from _parse_file_history(doc, common)
+    else:
+        yield OpaqueEvent(original_type=str(rtype), **common)
+
+
+def _common_fields(doc: dict, line_no: int = 0) -> dict[str, Any]:
+    # Prefer the row's uuid; fall back to a synthetic line id so events
+    # from rows that don't carry a uuid (permission-mode, file-history,
+    # etc.) still have a unique id for serializer dedup and tree-walking.
+    row_id = doc.get("uuid") or (f"L{line_no}" if line_no else None)
+    return {
+        "source": "claude",
+        "id": row_id,
+        "parent_id": doc.get("parentUuid"),
+        "timestamp": doc.get("timestamp"),
+        "raw": doc,
+    }
+
+
+def _sub_id(common: dict, idx: int) -> dict:
+    """Return a `common` with the id suffixed by `#idx` (0 → unchanged)."""
+    if idx == 0:
+        # First sub-event keeps the row's uuid for natural reference.
+        # Subsequent rows in the same row chain link to this one.
+        return common
+    return {**common, "id": f"{common.get('id') or ''}#{idx}"}
+
+
+# ------------------------------------------------------------------ #
+# user rows                                                            #
+# ------------------------------------------------------------------ #
+
+
+def _parse_user(doc: dict, common: dict) -> Iterator[Event]:
+    msg = doc.get("message") or {}
+    content = msg.get("content")
+
+    if isinstance(content, str):
+        yield UserMessage(text=content, **common)
+        return
+
+    if not isinstance(content, list):
+        # Unknown shape; preserve as opaque.
+        yield OpaqueEvent(original_type="user_unknown_content_shape", **common)
+        return
+
+    for i, block in enumerate(content):
+        if not isinstance(block, dict):
+            continue
+        bt = block.get("type")
+        sub_common = _sub_id(common, i)
+
+        if bt == "text":
+            yield UserMessage(text=block.get("text", ""), **sub_common)
+        elif bt == "tool_result":
+            output = _tool_result_to_text(block.get("content"))
+            yield ToolResult(
+                tool_call_id=block.get("tool_use_id", ""),
+                output=output,
+                is_error=bool(block.get("is_error", False)),
+                **sub_common,
+            )
+        elif bt == "image":
+            # User-attached image: model as Attachment with content (base64
+            # in claude's `source.data` field) or ref preserved in raw.
+            src = block.get("source") or {}
+            data = src.get("data") if isinstance(src, dict) else None
+            media = (src.get("media_type") if isinstance(src, dict) else None) or "image/png"
+            yield Attachment(
+                media_type=media,
+                content=data if isinstance(data, str) else None,
+                **sub_common,
+            )
+        else:
+            yield OpaqueEvent(original_type=f"user_block.{bt or 'unknown'}", **sub_common)
+
+
+def _tool_result_to_text(content: Any) -> str:
+    """Flatten a claude tool_result.content (string OR block list) into a single string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for b in content:
+            if isinstance(b, dict):
+                if b.get("type") == "text":
+                    parts.append(str(b.get("text", "")))
+                elif b.get("type") == "image":
+                    # Preserve a placeholder; the actual image bytes
+                    # live in raw on the parent event.
+                    parts.append("[image]")
+                else:
+                    parts.append(json.dumps(b, ensure_ascii=False))
+            else:
+                parts.append(str(b))
+        return "\n".join(parts)
+    return str(content)
+
+
+# ------------------------------------------------------------------ #
+# assistant rows                                                       #
+# ------------------------------------------------------------------ #
+
+
+def _parse_assistant(doc: dict, common: dict) -> Iterator[Event]:
+    msg = doc.get("message") or {}
+    content = msg.get("content") or []
+
+    if not isinstance(content, list):
+        yield OpaqueEvent(original_type="assistant_unknown_content_shape", **common)
+        return
+
+    for i, block in enumerate(content):
+        if not isinstance(block, dict):
+            continue
+        bt = block.get("type")
+        sub_common = _sub_id(common, i)
+
+        if bt == "text":
+            yield AssistantMessage(
+                text=block.get("text", ""),
+                model=msg.get("model"),
+                **sub_common,
+            )
+        elif bt == "thinking":
+            yield AssistantReasoning(text=block.get("thinking", ""), **sub_common)
+        elif bt == "tool_use":
+            yield ToolCall(
+                tool_call_id=block.get("id", ""),
+                name=block.get("name", ""),
+                input=block.get("input") or {},
+                **sub_common,
+            )
+        else:
+            yield OpaqueEvent(original_type=f"assistant_block.{bt or 'unknown'}", **sub_common)
+
+
+# ------------------------------------------------------------------ #
+# file-history-snapshot rows                                           #
+# ------------------------------------------------------------------ #
+
+
+def _has_substantive_raw(raw) -> bool:
+    """True when `raw` carries an actual source row, not just our
+    `_synth` annotation. The resumer pre-injects `_synth` metadata into
+    every event's raw so cross-source synthesis can read session-wide
+    context out of any row; that annotation alone shouldn't cause the
+    serializer to think there's a real row to emit."""
+    if not raw:
+        return False
+    return any(k != "_synth" for k in raw.keys())
+
+
+def _serialize_event_for_claude(ev: Event, seen_row_ids: set[str]) -> Optional[str]:
+    """Return one JSONL line for `ev`, or None to skip.
+
+    Decision matrix:
+      - source==claude, raw set      → emit raw (same-source roundtrip)
+      - source==claude, raw empty    → skip (parser-synthesized event;
+                                       no original row to reproduce)
+      - source!=claude               → synthesize a claude row (lossy
+                                       cross-format conversion)
+    """
+    if ev.source == "claude":
+        if ev.synthesized:
+            return None  # parser-synthesized view; no original row to emit
+        if not _has_substantive_raw(ev.raw):
+            # Same-source bare event (e.g. seeded into a SessionStore
+            # without raw context — raw is empty or only carries
+            # `_synth` metadata). Synthesize a native row from kernel
+            # fields so the data isn't lost.
+            return _synthesize_claude_cross_source(ev)
+        ev_id = str(ev.id or "")
+        if "#" in ev_id:
+            return None  # secondary block; row already emitted by primary
+        if ev_id in seen_row_ids:
+            return None  # defensive: same primary id seen twice
+        if ev_id:
+            seen_row_ids.add(ev_id)
+        return json.dumps(dict(ev.raw), ensure_ascii=False, separators=(",", ":"))
+
+    # Cross-source: synthesize a claude row. (Implemented in iteration 4
+    # alongside the cross-format tests.) For now, we fall back to
+    # emitting the event as a `system`-typed claude row carrying its
+    # source and raw payload — preserves data without crashing the
+    # claude reader.
+    return _synthesize_claude_cross_source(ev)
+
+
+def _synthesize_claude_cross_source(ev: Event) -> str:
+    """Produce a claude row from a non-claude unified event.
+
+    Field set is the union of what real claude sessions carry on
+    user/assistant rows (audited from production session files):
+    cwd, entrypoint, gitBranch, isSidechain, parentUuid, sessionId,
+    timestamp, type, userType, uuid, version, message.
+
+    `claude --resume <uuid>` expects a file at
+    `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` where every
+    row carries the matching `sessionId`. Cross-source-synthesized
+    rows propagate `_session_id` and `_cwd` from a SessionStart-shaped
+    Event when present (held in `raw["_synth"]`). Otherwise we fall
+    back to placeholders that won't crash the claude reader.
+    """
+    synth_meta = (ev.raw or {}).get("_synth", {}) if isinstance(ev.raw, dict) else {}
+    session_id = synth_meta.get("session_id") or ev.id or "00000000-0000-0000-0000-000000000000"
+    cwd = synth_meta.get("cwd") or "/tmp"
+    git_branch = synth_meta.get("git_branch") or ""
+    version = synth_meta.get("version") or "0.0.0-converted"
+
+    base = {
+        "uuid": ev.id or session_id,
+        "parentUuid": ev.parent_id,
+        "timestamp": ev.timestamp or "",
+        "sessionId": session_id,
+        "cwd": cwd,
+        "gitBranch": git_branch,
+        "version": version,
+        "entrypoint": "converted",
+        "isSidechain": False,
+        "userType": "external",
+    }
+
+    if ev.type == "user_message":
+        return json.dumps({**base, "type": "user", "message": {
+            "role": "user", "content": getattr(ev, "text", "")
+        }}, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "assistant_message":
+        text = getattr(ev, "text", "")
+        return json.dumps({**base, "type": "assistant", "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+        }}, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "assistant_reasoning":
+        text = getattr(ev, "text", None) or ""
+        return json.dumps({**base, "type": "assistant", "message": {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": text}],
+        }}, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "tool_call":
+        return json.dumps({**base, "type": "assistant", "message": {
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": getattr(ev, "tool_call_id", ""),
+                "name": getattr(ev, "name", ""),
+                "input": getattr(ev, "input", {}) or {},
+            }],
+        }}, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "tool_result":
+        return json.dumps({**base, "type": "user", "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": getattr(ev, "tool_call_id", ""),
+                "content": getattr(ev, "output", "") or "",
+                "is_error": getattr(ev, "is_error", False),
+            }],
+        }}, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "session_start":
+        # No claude row type cleanly maps to "session start". Emit a
+        # `system` row carrying the metadata so the data isn't lost.
+        cwd = getattr(ev, "cwd", None)
+        version = getattr(ev, "agent_version", None)
+        return json.dumps({**base, "type": "system",
+                           "content": f"[converted from {ev.source}] cwd={cwd} agent={version}"
+                           }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "lifecycle":
+        # Many lifecycle events map to claude top-level types. For
+        # now, fall back to `system` with a description.
+        name = getattr(ev, "name", "")
+        return json.dumps({**base, "type": "system",
+                           "content": f"[converted from {ev.source}] {name}"
+                           }, ensure_ascii=False, separators=(",", ":"))
+
+    # Everything else: a no-op `system` row so cross-format converted
+    # files still parse on the claude side.
+    return json.dumps({**base, "type": "system",
+                       "content": f"[converted from {ev.source}] {ev.type}"
+                       }, ensure_ascii=False, separators=(",", ":"))
+
+
+def _parse_attachment_row(doc: dict, common: dict) -> Iterator[Event]:
+    """Claude's `attachment` rows describe a file or image the user attached
+    to the conversation. Shape varies; we extract media_type + name + ref
+    where present and preserve everything else in raw."""
+    att = doc.get("attachment") or {}
+    if not isinstance(att, dict):
+        # Attachment row without a structured payload: fall back to a
+        # bare Attachment (raw still has the original).
+        yield Attachment(media_type="application/octet-stream", **common)
+        return
+
+    media_type = (
+        att.get("type")
+        or att.get("media_type")
+        or att.get("mimeType")
+        or "application/octet-stream"
+    )
+    name = att.get("name") or att.get("path") or att.get("filename")
+    ref = att.get("path") or att.get("url") or att.get("ref")
+    content = att.get("data") if isinstance(att.get("data"), str) else None
+    yield Attachment(
+        media_type=str(media_type),
+        name=str(name) if name else None,
+        ref=str(ref) if ref else None,
+        content=content,
+        **common,
+    )
+
+
+def _parse_file_history(doc: dict, common: dict) -> Iterator[Event]:
+    """Each row may snapshot one or many files. Emit one FileEdit per file."""
+    snapshot = doc.get("snapshot")
+    if isinstance(snapshot, dict):
+        # Single-file shape.
+        path = snapshot.get("path") or snapshot.get("filePath") or ""
+        yield FileEdit(
+            path=str(path),
+            diff=snapshot.get("diff"),
+            pre_content=snapshot.get("pre"),
+            post_content=snapshot.get("post"),
+            **common,
+        )
+        return
+
+    if isinstance(snapshot, list):
+        for i, item in enumerate(snapshot):
+            if not isinstance(item, dict):
+                continue
+            sub_common = _sub_id(common, i)
+            path = item.get("path") or item.get("filePath") or ""
+            yield FileEdit(
+                path=str(path),
+                diff=item.get("diff"),
+                pre_content=item.get("pre"),
+                post_content=item.get("post"),
+                **sub_common,
+            )
+        return
+
+    # No snapshot field — emit Lifecycle as fallback so the row isn't lost.
+    yield Lifecycle(name="file_history_snapshot", **common)

--- a/fleet/track/sources/codex.py
+++ b/fleet/track/sources/codex.py
@@ -57,7 +57,7 @@ from ..unified import (
     TurnStart,
     UserMessage,
 )
-from .base import Source, _walk_glob
+from .base import Source, _walk_glob, has_substantive_raw
 
 log = logging.getLogger("fleet.track.sources.codex")
 
@@ -660,14 +660,6 @@ def _mcp_content_to_text(content: Any) -> str:
     return "\n".join(parts)
 
 
-def _has_substantive_raw(raw) -> bool:
-    """Same logic as claude's: raw carrying only `_synth` metadata is
-    treated as if empty (the resumer pre-injects `_synth` on every event)."""
-    if not raw:
-        return False
-    return any(k != "_synth" for k in raw.keys())
-
-
 def _serialize_event_for_codex(ev: Event, seen: set[str]) -> Optional[str]:
     """Return one codex JSONL line for `ev`, or None to skip.
 
@@ -677,7 +669,7 @@ def _serialize_event_for_codex(ev: Event, seen: set[str]) -> Optional[str]:
     if ev.source == "codex":
         if ev.synthesized:
             return None
-        if not _has_substantive_raw(ev.raw):
+        if not has_substantive_raw(ev.raw):
             # Same-source bare event (e.g. seeded into a SessionStore
             # without raw context, or raw carrying only `_synth`).
             return _synthesize_codex_cross_source(ev)

--- a/fleet/track/sources/codex.py
+++ b/fleet/track/sources/codex.py
@@ -1,0 +1,850 @@
+"""CodexSource — `~/.codex/{sessions,archived_sessions}/**/*.jsonl`.
+
+Format notes (cataloged from real session files):
+
+  Each row: {type, timestamp, payload}.
+
+  Top-level types:
+    - `session_meta`   — start of file (cwd, cli_version, etc.)
+    - `turn_context`   — per-turn config (cwd, model, sandbox, system prompt)
+    - `response_item`  — wire-level OpenAI Response API events
+    - `event_msg`      — UX-level streamed events (overlap with response_item)
+
+  response_item.payload.type values:
+    - `message`              — role + content blocks
+    - `function_call`        — tool call (name, arguments JSON, call_id)
+    - `function_call_output` — tool result (call_id, output)
+    - `reasoning`            — encrypted reasoning blob
+    - `custom_tool_call`(_output) — user-defined tools
+    - `web_search_call`(_end)     — web search
+
+  event_msg.payload.type values:
+    - `user_message`         — input text + images
+    - `agent_message`        — visible assistant text (with phase)
+    - `agent_reasoning`      — visible reasoning text
+    - `task_started`/_complete/_aborted  — turn lifecycle
+    - `token_count`          — usage + rate limits
+    - `exec_command_end`     — shell tool result with exit_code, duration
+    - `web_search_end`, `patch_apply_end`, `thread_name_updated`, `error`
+
+  Note that response_item and event_msg often duplicate the same
+  conceptual event (e.g. response_item.message vs event_msg.agent_message).
+  We emit BOTH on parse — round-trip integrity requires it. Cross-format
+  conversion to claude prefers the response_item layer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+from ..unified import (
+    AssistantMessage,
+    AssistantReasoning,
+    Attachment,
+    Event,
+    FileEdit,
+    Lifecycle,
+    Operator,
+    OpaqueEvent,
+    SessionStart,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+    TurnEnd,
+    TurnStart,
+    UserMessage,
+)
+from .base import Source, _walk_glob
+
+log = logging.getLogger("fleet.track.sources.codex")
+
+
+class CodexSource(Source):
+    name = "codex"
+
+    @property
+    def root(self) -> Path:
+        return self._home / ".codex"
+
+    def iter_files(self) -> Iterator[Path]:
+        sessions = self._home / ".codex" / "sessions"
+        archived = self._home / ".codex" / "archived_sessions"
+        yield from _walk_glob(sessions, "**/*.jsonl", self.exclude_patterns)
+        yield from _walk_glob(archived, "**/*.jsonl", self.exclude_patterns)
+
+    def is_present(self) -> bool:
+        sessions = self._home / ".codex" / "sessions"
+        archived = self._home / ".codex" / "archived_sessions"
+        return sessions.is_dir() or archived.is_dir()
+
+    def read_for_upload(self, path: Path) -> bytes | None:
+        try:
+            data = path.read_bytes()
+        except OSError:
+            return None
+
+        if data and not data.endswith(b"\n"):
+            last_nl = data.rfind(b"\n")
+            if last_nl > 0:
+                data = data[: last_nl + 1]
+        return data
+
+    # ------------------------------------------------------------------ #
+    # Parse                                                                #
+    # ------------------------------------------------------------------ #
+
+    def parse(self, path: Path) -> Iterable[Event]:
+        # Per-file state: codex's `model`, `approval_policy`, and
+        # `sandbox_policy` are set in each `turn_context` row but apply
+        # to subsequent rows until a new turn_context overrides them.
+        # Tracking them lets us populate AssistantMessage.model and
+        # emit Operator events when approval/sandbox change mid-session.
+        state: dict[str, Any] = {
+            "model": None,
+            "approval_policy": None,
+            "sandbox_policy": None,
+            "provider": None,  # set from session_meta.model_provider
+        }
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                for line_no, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        doc = json.loads(line)
+                    except json.JSONDecodeError as e:
+                        log.debug("codex.parse: skip malformed line %d in %s: %s", line_no, path, e)
+                        continue
+                    if not isinstance(doc, dict):
+                        continue
+                    yield from _parse_row(doc, line_no=line_no, state=state)
+        except OSError as e:
+            log.warning("codex.parse: cannot read %s: %s", path, e)
+            return
+
+    # ------------------------------------------------------------------ #
+    # Serialize                                                            #
+    # ------------------------------------------------------------------ #
+
+    def serialize(self, events: Iterable[Event]) -> bytes:
+        """Convert unified events to codex JSONL bytes.
+
+        Same-source: emit raw verbatim (deduped per row).
+        Cross-source: synthesize codex-shaped rows. Lossy.
+        """
+        out_lines: list[str] = []
+        seen: set[str] = set()
+        for ev in events:
+            line = _serialize_event_for_codex(ev, seen)
+            if line is not None:
+                out_lines.append(line)
+        return ("\n".join(out_lines) + ("\n" if out_lines else "")).encode("utf-8")
+
+
+# ------------------------------------------------------------------ #
+# Per-row dispatch                                                     #
+# ------------------------------------------------------------------ #
+
+
+def _parse_row(doc: dict, line_no: int = 0, state: Optional[dict] = None) -> Iterator[Event]:
+    rtype = doc.get("type")
+    timestamp = doc.get("timestamp")
+    payload = doc.get("payload") or {}
+    common: dict[str, Any] = {
+        "source": "codex",
+        "timestamp": timestamp,
+        "raw": doc,
+    }
+    line_id = f"L{line_no}" if line_no else None
+    if state is None:
+        state = {"model": None, "approval_policy": None,
+                 "sandbox_policy": None, "provider": None}
+
+    if rtype == "session_meta":
+        # Pull the provider out of the meta so subsequent token_count
+        # events can be tagged with it.
+        state["provider"] = payload.get("model_provider") or state["provider"]
+        yield SessionStart(
+            id=line_id,
+            cwd=payload.get("cwd"),
+            agent_version=payload.get("cli_version"),
+            user_instructions=_extract_text(payload.get("base_instructions")),
+            **common,
+        )
+        return
+
+    if rtype == "turn_context":
+        # Update tracked state. Then emit TurnStart, plus an Operator
+        # event if approval_policy or sandbox_policy actually changed
+        # from the previous turn (i.e. the user toggled a permission).
+        new_model = payload.get("model")
+        new_approval = payload.get("approval_policy")
+        new_sandbox = payload.get("sandbox_policy")
+
+        prev_approval = state.get("approval_policy")
+        prev_sandbox = state.get("sandbox_policy")
+
+        if new_model is not None:
+            state["model"] = new_model
+        if new_approval is not None:
+            state["approval_policy"] = new_approval
+        if new_sandbox is not None:
+            state["sandbox_policy"] = new_sandbox
+
+        yield TurnStart(
+            id=line_id,
+            turn_id=payload.get("turn_id"),
+            cwd=payload.get("cwd"),
+            model=new_model,
+            **common,
+        )
+
+        # Detect explicit policy changes mid-session. We only emit on
+        # actual change (not the first turn_context, where prev is None).
+        if prev_approval is not None and new_approval and new_approval != prev_approval:
+            # Parser-derived (no native row to round-trip back to) →
+            # `synthesized=True` so serialize skips on self-roundtrip.
+            # Cross-format converters still see and re-emit the event.
+            yield Operator(
+                source="codex",
+                id=f"{line_id}#approval" if line_id else None,
+                timestamp=timestamp,
+                raw={},
+                synthesized=True,
+                action="approval_policy",
+                detail=str(new_approval),
+                metadata={"previous": prev_approval, "current": new_approval},
+            )
+        if prev_sandbox is not None and new_sandbox and new_sandbox != prev_sandbox:
+            yield Operator(
+                source="codex",
+                id=f"{line_id}#sandbox" if line_id else None,
+                timestamp=timestamp,
+                raw={},
+                synthesized=True,
+                action="sandbox_policy",
+                detail=_sandbox_label(new_sandbox),
+                metadata={"previous": prev_sandbox, "current": new_sandbox},
+            )
+        return
+
+    if rtype == "response_item":
+        yield from _parse_response_item(payload, common, line_id, state)
+        return
+
+    if rtype == "event_msg":
+        yield from _parse_event_msg(payload, common, line_id, state)
+        return
+
+    if rtype == "compacted":
+        # Top-level context-compaction event. Carries `replacement_history`
+        # — a fresh conversation list that supersedes everything before it.
+        # Surfacing as a single Lifecycle event (with raw preserving the
+        # full history) is the honest representation; consumers that
+        # want to "replay" can re-parse from raw["payload"]["replacement_history"].
+        yield Lifecycle(name="context_compacted", id=line_id, **common)
+        return
+
+    yield OpaqueEvent(original_type=str(rtype) if rtype else "unknown", id=line_id, **common)
+
+
+# ------------------------------------------------------------------ #
+# response_item                                                        #
+# ------------------------------------------------------------------ #
+
+
+def _parse_response_item(
+    payload: dict, common: dict, line_id: Optional[str], state: dict
+) -> Iterator[Event]:
+    ptype = payload.get("type")
+
+    if ptype == "message":
+        role = payload.get("role")
+        text = _message_content_to_text(payload.get("content"))
+        if role in ("user", "developer", "system"):
+            yield UserMessage(id=line_id, text=text, **common)
+        else:
+            yield AssistantMessage(
+                id=line_id, text=text, model=state.get("model"), **common,
+            )
+        return
+
+    if ptype == "function_call":
+        call_id = payload.get("call_id", "")
+        args_str = payload.get("arguments") or "{}"
+        yield ToolCall(
+            id=line_id,  # row-unique; tool_call_id is semantic
+            tool_call_id=call_id,
+            name=payload.get("name", ""),
+            input=_safe_json_object(args_str),
+            **common,
+        )
+        return
+
+    if ptype == "function_call_output":
+        call_id = payload.get("call_id", "")
+        yield ToolResult(
+            # Both function_call and function_call_output carry the same
+            # call_id but live on different rows. Disambiguate via the
+            # row's line id — keep call_id as a tag, but make the event id
+            # row-unique so the serializer doesn't dedup the pair into one.
+            id=line_id,
+            tool_call_id=call_id,
+            output=str(payload.get("output", "")),
+            **common,
+        )
+        return
+
+    if ptype == "reasoning":
+        yield AssistantReasoning(
+            id=line_id,
+            text=_summary_to_text(payload.get("summary")),
+            encrypted=bool(payload.get("encrypted_content")),
+            encrypted_content=payload.get("encrypted_content"),
+            **common,
+        )
+        return
+
+    if ptype in ("custom_tool_call", "web_search_call", "tool_search_call"):
+        call_id = payload.get("id") or payload.get("call_id") or ""
+        raw_input = (
+            payload.get("input")
+            or payload.get("action")
+            or payload.get("arguments")
+            or {}
+        )
+        if isinstance(raw_input, str):
+            raw_input = _safe_json_object(raw_input)
+        yield ToolCall(
+            id=line_id,  # row-unique
+            tool_call_id=call_id,
+            name=str(payload.get("name", ptype)),
+            input=raw_input if isinstance(raw_input, dict) else {"value": raw_input},
+            **common,
+        )
+        return
+
+    if ptype in ("custom_tool_call_output", "web_search_call_output", "tool_search_output"):
+        call_id = payload.get("call_id") or payload.get("id") or ""
+        out = (
+            payload.get("output")
+            or payload.get("result")
+            or json.dumps(payload.get("tools", []), ensure_ascii=False)
+        )
+        yield ToolResult(
+            id=line_id,  # row-unique; tool_call_id keeps the original
+            tool_call_id=call_id,
+            output=str(out),
+            **common,
+        )
+        return
+
+    if ptype == "compacted":
+        yield Lifecycle(name="context_compacted", id=line_id, **common)
+        return
+
+    yield OpaqueEvent(
+        original_type=f"response_item.{ptype or 'unknown'}",
+        id=line_id,
+        **common,
+    )
+
+
+def _message_content_to_text(content: Any) -> str:
+    """Flatten a response_item.message.content list into plain text."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            parts.append(str(block))
+            continue
+        bt = block.get("type")
+        if bt in ("input_text", "output_text", "text"):
+            parts.append(str(block.get("text", "")))
+        elif bt == "input_image":
+            parts.append("[image]")
+        else:
+            parts.append(json.dumps(block, ensure_ascii=False))
+    return "\n".join(parts)
+
+
+def _summary_to_text(summary: Any) -> Optional[str]:
+    """codex reasoning has summary: list of {type, text} blocks. None if empty."""
+    if not summary:
+        return None
+    if isinstance(summary, str):
+        return summary
+    if isinstance(summary, list):
+        parts = []
+        for s in summary:
+            if isinstance(s, dict) and "text" in s:
+                parts.append(str(s["text"]))
+            else:
+                parts.append(str(s))
+        return "\n".join(parts) if parts else None
+    return str(summary)
+
+
+def _sandbox_label(policy: Any) -> str:
+    """codex sandbox_policy is `{type: "danger-full-access" | ...}` or similar.
+    Pull a short string for the Operator detail field."""
+    if isinstance(policy, dict):
+        return str(policy.get("type") or "")
+    return str(policy or "")
+
+
+def _image_media_type(image: Any) -> str:
+    """Best-effort media type for an inline image. codex emits base64
+    strings without prefixes most of the time, so we fall back to png."""
+    if isinstance(image, str) and image.startswith("data:"):
+        sep = image.find(";")
+        if sep > 5:
+            return image[5:sep]
+    return "image/png"
+
+
+def _image_media_type_from_path(path: Any) -> str:
+    if not isinstance(path, str):
+        return "image/png"
+    p = path.lower()
+    if p.endswith(".png"):
+        return "image/png"
+    if p.endswith(".jpg") or p.endswith(".jpeg"):
+        return "image/jpeg"
+    if p.endswith(".gif"):
+        return "image/gif"
+    if p.endswith(".webp"):
+        return "image/webp"
+    return "image/png"
+
+
+def _extract_text(value: Any) -> Optional[str]:
+    """Extract a string from a value that's either str, None, or {'text': str}.
+
+    codex `base_instructions` and a few other fields use the `{text: ...}`
+    wrapper inconsistently. Tolerate both shapes."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        t = value.get("text")
+        if isinstance(t, str):
+            return t
+    return None
+
+
+def _safe_json_object(s: Any) -> dict:
+    """Parse a JSON string as a dict; return {} on failure or non-dict."""
+    if isinstance(s, dict):
+        return s
+    if not isinstance(s, str):
+        return {}
+    try:
+        v = json.loads(s)
+        return v if isinstance(v, dict) else {"value": v}
+    except json.JSONDecodeError:
+        return {}
+
+
+# ------------------------------------------------------------------ #
+# event_msg                                                            #
+# ------------------------------------------------------------------ #
+
+
+def _parse_event_msg(
+    payload: dict, common: dict, line_id: Optional[str], state: dict
+) -> Iterator[Event]:
+    ptype = payload.get("type")
+
+    if ptype == "user_message":
+        yield UserMessage(id=line_id, text=str(payload.get("message", "")), **common)
+        # codex carries attached images alongside the message itself in
+        # `images` (inline) and `local_image_paths` (refs). Surface each
+        # as its own Attachment so consumers see them as first-class.
+        # synthesized=True because the original codex row holds them
+        # inline; we don't want self-roundtrip to emit duplicates.
+        for i, image in enumerate(payload.get("images") or []):
+            yield Attachment(
+                source="codex",
+                id=f"{line_id}#img{i}" if line_id else None,
+                timestamp=common.get("timestamp"),
+                raw={},
+                synthesized=True,
+                media_type=_image_media_type(image),
+                content=image if isinstance(image, str) else None,
+            )
+        for i, path in enumerate(payload.get("local_image_paths") or []):
+            yield Attachment(
+                source="codex",
+                id=f"{line_id}#imgref{i}" if line_id else None,
+                timestamp=common.get("timestamp"),
+                raw={},
+                synthesized=True,
+                media_type=_image_media_type_from_path(path),
+                ref=str(path),
+                name=str(path).split("/")[-1] if path else None,
+            )
+        return
+
+    if ptype == "agent_message":
+        yield AssistantMessage(
+            id=line_id,
+            text=str(payload.get("message", "")),
+            phase=payload.get("phase"),
+            model=state.get("model"),
+            **common,
+        )
+        return
+
+    if ptype == "agent_reasoning":
+        yield AssistantReasoning(
+            id=line_id,
+            text=str(payload.get("text", "")),
+            encrypted=False,
+            **common,
+        )
+        return
+
+    if ptype == "task_started":
+        yield TurnStart(id=line_id, turn_id=payload.get("turn_id"), **common)
+        return
+
+    if ptype == "task_complete":
+        yield TurnEnd(id=line_id, turn_id=payload.get("turn_id"), **common)
+        return
+
+    if ptype == "turn_aborted":
+        yield TurnEnd(id=line_id, turn_id=payload.get("turn_id"), aborted=True, **common)
+        return
+
+    if ptype == "token_count":
+        info = payload.get("info") or {}
+        last_token_usage = info.get("last_token_usage") or {}
+        total_token_usage = info.get("total_token_usage") or {}
+        usage = last_token_usage or total_token_usage or {}
+        yield TokenUsage(
+            id=line_id,
+            input_tokens=usage.get("input_tokens"),
+            output_tokens=usage.get("output_tokens"),
+            cache_read_tokens=usage.get("cached_input_tokens"),
+            total_tokens=usage.get("total_tokens"),
+            provider=state.get("provider") or "openai",
+            **common,
+        )
+        return
+
+    if ptype == "exec_command_end":
+        call_id = payload.get("call_id", "")
+        yield ToolResult(
+            id=line_id,
+            tool_call_id=call_id,
+            output=str(payload.get("formatted_output") or payload.get("output") or ""),
+            exit_code=payload.get("exit_code"),
+            duration_ms=_extract_duration_ms(payload),
+            **common,
+        )
+        return
+
+    if ptype == "patch_apply_end":
+        yield Lifecycle(name="patch_apply_end", id=line_id, **common)
+        return
+
+    if ptype == "web_search_end":
+        yield ToolResult(
+            id=line_id,
+            tool_call_id=payload.get("call_id", ""),
+            output=str(payload.get("output") or ""),
+            **common,
+        )
+        return
+
+    if ptype == "thread_name_updated":
+        yield Lifecycle(name="thread_name_updated", id=line_id, **common)
+        return
+
+    if ptype == "error":
+        yield Lifecycle(name="error", id=line_id, **common)
+        return
+
+    if ptype == "context_compacted":
+        yield Lifecycle(name="context_compacted", id=line_id, **common)
+        return
+
+    if ptype == "mcp_tool_call_end":
+        call_id = payload.get("call_id", "")
+        result = payload.get("result") or {}
+        if isinstance(result, dict):
+            ok = result.get("Ok") or result.get("ok") or {}
+            err = result.get("Err") or result.get("err")
+            content = ok.get("content") if isinstance(ok, dict) else None
+            output_text = _mcp_content_to_text(content) if content else json.dumps(result, ensure_ascii=False)
+            is_error = bool(err)
+        else:
+            output_text = str(result)
+            is_error = False
+        yield ToolResult(
+            id=line_id,
+            tool_call_id=call_id,
+            output=output_text,
+            is_error=is_error,
+            duration_ms=_extract_duration_ms(payload),
+            **common,
+        )
+        return
+
+    if ptype == "collab_agent_spawn_end":
+        call_id = payload.get("call_id", "")
+        yield ToolCall(
+            id=line_id,
+            tool_call_id=call_id,
+            name=f"collab_agent.{payload.get('new_agent_role', 'agent')}",
+            input={
+                "agent_nickname": payload.get("new_agent_nickname"),
+                "agent_role": payload.get("new_agent_role"),
+                "thread_id": payload.get("new_thread_id"),
+                "prompt": payload.get("prompt"),
+            },
+            **common,
+        )
+        return
+
+    if ptype == "collab_waiting_end":
+        call_id = payload.get("call_id", "")
+        statuses = payload.get("agent_statuses") or []
+        yield ToolResult(
+            id=line_id,
+            tool_call_id=call_id,
+            output=json.dumps(statuses, ensure_ascii=False),
+            **common,
+        )
+        return
+
+    if ptype == "collab_close_end":
+        call_id = payload.get("call_id", "")
+        status = payload.get("status") or {}
+        if isinstance(status, dict):
+            done_text = status.get("completed") or status.get("aborted") or json.dumps(status, ensure_ascii=False)
+        else:
+            done_text = str(status)
+        yield ToolResult(
+            id=line_id,
+            tool_call_id=call_id,
+            output=str(done_text),
+            **common,
+        )
+        return
+
+    yield OpaqueEvent(original_type=f"event_msg.{ptype or 'unknown'}", id=line_id, **common)
+
+
+def _mcp_content_to_text(content: Any) -> str:
+    """Flatten an MCP result.content list into a single string."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+    parts: list[str] = []
+    for b in content:
+        if isinstance(b, dict) and b.get("type") == "text":
+            parts.append(str(b.get("text", "")))
+        else:
+            parts.append(json.dumps(b, ensure_ascii=False))
+    return "\n".join(parts)
+
+
+def _has_substantive_raw(raw) -> bool:
+    """Same logic as claude's: raw carrying only `_synth` metadata is
+    treated as if empty (the resumer pre-injects `_synth` on every event)."""
+    if not raw:
+        return False
+    return any(k != "_synth" for k in raw.keys())
+
+
+def _serialize_event_for_codex(ev: Event, seen: set[str]) -> Optional[str]:
+    """Return one codex JSONL line for `ev`, or None to skip.
+
+    Decision matrix matches claude's: same-source emits raw, same-source
+    synthesized events skip, cross-source synthesizes.
+    """
+    if ev.source == "codex":
+        if ev.synthesized:
+            return None
+        if not _has_substantive_raw(ev.raw):
+            # Same-source bare event (e.g. seeded into a SessionStore
+            # without raw context, or raw carrying only `_synth`).
+            return _synthesize_codex_cross_source(ev)
+        ev_id = str(ev.id or "")
+        if ev_id and ev_id in seen:
+            return None
+        if ev_id:
+            seen.add(ev_id)
+        return json.dumps(dict(ev.raw), ensure_ascii=False, separators=(",", ":"))
+
+    return _synthesize_codex_cross_source(ev)
+
+
+def _synthesize_codex_cross_source(ev: Event) -> Optional[str]:
+    """Produce a codex row from a non-codex unified event.
+
+    Codex's two-layer (response_item / event_msg) shape gives us choice;
+    we project to the wire-level `response_item` layer because that's
+    what codex actually replays from. Events that don't map to a codex
+    response_item kind are emitted as `event_msg.error` lifecycle rows
+    so the file still parses.
+    """
+    timestamp = ev.timestamp or ""
+
+    if ev.type == "user_message":
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {"type": "message", "role": "user",
+                        "content": [{"type": "input_text", "text": getattr(ev, "text", "")}]},
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "assistant_message":
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {"type": "message", "role": "assistant",
+                        "content": [{"type": "output_text", "text": getattr(ev, "text", "")}]},
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "assistant_reasoning":
+        # Plaintext reasoning fits the response_item.reasoning shape via
+        # `summary`; encrypted content is preserved in `encrypted_content`.
+        text = getattr(ev, "text", None)
+        encrypted = getattr(ev, "encrypted_content", None)
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {"type": "reasoning",
+                        "summary": [{"type": "summary_text", "text": text}] if text else [],
+                        "encrypted_content": encrypted,
+                        },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "tool_call":
+        import json as _j
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {"type": "function_call",
+                        "call_id": getattr(ev, "tool_call_id", ""),
+                        "name": getattr(ev, "name", ""),
+                        "arguments": _j.dumps(getattr(ev, "input", {}) or {}, ensure_ascii=False),
+                        },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "tool_result":
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {"type": "function_call_output",
+                        "call_id": getattr(ev, "tool_call_id", ""),
+                        "output": getattr(ev, "output", "") or "",
+                        },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "session_start":
+        synth = (ev.raw or {}).get("_synth", {}) if isinstance(ev.raw, dict) else {}
+        # codex resume requires a UUID; if the source's id wasn't a UUID
+        # the converter pre-injects one in synth.session_id.
+        session_id = synth.get("session_id") or ev.id or ""
+        cwd = synth.get("cwd") or getattr(ev, "cwd", None) or "/tmp"
+        # codex's thread-store deserializes session_meta into a strict
+        # struct and 400s on `does not start with session metadata` when
+        # required keys are missing. The fields below are the ones real
+        # codex sessions carry on session_meta.payload.
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "timestamp": timestamp,  # nested duplicate is required
+                "cwd": cwd,
+                "originator": "codex_cli_rs",  # match a known originator
+                "cli_version": getattr(ev, "agent_version", None) or synth.get("version") or "0.0.0",
+                "source": "cli",  # the *kind* of run; "cli" is what real sessions emit
+                "model_provider": "openai",
+                # codex's deserializer requires {text: "..."}; a plain
+                # string here trips "does not start with session metadata".
+                "base_instructions": {"text": getattr(ev, "user_instructions", None)
+                                              or "You are an assistant."},
+            },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type in ("turn_start",):
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "turn_context",
+            "payload": {"turn_id": getattr(ev, "turn_id", "") or ev.id or "",
+                        "cwd": getattr(ev, "cwd", None),
+                        "model": getattr(ev, "model", None),
+                        },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "turn_end":
+        ptype = "turn_aborted" if getattr(ev, "aborted", False) else "task_complete"
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {"type": ptype,
+                        "turn_id": getattr(ev, "turn_id", "") or ev.id or "",
+                        },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    if ev.type == "token_usage":
+        return json.dumps({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {"type": "token_count",
+                        "info": {"last_token_usage": {
+                            "input_tokens": getattr(ev, "input_tokens", None),
+                            "output_tokens": getattr(ev, "output_tokens", None),
+                            "cached_input_tokens": getattr(ev, "cache_read_tokens", None),
+                            "total_tokens": getattr(ev, "total_tokens", None),
+                        }},
+                        },
+        }, ensure_ascii=False, separators=(",", ":"))
+
+    # Lifecycle / opaque / file_edit / session_end fall through to a
+    # generic event_msg row carrying the cross-source name so a codex
+    # reader can ignore it gracefully.
+    name = getattr(ev, "name", None) or getattr(ev, "original_type", None) or ev.type
+    return json.dumps({
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {"type": "thread_name_updated",
+                    "thread_name": f"[converted from {ev.source}] {name}"},
+    }, ensure_ascii=False, separators=(",", ":"))
+
+
+def _extract_duration_ms(payload: dict) -> Optional[int]:
+    """Try a couple of possible field shapes."""
+    if "duration_ms" in payload:
+        try:
+            return int(payload["duration_ms"])
+        except (ValueError, TypeError):
+            return None
+    duration = payload.get("duration")
+    if isinstance(duration, (int, float)):
+        return int(duration * 1000) if duration < 1e6 else int(duration)
+    if isinstance(duration, dict):
+        # Common shape: {"secs": int, "nanos": int}
+        secs = duration.get("secs")
+        nanos = duration.get("nanos", 0)
+        if secs is not None:
+            try:
+                return int(secs) * 1000 + int(nanos) // 1_000_000
+            except (ValueError, TypeError):
+                return None
+    return None

--- a/fleet/track/sources/cursor.py
+++ b/fleet/track/sources/cursor.py
@@ -1,0 +1,42 @@
+"""CursorSource — `~/.cursor/projects/**/agent-transcripts/**/*.{jsonl,txt}`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+from .base import Source, _walk_glob
+
+
+class CursorSource(Source):
+    name = "cursor"
+
+    @property
+    def root(self) -> Path:
+        return self._home / ".cursor" / "projects"
+
+    def iter_files(self) -> Iterator[Path]:
+        # Cursor sessions live in two extensions side-by-side. Earlier
+        # implementations split this across two pseudo-sources ("cursor"
+        # and "cursor_txt") so the flat list could express it; the class
+        # form simply yields both in one stream.
+        yield from _walk_glob(
+            self.root, "**/agent-transcripts/**/*.jsonl", self.exclude_patterns
+        )
+        yield from _walk_glob(
+            self.root, "**/agent-transcripts/**/*.txt", self.exclude_patterns
+        )
+
+    def read_for_upload(self, path: Path) -> bytes | None:
+        try:
+            data = path.read_bytes()
+        except OSError:
+            return None
+
+        # JSONL trim only applies to .jsonl files; .txt is human-flat,
+        # uploaded as-is.
+        if path.suffix == ".jsonl" and data and not data.endswith(b"\n"):
+            last_nl = data.rfind(b"\n")
+            if last_nl > 0:
+                data = data[: last_nl + 1]
+        return data

--- a/fleet/track/status.py
+++ b/fleet/track/status.py
@@ -1,0 +1,88 @@
+"""PID file and status.json management.
+
+status.json is the IPC primitive between the daemon, CLI, and menubar.
+Written atomically (write-to-tmp then rename) to avoid partial reads.
+
+All paths flow through `TrackPaths` so tests can target a tmp dir.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+from .paths import TrackPaths
+
+STATUS_SCHEMA_VERSION = 1
+
+
+@dataclass
+class TrackStatus:
+    pid: int = 0
+    state: str = "idle"          # idle | syncing | error
+    last_sync: Optional[str] = None
+    queue_depth: int = 0
+    files_total: int = 0
+    files_synced: int = 0
+    bytes_uploaded_session: int = 0
+    errors: list[str] = field(default_factory=list)
+    sources: dict = field(default_factory=dict)
+    updated_at: str = ""
+    schema_version: int = STATUS_SCHEMA_VERSION
+
+
+def write_pid(paths: TrackPaths) -> None:
+    paths.ensure_track_dir()
+    paths.pid_file.write_text(str(os.getpid()))
+
+
+def clear_pid(paths: TrackPaths) -> None:
+    paths.pid_file.unlink(missing_ok=True)
+
+
+def is_running(paths: TrackPaths) -> bool:
+    """Return True if a daemon process is alive."""
+    if not paths.pid_file.exists():
+        return False
+    try:
+        pid = int(paths.pid_file.read_text().strip())
+        os.kill(pid, 0)  # signal 0 = existence check
+        return True
+    except (ValueError, ProcessLookupError, PermissionError):
+        return False
+
+
+def write_status(paths: TrackPaths, status: TrackStatus) -> None:
+    paths.ensure_track_dir()
+    status.updated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    data = json.dumps(asdict(status), indent=2)
+
+    # Atomic write: tmp file in same dir → rename.
+    fd, tmp = tempfile.mkstemp(dir=paths.track_dir, prefix=".status-", suffix=".json")
+    try:
+        os.write(fd, data.encode())
+        os.close(fd)
+        fd = -1  # mark closed so the except block doesn't double-close
+        os.replace(tmp, paths.status_file)
+    except Exception:
+        if fd != -1:
+            os.close(fd)
+        os.unlink(tmp)
+        raise
+
+
+def read_status(paths: TrackPaths) -> Optional[TrackStatus]:
+    if not paths.status_file.exists():
+        return None
+    try:
+        data = json.loads(paths.status_file.read_text())
+        # Ignore unknown fields so a daemon written by a newer schema
+        # version doesn't crash an older CLI.
+        known = {f.name for f in TrackStatus.__dataclass_fields__.values()}
+        return TrackStatus(**{k: v for k, v in data.items() if k in known})
+    except Exception:
+        return None

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -1,0 +1,837 @@
+"""Session store: the canonical place sessions live.
+
+Two implementations, one protocol:
+
+  - `LocalSessionStore`  — dev stub. Stores sessions in
+    `~/.fleet/track/local-store/` (separate from the CLIs' native
+    directories). Lets us validate the SDK end-to-end without theseus.
+
+  - `RemoteSessionStore` — production. Hits theseus's
+    `/v1/track/sessions` endpoints. Stub today; flips on once the
+    server side ships.
+
+All higher-level SDK code (`flt track ls`, `flt track resume`) talks
+to a `SessionStore`; never directly to either backend.
+
+# Why "store" and not "client"?
+
+Because a session has a lifecycle (create → append → fork → list →
+fetch → delete) that's bigger than HTTP semantics. The protocol
+captures the *operations* the SDK needs, regardless of where the
+data lives. The local stub and the future remote impl satisfy the
+same contract.
+
+# Sessions are a DAG
+
+Each session can have a `forked_from` parent — like git. When you
+resume a codex session in claude, the SDK creates a derived session
+with `forked_from = <codex-session-id>` and `fork_point = <event-index>`.
+Resuming the derived session reconstructs the full history by
+walking parents. Stored as a flat collection with parent pointers;
+the DAG is implicit.
+
+Concurrency: nothing here is atomic across processes. The local
+stub uses tmpfile+rename for individual writes but doesn't take
+cross-process locks. Good enough for a single-developer dev loop;
+revisit if we ever ship multi-process scenarios.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, Optional, Protocol
+
+from .paths import TrackPaths
+from .unified import Event
+
+log = logging.getLogger("fleet.track.store")
+
+
+# ------------------------------------------------------------------ #
+# Session record                                                       #
+# ------------------------------------------------------------------ #
+
+
+@dataclass(frozen=True)
+class Session:
+    """One session in the store.
+
+    `id` — globally unique within the store. UUIDs are recommended; the
+        store doesn't enforce a format so callers can use claude/codex's
+        native ids when seeding from local files.
+
+    `tool` — which CLI emitted *this* session's events.
+        Same as the unified Event.source, lifted to the session level
+        for fast filtering without parsing events.
+
+    `cwd` — the working directory the agent was run in. Used by
+        the resume flow to pick the right local target dir.
+
+    `started_at` / `last_active` — ISO-8601 timestamps. `last_active` is
+        a max over the session's events; the daemon updates it on
+        every sync.
+
+    `event_count` — cached count for quick listing without reading
+        the full file.
+
+    `forked_from` / `fork_point` — branch lineage. Set on derived
+        sessions (e.g. claude resume of a codex session). The original
+        sessions have both as None.
+
+    `metadata` — open-ended bag for future extensions (model, agent
+        version, git_branch, anything else). Stored verbatim, not
+        validated.
+    """
+
+    id: str
+    tool: str  # "claude" | "codex" | "cursor" | "opencode" | "unknown"
+    cwd: Optional[str] = None
+    started_at: Optional[str] = None
+    last_active: Optional[str] = None
+    event_count: int = 0
+    forked_from: Optional[str] = None
+    fork_point: Optional[int] = None
+    metadata: dict = field(default_factory=dict)
+
+
+# ------------------------------------------------------------------ #
+# Protocol                                                             #
+# ------------------------------------------------------------------ #
+
+
+class SessionStore(Protocol):
+    """The contract. Both LocalSessionStore and (future) RemoteSessionStore
+    implement this."""
+
+    def list(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> Iterable[Session]:
+        """List sessions, optionally filtered.
+
+        `since` is ISO-8601; matched against `last_active`. Implementations
+        may be lazy (returning an iterator) or eager (a list); callers
+        should treat it as one-shot iterable.
+        """
+        ...
+
+    def get(self, id: str) -> Optional[Session]:
+        """Lookup by id. Accepts full id or unique prefix; returns None
+        if not found, raises KeyError if prefix is ambiguous."""
+        ...
+
+    def events(self, id: str) -> Iterator[Event]:
+        """Stream the session's unified Event stream.
+
+        For root sessions: just this session's events.
+        For derived (`forked_from` is set): walks the parent chain,
+        yielding events from each ancestor up to its fork_point, then
+        this session's own events.
+        """
+        ...
+
+    def create(self, session: Session, events: Iterable[Event]) -> Session:
+        """Insert a new session. `session.id` must be set by the caller.
+        Returns the stored session record (potentially with normalized
+        timestamps/counts the store filled in)."""
+        ...
+
+    def append(self, id: str, events: Iterable[Event]) -> int:
+        """Append events to an existing session. Returns the count of
+        events appended. Raises KeyError if session not found."""
+        ...
+
+    def delete(self, id: str) -> bool:
+        """Remove a session and its events. Returns True if deleted,
+        False if it wasn't there. Forks of this session are NOT
+        cascaded (they retain `forked_from = <id>` as a dangling
+        reference; lineage walks gracefully degrade)."""
+        ...
+
+
+# ------------------------------------------------------------------ #
+# LocalSessionStore                                                    #
+# ------------------------------------------------------------------ #
+
+
+@dataclass(frozen=True)
+class LocalStorePaths:
+    """Filesystem layout under the store root.
+
+        <root>/
+          index.jsonl          # one Session record per line, append-only
+          sessions/
+            <id>.jsonl         # one Event-as-JSON per line
+    """
+
+    root: Path
+
+    @classmethod
+    def under(cls, paths: TrackPaths, *, name: str = "local-store") -> "LocalStorePaths":
+        return cls(root=paths.track_dir / name)
+
+    @property
+    def index(self) -> Path:
+        return self.root / "index.jsonl"
+
+    @property
+    def sessions_dir(self) -> Path:
+        return self.root / "sessions"
+
+    def session_file(self, id: str) -> Path:
+        return self.sessions_dir / f"{id}.jsonl"
+
+    def ensure(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+
+
+class LocalSessionStore:
+    """Filesystem-backed session store. The dev stub for the future
+    remote one."""
+
+    def __init__(self, paths: TrackPaths, *, name: str = "local-store") -> None:
+        self._layout = LocalStorePaths.under(paths, name=name)
+        self._layout.ensure()
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
+
+    def list(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[Session]:
+        out: list[Session] = []
+        for s in self._read_index():
+            if tool is not None and s.tool != tool:
+                continue
+            if cwd is not None and s.cwd != cwd:
+                continue
+            if since is not None and (s.last_active or "") < since:
+                continue
+            out.append(s)
+        # Most-recent first.
+        out.sort(key=lambda s: s.last_active or s.started_at or "", reverse=True)
+        if limit is not None:
+            out = out[:limit]
+        return out
+
+    def get(self, id: str) -> Optional[Session]:
+        # Exact match first.
+        for s in self._read_index():
+            if s.id == id:
+                return s
+        # Prefix match.
+        matches = [s for s in self._read_index() if s.id.startswith(id)]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise KeyError(
+                f"Ambiguous prefix {id!r}: matches {[m.id for m in matches]}"
+            )
+        return None
+
+    def events(self, id: str) -> Iterator[Event]:
+        s = self.get(id)
+        if s is None:
+            raise KeyError(id)
+
+        # Walk parents first (full chain root → leaf), each contributing
+        # events up to its fork_point.
+        chain = self._build_chain(s)
+        for node, max_events in chain:
+            yielded = 0
+            for ev in self._read_events(node.id):
+                if max_events is not None and yielded >= max_events:
+                    break
+                yield ev
+                yielded += 1
+
+    def create(self, session: Session, events: Iterable[Event]) -> Session:
+        if not session.id:
+            raise ValueError("Session.id must be set by the caller")
+
+        # Materialize events to count; we need event_count anyway.
+        events_list = list(events)
+        normalized = Session(
+            id=session.id,
+            tool=session.tool,
+            cwd=session.cwd,
+            started_at=session.started_at,
+            last_active=session.last_active,
+            event_count=len(events_list),
+            forked_from=session.forked_from,
+            fork_point=session.fork_point,
+            metadata=dict(session.metadata),
+        )
+
+        # Write events file atomically.
+        target = self._layout.session_file(session.id)
+        self._atomic_write_jsonl(
+            target,
+            (ev.model_dump(mode="json") for ev in events_list),
+        )
+
+        # Append to index.
+        self._append_index(normalized)
+        return normalized
+
+    def append(self, id: str, events: Iterable[Event]) -> int:
+        if self.get(id) is None:
+            raise KeyError(id)
+        target = self._layout.session_file(id)
+        n = 0
+        with open(target, "a", encoding="utf-8") as f:
+            for ev in events:
+                f.write(json.dumps(ev.model_dump(mode="json"), ensure_ascii=False))
+                f.write("\n")
+                n += 1
+        # We don't update event_count in the index on every append; that
+        # would require a rewrite. `flt track ls` shows the count from
+        # the index; consumers that need exact counts call `events()`.
+        return n
+
+    def delete(self, id: str) -> bool:
+        s = self.get(id)
+        if s is None:
+            return False
+        # Remove events file.
+        target = self._layout.session_file(id)
+        target.unlink(missing_ok=True)
+        # Rewrite index without this entry.
+        kept = [r for r in self._read_index() if r.id != id]
+        self._write_index(kept)
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _read_index(self) -> Iterator[Session]:
+        if not self._layout.index.exists():
+            return iter(())
+        # Last writer wins: scan top-to-bottom and keep the most recent
+        # entry per id.
+        latest: dict[str, Session] = {}
+        with open(self._layout.index, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    d = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # Tolerate extra fields a future schema adds.
+                known = {f.name for f in Session.__dataclass_fields__.values()}
+                cleaned = {k: v for k, v in d.items() if k in known}
+                if "id" not in cleaned:
+                    continue
+                latest[cleaned["id"]] = Session(**cleaned)
+        return iter(latest.values())
+
+    def _append_index(self, session: Session) -> None:
+        self._layout.ensure()
+        with open(self._layout.index, "a", encoding="utf-8") as f:
+            f.write(json.dumps(asdict(session), ensure_ascii=False))
+            f.write("\n")
+
+    def _write_index(self, sessions: list[Session]) -> None:
+        self._atomic_write_jsonl(
+            self._layout.index,
+            (asdict(s) for s in sessions),
+        )
+
+    def _atomic_write_jsonl(self, path: Path, rows: Iterable[dict]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for row in rows:
+                    f.write(json.dumps(row, ensure_ascii=False))
+                    f.write("\n")
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def _read_events(self, id: str) -> Iterator[Event]:
+        """Read events from disk, parsed back through the unified union.
+
+        We use pydantic's discriminated-union validation rather than
+        manually dispatching on `type` — this keeps the parser logic
+        in one place (the union itself).
+        """
+        from pydantic import TypeAdapter
+
+        target = self._layout.session_file(id)
+        if not target.exists():
+            return
+        adapter: TypeAdapter[Event] = TypeAdapter(Event)
+        with open(target, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    d = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                try:
+                    yield adapter.validate_python(d)
+                except Exception as e:
+                    log.debug("local store: skip invalid event in %s: %s", id, e)
+                    continue
+
+    def _build_chain_from_external(self, leaf: Session, lookup) -> list[tuple[Session, Optional[int]]]:
+        """Variant of `_build_chain` that resolves parents via a caller-provided
+        `lookup(session_id) → Session | None` instead of `self.get`. Used by
+        ChainedSessionStore so cross-store fork chains resolve correctly."""
+        chain: list[Session] = []
+        seen: set[str] = set()
+        cur: Optional[Session] = leaf
+        while cur is not None:
+            if cur.id in seen:
+                log.warning("session lineage cycle at %s; truncating", cur.id)
+                break
+            seen.add(cur.id)
+            chain.append(cur)
+            if cur.forked_from is None:
+                break
+            cur = lookup(cur.forked_from)
+
+        chain.reverse()
+        out: list[tuple[Session, Optional[int]]] = []
+        for i, node in enumerate(chain):
+            if i + 1 < len(chain):
+                child = chain[i + 1]
+                out.append((node, child.fork_point))
+            else:
+                out.append((node, None))
+        return out
+
+    def _build_chain(self, leaf: Session) -> list[tuple[Session, Optional[int]]]:
+        """Return the chain root → ... → leaf as (session, max_events_or_none).
+
+        For each ancestor, max_events = its child's fork_point (so we
+        only replay up to the branch point). For the leaf itself,
+        max_events = None (replay all).
+        """
+        return self._build_chain_from_external(leaf, self.get)
+
+
+# ------------------------------------------------------------------ #
+# NativeFilesSessionStore                                              #
+# ------------------------------------------------------------------ #
+
+
+class NativeFilesSessionStore:
+    """Read-only `SessionStore` view of native CLI session files.
+
+    Walks `~/.claude/projects/` and `~/.codex/sessions/` (via the same
+    `Source` classes the daemon uses). Useful as a "show me what's
+    actually on disk" backend for `flt track ls` / `flt track resume`
+    before the remote backend exists or before LocalSessionStore has
+    been seeded.
+
+    Read-only: `create` / `append` / `delete` raise NotImplementedError.
+    `events()` re-parses the native file on each call (no caching) — fine
+    for interactive resume, not great for hot loops.
+
+    Identifies sessions:
+      - claude: filename `<sessionId>.jsonl` (UUID)
+      - codex: filename `rollout-<ts>-<sessionId>.jsonl` (last UUID)
+    """
+
+    def __init__(self, home: Optional["Path"] = None) -> None:  # noqa: F821
+        self._home = home or Path.home()
+
+    def list(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[Session]:
+        out: list[Session] = []
+        for source, build_session in self._sources_with_session_builders():
+            if tool is not None and source.name != tool:
+                continue
+            if not source.is_present():
+                continue
+            for path in source.iter_files():
+                # Skip fleet checkouts; they're transient views, not
+                # native sessions, and would clutter the picker.
+                if _looks_like_fleet_checkout(path):
+                    continue
+                try:
+                    s = build_session(path)
+                except OSError:
+                    continue
+                if s is None:
+                    continue
+                if cwd is not None and s.cwd != cwd:
+                    continue
+                if since is not None and (s.last_active or "") < since:
+                    continue
+                out.append(s)
+
+        out.sort(key=lambda s: s.last_active or s.started_at or "", reverse=True)
+        if limit is not None:
+            out = out[:limit]
+        return out
+
+    def get(self, id: str) -> Optional[Session]:
+        # Two-pass: exact match, then unique prefix.
+        all_sessions = self.list()
+        for s in all_sessions:
+            if s.id == id:
+                return s
+        matches = [s for s in all_sessions if s.id.startswith(id)]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise KeyError(
+                f"Ambiguous prefix {id!r}: matches {[m.id for m in matches]}"
+            )
+        return None
+
+    def events(self, id: str) -> Iterator[Event]:
+        s = self.get(id)
+        if s is None:
+            raise KeyError(id)
+        path = self._path_for(s)
+        if path is None:
+            return
+        # Lazy-import to avoid circular imports at module load.
+        from .sources import ClaudeSource, CodexSource
+
+        if s.tool == "claude":
+            yield from ClaudeSource(home=self._home).parse(path)
+        elif s.tool == "codex":
+            yield from CodexSource(home=self._home).parse(path)
+
+    def create(self, session: Session, events: Iterable[Event]) -> Session:
+        raise NotImplementedError(
+            "NativeFilesSessionStore is read-only. Use LocalSessionStore for writes."
+        )
+
+    def append(self, id: str, events: Iterable[Event]) -> int:
+        raise NotImplementedError("NativeFilesSessionStore is read-only.")
+
+    def delete(self, id: str) -> bool:
+        raise NotImplementedError("NativeFilesSessionStore is read-only.")
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _sources_with_session_builders(self):
+        """Each tuple is (source_instance, fn(path)→Session|None)."""
+        from .sources import ClaudeSource, CodexSource
+        return [
+            (ClaudeSource(home=self._home), self._build_claude_session),
+            (CodexSource(home=self._home), self._build_codex_session),
+        ]
+
+    def _build_claude_session(self, path) -> Optional[Session]:
+        # Filename `<uuid>.jsonl` is the session id by claude convention.
+        sid = path.stem
+        if not _looks_like_uuid(sid):
+            return None
+        return _build_session_from_path(
+            tool="claude", id=sid, path=path,
+            cwd=_decode_claude_cwd(path),
+        )
+
+    def _build_codex_session(self, path) -> Optional[Session]:
+        # Filename `rollout-<ts>-<uuid>.jsonl`; we want the trailing uuid.
+        stem = path.stem
+        # Split from the right: last uuid-shaped chunk wins.
+        parts = stem.split("-")
+        # uuids are 5 hyphen-separated chunks (8-4-4-4-12); take last 5.
+        if len(parts) < 5:
+            return None
+        candidate = "-".join(parts[-5:])
+        if not _looks_like_uuid(candidate):
+            return None
+        # codex stores cwd inside the file's session_meta payload; we
+        # parse the first line only to keep listing fast.
+        cwd = _read_codex_cwd(path)
+        return _build_session_from_path(
+            tool="codex", id=candidate, path=path, cwd=cwd,
+        )
+
+    def _path_for(self, session: Session) -> Optional["Path"]:  # noqa: F821
+        from .sources import ClaudeSource, CodexSource
+        if session.tool == "claude":
+            for p in ClaudeSource(home=self._home).iter_files():
+                if p.stem == session.id:
+                    return p
+        elif session.tool == "codex":
+            for p in CodexSource(home=self._home).iter_files():
+                if p.stem.endswith(session.id):
+                    return p
+        return None
+
+
+# ------------------------------------------------------------------ #
+# ChainedSessionStore                                                  #
+# ------------------------------------------------------------------ #
+
+
+class ChainedSessionStore:
+    """Combine multiple SessionStores into one logical view.
+
+    `list()` merges across stores, deduping by `id` (first store wins on
+    duplicates). `get()` and `events()` try each store in order.
+
+    Writes (`create`/`append`/`delete`) delegate to the FIRST writable
+    store. Read-only stores in the chain are skipped for writes.
+
+    Typical use:
+
+        chained = ChainedSessionStore(
+            LocalSessionStore(paths),       # explicitly ingested first
+            NativeFilesSessionStore(home),  # native fallback
+            # RemoteSessionStore(...),      # later
+        )
+    """
+
+    def __init__(self, *stores) -> None:
+        if not stores:
+            raise ValueError("ChainedSessionStore needs at least one backing store")
+        self._stores = list(stores)
+
+    def list(self, **kwargs) -> list[Session]:
+        seen: set[str] = set()
+        out: list[Session] = []
+        for store in self._stores:
+            for s in store.list(**kwargs):
+                if s.id in seen:
+                    continue
+                seen.add(s.id)
+                out.append(s)
+        out.sort(key=lambda s: s.last_active or s.started_at or "", reverse=True)
+        if "limit" in kwargs and kwargs["limit"] is not None:
+            out = out[:kwargs["limit"]]
+        return out
+
+    def get(self, id: str) -> Optional[Session]:
+        ambiguous: list[str] = []
+        for store in self._stores:
+            try:
+                s = store.get(id)
+            except KeyError as e:
+                ambiguous.append(str(e))
+                continue
+            if s is not None:
+                return s
+        if ambiguous:
+            raise KeyError("; ".join(ambiguous))
+        return None
+
+    def events(self, id: str) -> Iterator[Event]:
+        # Find the leaf, then walk fork_from chain (parents may live in
+        # different stores than the leaf).
+        leaf = self.get(id)
+        if leaf is None:
+            raise KeyError(id)
+
+        # Build the chain across stores using our own get() as the lookup.
+        chain = self._build_chain_across(leaf)
+        for node, max_events in chain:
+            home_store = self._store_for(node)
+            if home_store is None:
+                continue
+            yielded = 0
+            for ev in home_store.events(node.id):
+                if max_events is not None and yielded >= max_events:
+                    break
+                yield ev
+                yielded += 1
+
+    def create(self, session: Session, events) -> Session:
+        for store in self._stores:
+            try:
+                return store.create(session, events)
+            except NotImplementedError:
+                continue
+        raise NotImplementedError("No writable store in chain")
+
+    def append(self, id: str, events) -> int:
+        for store in self._stores:
+            try:
+                return store.append(id, events)
+            except (NotImplementedError, KeyError):
+                continue
+        raise KeyError(id)
+
+    def delete(self, id: str) -> bool:
+        deleted_any = False
+        for store in self._stores:
+            try:
+                if store.delete(id):
+                    deleted_any = True
+            except NotImplementedError:
+                continue
+        return deleted_any
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _store_for(self, session: Session):
+        """Return the first store whose `get(session.id)` finds this session."""
+        for store in self._stores:
+            try:
+                if store.get(session.id) is not None:
+                    return store
+            except KeyError:
+                continue
+        return None
+
+    def _build_chain_across(self, leaf: Session) -> list[tuple[Session, Optional[int]]]:
+        """Walk fork_from across all stores, the same way LocalSessionStore
+        walks within itself."""
+        # Borrow LocalSessionStore's helper if available, otherwise inline.
+        chain: list[Session] = []
+        seen: set[str] = set()
+        cur: Optional[Session] = leaf
+        while cur is not None:
+            if cur.id in seen:
+                log.warning("session lineage cycle at %s; truncating", cur.id)
+                break
+            seen.add(cur.id)
+            chain.append(cur)
+            if cur.forked_from is None:
+                break
+            cur = self.get(cur.forked_from)
+
+        chain.reverse()
+        out: list[tuple[Session, Optional[int]]] = []
+        for i, node in enumerate(chain):
+            if i + 1 < len(chain):
+                out.append((node, chain[i + 1].fork_point))
+            else:
+                out.append((node, None))
+        return out
+
+
+# ------------------------------------------------------------------ #
+# Native-files helpers                                                 #
+# ------------------------------------------------------------------ #
+
+
+_UUID_RE = None
+def _looks_like_uuid(s: str) -> bool:
+    global _UUID_RE
+    if _UUID_RE is None:
+        import re as _re
+        _UUID_RE = _re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+    return bool(_UUID_RE.match(s))
+
+
+def _decode_claude_cwd(path) -> Optional[str]:
+    """Reverse claude's cwd encoding: the parent dir name is `cwd` with
+    every non-alnum/dash/underscore replaced by '-'. We can't perfectly
+    recover originals (the encoding is lossy: `/foo` and `-foo` both
+    encode to `-foo`), but `/<dirname>` is a safe approximation that's
+    correct for the canonical macOS / linux paths."""
+    try:
+        encoded = path.parent.name
+    except AttributeError:
+        return None
+    if not encoded.startswith("-"):
+        return None
+    # Replace `-` with `/`. Lossy when the original had literal dashes
+    # but matches the common case; resume code resolves through cwd
+    # anyway so this is a display-only field.
+    return "/" + encoded[1:].replace("-", "/")
+
+
+def _read_codex_cwd(path) -> Optional[str]:
+    """Read just the first line of a codex rollout to extract `payload.cwd`.
+    Avoids parsing the whole file on every list."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            first = f.readline()
+    except OSError:
+        return None
+    if not first:
+        return None
+    try:
+        d = json.loads(first)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(d, dict):
+        return None
+    payload = d.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    cwd = payload.get("cwd")
+    return cwd if isinstance(cwd, str) else None
+
+
+def _build_session_from_path(*, tool: str, id: str, path, cwd: Optional[str]) -> Session:
+    """Cheap Session record from a path's stat. event_count is approximated
+    by line count (avoids parsing); fine for picker display."""
+    import datetime as _dt
+    stat = path.stat()
+    last_active = _dt.datetime.fromtimestamp(stat.st_mtime, tz=_dt.timezone.utc).isoformat()
+    started_at = _dt.datetime.fromtimestamp(stat.st_ctime, tz=_dt.timezone.utc).isoformat()
+    # Line count is a fast approximation of event_count.
+    line_count = 0
+    try:
+        with open(path, "rb") as f:
+            for _ in f:
+                line_count += 1
+    except OSError:
+        pass
+    return Session(
+        id=id, tool=tool, cwd=cwd,
+        started_at=started_at, last_active=last_active,
+        event_count=line_count,
+    )
+
+
+def _looks_like_fleet_checkout(path) -> bool:
+    """A native-files lister should skip our own checkout files (they're
+    transient views, not real sessions)."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            first = f.readline()
+    except OSError:
+        return False
+    if not first:
+        return False
+    try:
+        d = json.loads(first)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(d, dict):
+        return False
+    if "_fleet_meta" in d:
+        return True
+    payload = d.get("payload")
+    if isinstance(payload, dict) and "_fleet_meta" in payload:
+        return True
+    return False

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -47,6 +47,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable, Iterator, Optional, Protocol
 
+from pydantic import BaseModel, ConfigDict, Field
+
 from .paths import TrackPaths
 from .unified import Event
 
@@ -107,6 +109,23 @@ def _clamp_limit(limit: int) -> int:
     if limit > MAX_PAGE_LIMIT:
         return MAX_PAGE_LIMIT
     return limit
+
+
+def _read_local_device_id() -> Optional[str]:
+    """Pull the device_id stamped on this machine by `flt track enable`.
+
+    Used to populate `Session.origin_device` for sessions produced
+    locally. None when the user hasn't enabled tracking yet (the LocalSessionStore
+    still works as a dev stub; it just won't carry origin info)."""
+    try:
+        cfg_path = TrackPaths.default().config_file
+        if not cfg_path.exists():
+            return None
+        cfg = json.loads(cfg_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    did = cfg.get("device_id")
+    return did if isinstance(did, str) and did else None
 
 
 def _sort_key(s: "Session") -> tuple[int, str, str]:
@@ -178,6 +197,43 @@ def _passes_cursor(s: "Session", cursor: Optional[dict]) -> bool:
 # ------------------------------------------------------------------ #
 
 
+class SessionMetadata(BaseModel):
+    """Canonical schema for `Session.metadata`.
+
+    Both the SDK and the orchestrator should read/write metadata
+    conforming to this model. The dict on `Session.metadata` itself
+    stays a plain dict for ergonomics (existing callers do
+    `s.metadata.get("title")`); `Session.metadata_typed()` parses it
+    through this model when typed access is needed.
+
+    `extra="allow"` so the model is forward-compatible — a server-side
+    field we haven't pinned yet still survives round-trip.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    # Display
+    title: Optional[str] = None
+
+    # Repo identity (cross-machine resume key)
+    # `repo_url` is the canonical key — normalized via `normalize_repo_url`
+    # in `fleet.track.repos`. `repo_subpath` is the path relative to the
+    # repo root. `origin_cwd` is the absolute path on the originating
+    # machine, kept as a fallback for sessions outside any git repo.
+    repo_url: Optional[str] = None
+    repo_subpath: Optional[str] = None
+    origin_cwd: Optional[str] = None
+
+    # Source-recorded context (populated where the source format exposes it)
+    model: Optional[str] = None
+    agent_version: Optional[str] = None
+    git_branch: Optional[str] = None
+
+    # User-tagged labels (free-form). Reserved for future server-driven
+    # workflows; ingest writes none.
+    tags: list[str] = Field(default_factory=list)
+
+
 @dataclass(frozen=True)
 class Session:
     """One session in the store.
@@ -190,8 +246,10 @@ class Session:
         Same as the unified Event.source, lifted to the session level
         for fast filtering without parsing events.
 
-    `cwd` — the working directory the agent was run in. Used by
-        the resume flow to pick the right local target dir.
+    `cwd` — the working directory the agent was run in (originating
+        machine's absolute path). Use `metadata.repo_url` +
+        `metadata.repo_subpath` for cross-machine resume; cwd is only
+        meaningful on the device that produced the session.
 
     `started_at` / `last_active` — ISO-8601 timestamps. `last_active` is
         a max over the session's events; the daemon updates it on
@@ -204,9 +262,15 @@ class Session:
         sessions (e.g. claude resume of a codex session). The original
         sessions have both as None.
 
-    `metadata` — open-ended bag for future extensions (model, agent
-        version, git_branch, anything else). Stored verbatim, not
-        validated.
+    `origin_device` — id of the machine that produced this session
+        (`device_id` from `~/.fleet/track/config.json`). Top-level (not
+        metadata) because it's identity, not annotation. None when
+        unknown (e.g. NativeFilesSessionStore on a host that never ran
+        `flt track enable`).
+
+    `metadata` — open-ended bag conforming to `SessionMetadata`.
+        Validated lazily via `metadata_typed()`; stored as dict so
+        callers can read/write known keys directly.
     """
 
     id: str
@@ -217,7 +281,12 @@ class Session:
     event_count: int = 0
     forked_from: Optional[str] = None
     fork_point: Optional[int] = None
+    origin_device: Optional[str] = None
     metadata: dict = field(default_factory=dict)
+
+    def metadata_typed(self) -> SessionMetadata:
+        """Parse `metadata` through `SessionMetadata` for typed access."""
+        return SessionMetadata.model_validate(self.metadata)
 
 
 # ------------------------------------------------------------------ #
@@ -228,6 +297,14 @@ class Session:
 class SessionStore(Protocol):
     """The contract. Both LocalSessionStore and (future) RemoteSessionStore
     implement this."""
+
+    # Optional opt-in flag for ChainedSessionStore. When True, the chain
+    # delegates paging entirely to this store (it owns global ordering)
+    # and overlays other stores' rows only inside the returned page's
+    # (last_active, id) window. Local stores leave this False/absent so
+    # the legacy eager-merge path is used. RemoteSessionStore sets it
+    # True so paging scales beyond `_CHAINED_BUFFER_CAP`.
+    prefers_authoritative_paging: bool = False
 
     def list(
         self,
@@ -477,6 +554,12 @@ class LocalSessionStore:
 
         # Materialize events to count; we need event_count anyway.
         events_list = list(events)
+        # Stamp `origin_device` from the local config when the caller
+        # didn't set one. The local store is by definition the device
+        # producing the session, so pinning it here gives every record
+        # in the dev stub a stable origin id without callers having to
+        # know about it.
+        origin_device = session.origin_device or _read_local_device_id()
         normalized = Session(
             id=session.id,
             tool=session.tool,
@@ -486,6 +569,7 @@ class LocalSessionStore:
             event_count=len(events_list),
             forked_from=session.forked_from,
             fork_point=session.fork_point,
+            origin_device=origin_device,
             metadata=dict(session.metadata),
         )
 
@@ -891,28 +975,40 @@ class ChainedSessionStore:
         limit: int = DEFAULT_PAGE_LIMIT,
         cursor: Optional[str] = None,
     ) -> tuple[list[Session], Optional[str]]:
-        """Eager-merge then paginate.
+        """Page across the chained backends.
 
-        We pull up to `_CHAINED_BUFFER_CAP` rows from each backing store
-        with the same filters, dedupe by `id` (first store wins),
-        merge-sort by the global key, then apply the cursor predicate
-        and slice into a page.
+        Two strategies:
 
-        The `(la, id)` cursor format is the same as the single-store
-        backends — it indexes into the merged-and-sorted view, not into
-        any one store's local sequence. So a cursor minted on chained is
-        only meaningful against the same chained instance with the same
-        filters; that's fine because nobody passes chained cursors to
-        anything else.
+        1. **Authoritative-paging delegation** — when one of the backing
+           stores opts in via `prefers_authoritative_paging` (today: the
+           future RemoteSessionStore), we delegate paging entirely to
+           that store and merge other backends' rows ONLY into the
+           returned page. The authoritative store owns global ordering;
+           other stores contribute local-only rows that the authority
+           doesn't know about (e.g. a local fork that hasn't synced yet).
 
-        Limitation: if the total filtered row count across all backends
-        exceeds `_CHAINED_BUFFER_CAP`, later pages would miss whatever
-        fell off each store's per-call cap. For interactive picker use
-        (typical user has <2000 sessions across all backends today)
-        this is invisible; revisit when remote scale arrives and have
-        chained delegate paging to a RemoteSessionStore that owns the
-        global ordering.
+           Cursors in this mode are the authority's cursors verbatim —
+           pass-through, no rewrap. The local rows we overlay are
+           filtered to those that fit *within* the authority page's
+           (last_active, id) window, so we don't accidentally shadow
+           rows from later authority pages.
+
+        2. **Eager-merge** — when all backends are local, pull up to
+           `_CHAINED_BUFFER_CAP` rows from each, dedupe by id, sort,
+           cursor-walk, slice. Cheap and correct as long as the total
+           fits in the buffer (typical: <2000 rows across local +
+           native combined).
         """
+        # Strategy 1: delegate to authoritative-paging store if any.
+        for i, store in enumerate(self._stores):
+            if getattr(store, "prefers_authoritative_paging", False):
+                return self._authoritative_page(
+                    auth_idx=i,
+                    tool=tool, cwd=cwd, since=since,
+                    query=query, limit=limit, cursor=cursor,
+                )
+
+        # Strategy 2: legacy eager-merge.
         cur = _decode_cursor(cursor)
         seen: set[str] = set()
         rows: list[Session] = []
@@ -949,6 +1045,74 @@ class ChainedSessionStore:
             else None
         )
         return page, next_cursor
+
+    def _authoritative_page(
+        self,
+        *,
+        auth_idx: int,
+        tool: Optional[str],
+        cwd: Optional[str],
+        since: Optional[str],
+        query: Optional[str],
+        limit: int,
+        cursor: Optional[str],
+    ) -> tuple[list[Session], Optional[str]]:
+        """Delegate paging to `self._stores[auth_idx]` and overlay
+        rows from the other backends into the same window."""
+        auth = self._stores[auth_idx]
+        auth_page, next_cursor = auth.page(
+            tool=tool, cwd=cwd, since=since, query=query,
+            limit=limit, cursor=cursor,
+        )
+        if not auth_page:
+            return auth_page, next_cursor
+
+        # Ordering window of the authority's page: (top_la, top_id) is the
+        # newest row, (bot_la, bot_id) is the oldest. We let local rows
+        # in only if they sort within (or below) the bottom row — pages
+        # to come from the authority will pick up anything above us.
+        # We compare rows by `_sort_key` and keep those whose tuple is
+        # ≤ the top tuple AND ≥ the bottom tuple. (Larger sort key =
+        # newer row; reverse=True sort puts them first.)
+        top_key = _sort_key(auth_page[0])
+        bot_key = _sort_key(auth_page[-1])
+
+        seen: set[str] = {s.id for s in auth_page}
+        local_in_window: list[Session] = []
+        for j, store in enumerate(self._stores):
+            if j == auth_idx:
+                continue
+            try:
+                rows = list(store.list(
+                    tool=tool, cwd=cwd, since=since, query=query,
+                    limit=_CHAINED_BUFFER_CAP,
+                ))
+            except TypeError:
+                rows = list(store.list(
+                    tool=tool, cwd=cwd, since=since,
+                    limit=_CHAINED_BUFFER_CAP,
+                ))
+                if query:
+                    rows = [s for s in rows if _matches_query(s, query)]
+            for s in rows:
+                if s.id in seen:
+                    continue
+                k = _sort_key(s)
+                if not (bot_key <= k <= top_key):
+                    continue  # outside the page's window — skip
+                seen.add(s.id)
+                local_in_window.append(s)
+
+        # Merge: keep authority page rows, splice in local-window rows
+        # at their proper sorted position. Tie-break: the authority's
+        # row wins because it's the source of truth for ids it knows.
+        merged = sorted(
+            list(auth_page) + local_in_window,
+            key=_sort_key, reverse=True,
+        )
+        # Trim to the requested limit so we don't return more than asked.
+        merged = merged[:limit]
+        return merged, next_cursor
 
     def get(self, id: str) -> Optional[Session]:
         ambiguous: list[str] = []
@@ -1070,21 +1234,59 @@ def _looks_like_uuid(s: str) -> bool:
 
 
 def _decode_claude_cwd(path) -> Optional[str]:
-    """Reverse claude's cwd encoding: the parent dir name is `cwd` with
-    every non-alnum/dash/underscore replaced by '-'. We can't perfectly
-    recover originals (the encoding is lossy: `/foo` and `-foo` both
-    encode to `-foo`), but `/<dirname>` is a safe approximation that's
-    correct for the canonical macOS / linux paths."""
+    """Recover the session's original cwd.
+
+    Strategy: read the actual `cwd` field from the session file. Claude
+    writes it verbatim on user/assistant rows; that's the ground truth.
+    The directory-name encoding (`/Users/me/git/foo-bar` →
+    `-Users-me-git-foo-bar`) is irreversibly lossy because both `/` and
+    `-` collapse to `-`, so we only fall back to it when the file has
+    no row with a `cwd` field (empty / corrupt file).
+
+    Reads up to `_CWD_SCAN_LIMIT` rows; the early metadata rows don't
+    carry `cwd` but the first user message does, so a small bound is
+    enough.
+    """
+    cwd = _read_claude_cwd(path)
+    if cwd:
+        return cwd
+    # Fallback: lossy decode of the encoded parent dir. Useful only when
+    # the session file is empty or unreadable.
     try:
         encoded = path.parent.name
     except AttributeError:
         return None
     if not encoded.startswith("-"):
         return None
-    # Replace `-` with `/`. Lossy when the original had literal dashes
-    # but matches the common case; resume code resolves through cwd
-    # anyway so this is a display-only field.
     return "/" + encoded[1:].replace("-", "/")
+
+
+_CWD_SCAN_LIMIT: int = 20
+
+
+def _read_claude_cwd(path) -> Optional[str]:
+    """Scan the first few rows of a claude session for the `cwd` field.
+    Returns None if the file is missing, empty, or no row carries cwd
+    within the scan window."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            for i, line in enumerate(f):
+                if i >= _CWD_SCAN_LIMIT:
+                    break
+                if not line.strip():
+                    continue
+                try:
+                    d = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(d, dict):
+                    continue
+                cwd = d.get("cwd")
+                if isinstance(cwd, str) and cwd:
+                    return cwd
+    except OSError:
+        return None
+    return None
 
 
 def _read_codex_cwd(path) -> Optional[str]:
@@ -1112,8 +1314,16 @@ def _read_codex_cwd(path) -> Optional[str]:
 
 def _build_session_from_path(*, tool: str, id: str, path, cwd: Optional[str]) -> Session:
     """Cheap Session record from a path's stat. event_count is approximated
-    by line count (avoids parsing); fine for picker display."""
+    by line count (avoids parsing); fine for picker display.
+
+    Also stamps `metadata.repo_url` / `repo_subpath` / `origin_cwd` so the
+    resumer can locate a local checkout regardless of the absolute cwd
+    matching the current machine. `capture_repo()` is module-cached, so
+    repeated builds for sessions in the same cwd shell out only once.
+    """
     import datetime as _dt
+    from .repos import capture_repo
+
     stat = path.stat()
     last_active = _dt.datetime.fromtimestamp(stat.st_mtime, tz=_dt.timezone.utc).isoformat()
     started_at = _dt.datetime.fromtimestamp(stat.st_ctime, tz=_dt.timezone.utc).isoformat()
@@ -1125,10 +1335,25 @@ def _build_session_from_path(*, tool: str, id: str, path, cwd: Optional[str]) ->
                 line_count += 1
     except OSError:
         pass
+
+    metadata: dict = {}
+    if cwd:
+        info = capture_repo(cwd)
+        metadata["origin_cwd"] = info.origin_cwd
+        if info.url:
+            metadata["repo_url"] = info.url
+            metadata["repo_subpath"] = info.subpath
+
+    # Native files were written by this machine, so origin_device is the
+    # local device id when we have one stamped on disk.
+    origin_device = _read_local_device_id()
+
     return Session(
         id=id, tool=tool, cwd=cwd,
         started_at=started_at, last_active=last_active,
         event_count=line_count,
+        origin_device=origin_device,
+        metadata=metadata,
     )
 
 

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -407,16 +407,18 @@ class SessionStore(Protocol):
 class LocalStorePaths:
     """Filesystem layout under the store root.
 
-        <root>/
-          index.jsonl          # one Session record per line, append-only
-          sessions/
-            <id>.jsonl         # one Event-as-JSON per line
+    <root>/
+      index.jsonl          # one Session record per line, append-only
+      sessions/
+        <id>.jsonl         # one Event-as-JSON per line
     """
 
     root: Path
 
     @classmethod
-    def under(cls, paths: TrackPaths, *, name: str = "local-store") -> "LocalStorePaths":
+    def under(
+        cls, paths: TrackPaths, *, name: str = "local-store"
+    ) -> "LocalStorePaths":
         return cls(root=paths.track_dir / name)
 
     @property
@@ -461,7 +463,11 @@ class LocalSessionStore:
         # the default limit"; callers wanting more should use `page()`.
         page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
         items, _ = self.page(
-            tool=tool, cwd=cwd, since=since, query=query, limit=page_limit,
+            tool=tool,
+            cwd=cwd,
+            since=since,
+            query=query,
+            limit=page_limit,
         )
         return items
 
@@ -652,7 +658,9 @@ class LocalSessionStore:
 
     def _atomic_write_jsonl(self, path: Path, rows: Iterable[dict]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}-", suffix=".tmp")
+        fd, tmp = tempfile.mkstemp(
+            dir=path.parent, prefix=f".{path.name}-", suffix=".tmp"
+        )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 for row in rows:
@@ -694,7 +702,9 @@ class LocalSessionStore:
                     log.debug("local store: skip invalid event in %s: %s", id, e)
                     continue
 
-    def _build_chain_from_external(self, leaf: Session, lookup) -> list[tuple[Session, Optional[int]]]:
+    def _build_chain_from_external(
+        self, leaf: Session, lookup
+    ) -> list[tuple[Session, Optional[int]]]:
         """Variant of `_build_chain` that resolves parents via a caller-provided
         `lookup(session_id) → Session | None` instead of `self.get`. Used by
         ChainedSessionStore so cross-store fork chains resolve correctly."""
@@ -729,6 +739,127 @@ class LocalSessionStore:
         max_events = None (replay all).
         """
         return self._build_chain_from_external(leaf, self.get)
+
+
+# ------------------------------------------------------------------ #
+# RemoteSessionStore                                                   #
+# ------------------------------------------------------------------ #
+
+
+class RemoteSessionStore:
+    """Read-only SessionStore backed by orchestrator's metadata index.
+
+    The daemon writes bytes through the v1 S3-direct sync path and then
+    registers metadata through `/v1/track/sessions/{id}`. This store reads that
+    metadata and fetches native bytes through orchestrator-issued presigned S3
+    URLs when a caller needs events for resume.
+    """
+
+    prefers_authoritative_paging: bool = True
+
+    def __init__(self, api=None) -> None:
+        if api is None:
+            from .api import TrackAPIClient
+
+            api = TrackAPIClient()
+        self._api = api
+
+    def list(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[Session]:
+        page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
+        items, _ = self.page(
+            tool=tool,
+            cwd=cwd,
+            since=since,
+            query=query,
+            limit=page_limit,
+        )
+        return items
+
+    def page(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        cursor: Optional[str] = None,
+    ) -> tuple[list[Session], Optional[str]]:
+        data = self._api.list_sessions(
+            tool=tool,
+            cwd=cwd,
+            since=since,
+            query=query,
+            limit=_clamp_limit(limit),
+            cursor=cursor,
+        )
+        items = [_session_from_api(row) for row in data.get("items", [])]
+        return items, data.get("next_cursor")
+
+    def get(self, id: str) -> Optional[Session]:
+        try:
+            return _session_from_api(self._api.get_session(id))
+        except Exception as e:
+            if getattr(e, "status_code", None) == 404:
+                return None
+            raise
+
+    def events(self, id: str) -> Iterator[Event]:
+        leaf = self.get(id)
+        if leaf is None:
+            raise KeyError(id)
+
+        chain = _build_chain(leaf, self.get)
+        for node, max_events in chain:
+            yielded = 0
+            for ev in self.own_events(node.id):
+                if max_events is not None and yielded >= max_events:
+                    break
+                yield ev
+                yielded += 1
+
+    def own_events(self, id: str) -> Iterator[Event]:
+        session = self.get(id)
+        if session is None:
+            raise KeyError(id)
+
+        raw = self._api.download_session_content(session.id)
+        suffix = ".jsonl" if session.tool in {"claude", "codex"} else ""
+        with tempfile.NamedTemporaryFile(suffix=suffix) as f:
+            f.write(raw)
+            f.flush()
+            path = Path(f.name)
+            if session.tool == "claude":
+                from .sources import ClaudeSource
+
+                yield from ClaudeSource().parse(path)
+            elif session.tool == "codex":
+                from .sources import CodexSource
+
+                yield from CodexSource().parse(path)
+            else:
+                raise NotImplementedError(
+                    f"Remote event replay for {session.tool!r} sessions is not supported yet"
+                )
+
+    def create(self, session: Session, events: Iterable[Event]) -> Session:
+        raise NotImplementedError(
+            "RemoteSessionStore is read-only; the daemon writes remote metadata"
+        )
+
+    def append(self, id: str, events: Iterable[Event]) -> int:
+        raise NotImplementedError("RemoteSessionStore is read-only")
+
+    def delete(self, id: str) -> bool:
+        raise NotImplementedError("RemoteSessionStore is read-only")
 
 
 # ------------------------------------------------------------------ #
@@ -770,7 +901,11 @@ class NativeFilesSessionStore:
         # and filter semantics are identical.
         page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
         items, _ = self.page(
-            tool=tool, cwd=cwd, since=since, query=query, limit=page_limit,
+            tool=tool,
+            cwd=cwd,
+            since=since,
+            query=query,
+            limit=page_limit,
         )
         return items
 
@@ -877,6 +1012,7 @@ class NativeFilesSessionStore:
     def _sources_with_session_builders(self):
         """Each tuple is (source_instance, fn(path)→Session|None)."""
         from .sources import ClaudeSource, CodexSource
+
         return [
             (ClaudeSource(home=self._home), self._build_claude_session),
             (CodexSource(home=self._home), self._build_codex_session),
@@ -888,7 +1024,9 @@ class NativeFilesSessionStore:
         if not _looks_like_uuid(sid):
             return None
         return _build_session_from_path(
-            tool="claude", id=sid, path=path,
+            tool="claude",
+            id=sid,
+            path=path,
             cwd=_decode_claude_cwd(path),
         )
 
@@ -907,11 +1045,15 @@ class NativeFilesSessionStore:
         # parse the first line only to keep listing fast.
         cwd = _read_codex_cwd(path)
         return _build_session_from_path(
-            tool="codex", id=candidate, path=path, cwd=cwd,
+            tool="codex",
+            id=candidate,
+            path=path,
+            cwd=cwd,
         )
 
     def _path_for(self, session: Session) -> Optional["Path"]:  # noqa: F821
         from .sources import ClaudeSource, CodexSource
+
         if session.tool == "claude":
             for p in ClaudeSource(home=self._home).iter_files():
                 if p.stem == session.id:
@@ -1004,8 +1146,12 @@ class ChainedSessionStore:
             if getattr(store, "prefers_authoritative_paging", False):
                 return self._authoritative_page(
                     auth_idx=i,
-                    tool=tool, cwd=cwd, since=since,
-                    query=query, limit=limit, cursor=cursor,
+                    tool=tool,
+                    cwd=cwd,
+                    since=since,
+                    query=query,
+                    limit=limit,
+                    cursor=cursor,
                 )
 
         # Strategy 2: legacy eager-merge.
@@ -1014,17 +1160,26 @@ class ChainedSessionStore:
         rows: list[Session] = []
         for store in self._stores:
             try:
-                store_rows = list(store.list(
-                    tool=tool, cwd=cwd, since=since, query=query,
-                    limit=_CHAINED_BUFFER_CAP,
-                ))
+                store_rows = list(
+                    store.list(
+                        tool=tool,
+                        cwd=cwd,
+                        since=since,
+                        query=query,
+                        limit=_CHAINED_BUFFER_CAP,
+                    )
+                )
             except TypeError:
                 # Backwards-compat: a backing store that hasn't grown the
                 # `query` kwarg yet — fall back to filtering ourselves.
-                store_rows = list(store.list(
-                    tool=tool, cwd=cwd, since=since,
-                    limit=_CHAINED_BUFFER_CAP,
-                ))
+                store_rows = list(
+                    store.list(
+                        tool=tool,
+                        cwd=cwd,
+                        since=since,
+                        limit=_CHAINED_BUFFER_CAP,
+                    )
+                )
                 if query:
                     store_rows = [s for s in store_rows if _matches_query(s, query)]
             for s in store_rows:
@@ -1061,8 +1216,12 @@ class ChainedSessionStore:
         rows from the other backends into the same window."""
         auth = self._stores[auth_idx]
         auth_page, next_cursor = auth.page(
-            tool=tool, cwd=cwd, since=since, query=query,
-            limit=limit, cursor=cursor,
+            tool=tool,
+            cwd=cwd,
+            since=since,
+            query=query,
+            limit=limit,
+            cursor=cursor,
         )
         if not auth_page:
             return auth_page, next_cursor
@@ -1083,15 +1242,24 @@ class ChainedSessionStore:
             if j == auth_idx:
                 continue
             try:
-                rows = list(store.list(
-                    tool=tool, cwd=cwd, since=since, query=query,
-                    limit=_CHAINED_BUFFER_CAP,
-                ))
+                rows = list(
+                    store.list(
+                        tool=tool,
+                        cwd=cwd,
+                        since=since,
+                        query=query,
+                        limit=_CHAINED_BUFFER_CAP,
+                    )
+                )
             except TypeError:
-                rows = list(store.list(
-                    tool=tool, cwd=cwd, since=since,
-                    limit=_CHAINED_BUFFER_CAP,
-                ))
+                rows = list(
+                    store.list(
+                        tool=tool,
+                        cwd=cwd,
+                        since=since,
+                        limit=_CHAINED_BUFFER_CAP,
+                    )
+                )
                 if query:
                     rows = [s for s in rows if _matches_query(s, query)]
             for s in rows:
@@ -1108,7 +1276,8 @@ class ChainedSessionStore:
         # row wins because it's the source of truth for ids it knows.
         merged = sorted(
             list(auth_page) + local_in_window,
-            key=_sort_key, reverse=True,
+            key=_sort_key,
+            reverse=True,
         )
         # Trim to the requested limit so we don't return more than asked.
         merged = merged[:limit]
@@ -1219,18 +1388,97 @@ class ChainedSessionStore:
         return out
 
 
+def _build_chain(
+    leaf: Session,
+    lookup,
+) -> list[tuple[Session, Optional[int]]]:
+    """Build a fork chain root → leaf using `lookup(session_id)`."""
+    chain: list[Session] = []
+    seen: set[str] = set()
+    cur: Optional[Session] = leaf
+    while cur is not None:
+        if cur.id in seen:
+            log.warning("session lineage cycle at %s; truncating", cur.id)
+            break
+        seen.add(cur.id)
+        chain.append(cur)
+        if cur.forked_from is None:
+            break
+        cur = lookup(cur.forked_from)
+
+    chain.reverse()
+    out: list[tuple[Session, Optional[int]]] = []
+    for i, node in enumerate(chain):
+        if i + 1 < len(chain):
+            out.append((node, chain[i + 1].fork_point))
+        else:
+            out.append((node, None))
+    return out
+
+
+def _session_from_api(row: dict) -> Session:
+    """Map orchestrator SessionMetadata JSON to the SDK dataclass."""
+    known = {f.name for f in Session.__dataclass_fields__.values()}
+    cleaned = {k: v for k, v in row.items() if k in known}
+    if "origin_device" not in cleaned and row.get("device_id"):
+        cleaned["origin_device"] = row["device_id"]
+    return Session(**cleaned)
+
+
 # ------------------------------------------------------------------ #
 # Native-files helpers                                                 #
 # ------------------------------------------------------------------ #
 
 
 _UUID_RE = None
+
+
 def _looks_like_uuid(s: str) -> bool:
     global _UUID_RE
     if _UUID_RE is None:
         import re as _re
-        _UUID_RE = _re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+
+        _UUID_RE = _re.compile(
+            r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        )
     return bool(_UUID_RE.match(s))
+
+
+def session_from_native_path(path, *, home: Optional[Path] = None) -> Optional[Session]:
+    """Return a cheap Session metadata record for a native session file.
+
+    This is the daemon's bridge from the v1 file syncer to the orchestrator
+    metadata index. It deliberately supports only source formats whose session
+    id and parser semantics are implemented locally.
+    """
+    path = Path(path)
+    home = home or Path.home()
+    try:
+        rel = path.relative_to(home)
+    except ValueError:
+        return None
+    if _looks_like_fleet_checkout(path):
+        return None
+
+    parts = rel.parts
+    native = NativeFilesSessionStore(home=home)
+    if len(parts) >= 3 and parts[0] == ".claude" and parts[1] == "projects":
+        if path.suffix != ".jsonl":
+            return None
+        return native._build_claude_session(path)
+    if (
+        len(parts) >= 3
+        and parts[0] == ".codex"
+        and parts[1]
+        in {
+            "sessions",
+            "archived_sessions",
+        }
+    ):
+        if path.suffix != ".jsonl":
+            return None
+        return native._build_codex_session(path)
+    return None
 
 
 def _decode_claude_cwd(path) -> Optional[str]:
@@ -1312,7 +1560,9 @@ def _read_codex_cwd(path) -> Optional[str]:
     return cwd if isinstance(cwd, str) else None
 
 
-def _build_session_from_path(*, tool: str, id: str, path, cwd: Optional[str]) -> Session:
+def _build_session_from_path(
+    *, tool: str, id: str, path, cwd: Optional[str]
+) -> Session:
     """Cheap Session record from a path's stat. event_count is approximated
     by line count (avoids parsing); fine for picker display.
 
@@ -1325,8 +1575,12 @@ def _build_session_from_path(*, tool: str, id: str, path, cwd: Optional[str]) ->
     from .repos import capture_repo
 
     stat = path.stat()
-    last_active = _dt.datetime.fromtimestamp(stat.st_mtime, tz=_dt.timezone.utc).isoformat()
-    started_at = _dt.datetime.fromtimestamp(stat.st_ctime, tz=_dt.timezone.utc).isoformat()
+    last_active = _dt.datetime.fromtimestamp(
+        stat.st_mtime, tz=_dt.timezone.utc
+    ).isoformat()
+    started_at = _dt.datetime.fromtimestamp(
+        stat.st_ctime, tz=_dt.timezone.utc
+    ).isoformat()
     # Line count is a fast approximation of event_count.
     line_count = 0
     try:
@@ -1349,8 +1603,11 @@ def _build_session_from_path(*, tool: str, id: str, path, cwd: Optional[str]) ->
     origin_device = _read_local_device_id()
 
     return Session(
-        id=id, tool=tool, cwd=cwd,
-        started_at=started_at, last_active=last_active,
+        id=id,
+        tool=tool,
+        cwd=cwd,
+        started_at=started_at,
+        last_active=last_active,
         event_count=line_count,
         origin_device=origin_device,
         metadata=metadata,

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -119,6 +119,27 @@ def _sort_key(s: "Session") -> tuple[int, str, str]:
     return (1 if la else 0, la or "", s.id)
 
 
+def _matches_query(s: "Session", query: Optional[str]) -> bool:
+    """Case-insensitive substring match across the fields a user is
+    likely to type (id, tool, cwd, metadata.title). Empty/None query
+    matches everything.
+
+    Server-side this becomes ILIKE on the same columns; both sides apply
+    the predicate BEFORE the cursor walk so a cursor minted with a query
+    keeps walking the same filtered set.
+    """
+    if not query:
+        return True
+    needle = query.lower()
+    title = ""
+    if isinstance(s.metadata, dict):
+        t = s.metadata.get("title")
+        if isinstance(t, str):
+            title = t
+    haystack = " ".join((s.id, s.tool or "", s.cwd or "", title)).lower()
+    return needle in haystack
+
+
 def _passes_cursor(s: "Session", cursor: Optional[dict]) -> bool:
     """True if `s` comes strictly AFTER the cursor's row in the global
     ordering. Mirrors the server's WHERE predicate exactly so a cursor
@@ -227,6 +248,7 @@ class SessionStore(Protocol):
         tool: Optional[str] = None,
         cwd: Optional[str] = None,
         since: Optional[str] = None,
+        query: Optional[str] = None,
         limit: int = DEFAULT_PAGE_LIMIT,
         cursor: Optional[str] = None,
     ) -> tuple[list[Session], Optional[str]]:
@@ -236,6 +258,10 @@ class SessionStore(Protocol):
         backend so cursors are interchangeable. `limit` is clamped to
         [1, MAX_PAGE_LIMIT] (matching the orchestrator). `cursor` is an
         opaque token from a prior call; pass `None` for the first page.
+
+        `query` is a case-insensitive substring match across id/tool/cwd/
+        metadata.title — used by the picker's live-search to re-query the
+        store on each keystroke.
 
         Returns `(items, next_cursor)`. `next_cursor is None` when this
         is the last page. The cursor format is byte-compatible with
@@ -343,13 +369,16 @@ class LocalSessionStore:
         tool: Optional[str] = None,
         cwd: Optional[str] = None,
         since: Optional[str] = None,
+        query: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> list[Session]:
         # Backed by `page()` so sort+filter semantics stay identical to
         # the cursor-paginated path. `limit=None` means "first page using
         # the default limit"; callers wanting more should use `page()`.
         page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
-        items, _ = self.page(tool=tool, cwd=cwd, since=since, limit=page_limit)
+        items, _ = self.page(
+            tool=tool, cwd=cwd, since=since, query=query, limit=page_limit,
+        )
         return items
 
     def page(
@@ -358,6 +387,7 @@ class LocalSessionStore:
         tool: Optional[str] = None,
         cwd: Optional[str] = None,
         since: Optional[str] = None,
+        query: Optional[str] = None,
         limit: int = DEFAULT_PAGE_LIMIT,
         cursor: Optional[str] = None,
     ) -> tuple[list[Session], Optional[str]]:
@@ -374,6 +404,8 @@ class LocalSessionStore:
             if cwd is not None and s.cwd != cwd:
                 continue
             if since is not None and (s.last_active or "") < since:
+                continue
+            if not _matches_query(s, query):
                 continue
             rows.append(s)
         rows.sort(key=_sort_key, reverse=True)
@@ -640,12 +672,15 @@ class NativeFilesSessionStore:
         tool: Optional[str] = None,
         cwd: Optional[str] = None,
         since: Optional[str] = None,
+        query: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> list[Session]:
         # Same trick as LocalSessionStore.list: defer to page() so sort
         # and filter semantics are identical.
         page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
-        items, _ = self.page(tool=tool, cwd=cwd, since=since, limit=page_limit)
+        items, _ = self.page(
+            tool=tool, cwd=cwd, since=since, query=query, limit=page_limit,
+        )
         return items
 
     def page(
@@ -654,6 +689,7 @@ class NativeFilesSessionStore:
         tool: Optional[str] = None,
         cwd: Optional[str] = None,
         since: Optional[str] = None,
+        query: Optional[str] = None,
         limit: int = DEFAULT_PAGE_LIMIT,
         cursor: Optional[str] = None,
     ) -> tuple[list[Session], Optional[str]]:
@@ -680,6 +716,8 @@ class NativeFilesSessionStore:
                 if cwd is not None and s.cwd != cwd:
                     continue
                 if since is not None and (s.last_active or "") < since:
+                    continue
+                if not _matches_query(s, query):
                     continue
                 rows.append(s)
 
@@ -842,6 +880,7 @@ class ChainedSessionStore:
         tool: Optional[str] = None,
         cwd: Optional[str] = None,
         since: Optional[str] = None,
+        query: Optional[str] = None,
         limit: int = DEFAULT_PAGE_LIMIT,
         cursor: Optional[str] = None,
     ) -> tuple[list[Session], Optional[str]]:

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -139,6 +139,16 @@ class SessionStore(Protocol):
         """
         ...
 
+    def own_events(self, id: str) -> Iterator[Event]:
+        """Yield only this session's own events — no fork-chain walking.
+
+        Composing wrappers (e.g. ChainedSessionStore) walk fork chains
+        themselves to span multiple stores; they need a way to ask each
+        backend for one node's events without the backend also walking
+        the chain (which would double-emit parents).
+        """
+        ...
+
     def create(self, session: Session, events: Iterable[Event]) -> Session:
         """Insert a new session. `session.id` must be set by the caller.
         Returns the stored session record (potentially with normalized
@@ -260,6 +270,17 @@ class LocalSessionStore:
                     break
                 yield ev
                 yielded += 1
+
+    def own_events(self, id: str) -> Iterator[Event]:
+        """Yield only this session's own events — no fork-chain walk.
+
+        Used by ChainedSessionStore, which performs the cross-store chain
+        walk itself and would otherwise double-emit parent events when both
+        parent and child live in the same LocalSessionStore.
+        """
+        if self.get(id) is None:
+            raise KeyError(id)
+        yield from self._read_events(id)
 
     def create(self, session: Session, events: Iterable[Event]) -> Session:
         if not session.id:
@@ -529,6 +550,10 @@ class NativeFilesSessionStore:
         elif s.tool == "codex":
             yield from CodexSource(home=self._home).parse(path)
 
+    # Native session files don't carry forked_from links, so events()
+    # here never walks a fork chain — own_events is the same stream.
+    own_events = events
+
     def create(self, session: Session, events: Iterable[Event]) -> Session:
         raise NotImplementedError(
             "NativeFilesSessionStore is read-only. Use LocalSessionStore for writes."
@@ -657,13 +682,17 @@ class ChainedSessionStore:
             raise KeyError(id)
 
         # Build the chain across stores using our own get() as the lookup.
+        # Then for each node we ask its home store for that node's *own*
+        # events only — never `events()`, which would re-walk the chain
+        # internally and double-emit parents that live in the same store.
         chain = self._build_chain_across(leaf)
         for node, max_events in chain:
             home_store = self._store_for(node)
             if home_store is None:
                 continue
+            read_own = getattr(home_store, "own_events", home_store.events)
             yielded = 0
-            for ev in home_store.events(node.id):
+            for ev in read_own(node.id):
                 if max_events is not None and yielded >= max_events:
                     break
                 yield ev

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -71,6 +71,13 @@ log = logging.getLogger("fleet.track.store")
 MAX_PAGE_LIMIT: int = 200
 DEFAULT_PAGE_LIMIT: int = 50
 
+# Internal cap for ChainedSessionStore.page(): the maximum number of
+# rows pulled from each backing store per call. Only matters when the
+# total filtered row count across all stores exceeds this — for which
+# later cursor pages would miss data that fell off the per-store cap.
+# Tuned to comfortably exceed any single user's session count today.
+_CHAINED_BUFFER_CAP: int = 2000
+
 
 def _encode_cursor(last_active: Optional[str], id: str) -> str:
     raw = json.dumps({"la": last_active, "id": id}, separators=(",", ":"))
@@ -884,19 +891,64 @@ class ChainedSessionStore:
         limit: int = DEFAULT_PAGE_LIMIT,
         cursor: Optional[str] = None,
     ) -> tuple[list[Session], Optional[str]]:
-        # Cursor pagination across multiple stores requires a k-way
-        # merge with a composite cursor (one per backing store), which
-        # we don't need yet — the only paged consumer (`flt track ls
-        # --cursor`) targets a single backend at a time. If you want
-        # paged scripting, pick `--source native` / `stub` / `remote`
-        # explicitly. The interactive picker uses `list()` (eager merge)
-        # and never sees a cursor.
-        raise NotImplementedError(
-            "ChainedSessionStore.page() is intentionally unimplemented: "
-            "use --source native|stub|remote to paginate against a single "
-            "backend, or call .list() for the eager-merge view used by "
-            "the picker."
+        """Eager-merge then paginate.
+
+        We pull up to `_CHAINED_BUFFER_CAP` rows from each backing store
+        with the same filters, dedupe by `id` (first store wins),
+        merge-sort by the global key, then apply the cursor predicate
+        and slice into a page.
+
+        The `(la, id)` cursor format is the same as the single-store
+        backends — it indexes into the merged-and-sorted view, not into
+        any one store's local sequence. So a cursor minted on chained is
+        only meaningful against the same chained instance with the same
+        filters; that's fine because nobody passes chained cursors to
+        anything else.
+
+        Limitation: if the total filtered row count across all backends
+        exceeds `_CHAINED_BUFFER_CAP`, later pages would miss whatever
+        fell off each store's per-call cap. For interactive picker use
+        (typical user has <2000 sessions across all backends today)
+        this is invisible; revisit when remote scale arrives and have
+        chained delegate paging to a RemoteSessionStore that owns the
+        global ordering.
+        """
+        cur = _decode_cursor(cursor)
+        seen: set[str] = set()
+        rows: list[Session] = []
+        for store in self._stores:
+            try:
+                store_rows = list(store.list(
+                    tool=tool, cwd=cwd, since=since, query=query,
+                    limit=_CHAINED_BUFFER_CAP,
+                ))
+            except TypeError:
+                # Backwards-compat: a backing store that hasn't grown the
+                # `query` kwarg yet — fall back to filtering ourselves.
+                store_rows = list(store.list(
+                    tool=tool, cwd=cwd, since=since,
+                    limit=_CHAINED_BUFFER_CAP,
+                ))
+                if query:
+                    store_rows = [s for s in store_rows if _matches_query(s, query)]
+            for s in store_rows:
+                if s.id in seen:
+                    continue
+                seen.add(s.id)
+                rows.append(s)
+
+        rows.sort(key=_sort_key, reverse=True)
+        rows = [s for s in rows if _passes_cursor(s, cur)]
+
+        page = rows[: limit + 1]
+        has_more = len(page) > limit
+        page = page[:limit]
+        next_cursor = (
+            _encode_cursor(page[-1].last_active, page[-1].id)
+            if has_more and page
+            else None
         )
+        return page, next_cursor
 
     def get(self, id: str) -> Optional[Session]:
         ambiguous: list[str] = []

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -38,6 +38,7 @@ revisit if we ever ship multi-process scenarios.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -50,6 +51,98 @@ from .paths import TrackPaths
 from .unified import Event
 
 log = logging.getLogger("fleet.track.store")
+
+
+# ------------------------------------------------------------------ #
+# Pagination cursor — must stay byte-compatible with the orchestrator  #
+# ------------------------------------------------------------------ #
+#
+# A page cursor is `base64url(json({"la": <last_active or null>, "id": <id>}))`
+# with `=` padding stripped. Sort key everywhere is
+# `(last_active DESC NULLS LAST, id DESC)`; the cursor walks that ordering.
+#
+# Both ends MUST emit and consume the same bytes — see the matching helpers
+# in `theseus:orchestrator/public_api/track.py:_encode_cursor`. Any drift
+# is a wire-protocol break; the round-trip golden test in
+# `tests/track/test_store.py::test_cursor_format_pinned` exists to catch
+# accidental edits.
+
+# Page-size limit mirrors the orchestrator's `Query(ge=1, le=200)`.
+MAX_PAGE_LIMIT: int = 200
+DEFAULT_PAGE_LIMIT: int = 50
+
+
+def _encode_cursor(last_active: Optional[str], id: str) -> str:
+    raw = json.dumps({"la": last_active, "id": id}, separators=(",", ":"))
+    return base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: Optional[str]) -> Optional[dict]:
+    """Inverse of `_encode_cursor`. Returns None for empty input;
+    raises `ValueError` on malformed cursors so callers can map it to
+    HTTP 400 / typer.BadParameter as appropriate."""
+    if not cursor:
+        return None
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        decoded = json.loads(raw)
+    except (ValueError, json.JSONDecodeError) as e:
+        raise ValueError(f"invalid cursor: {e}") from e
+    if not isinstance(decoded, dict) or "id" not in decoded or "la" not in decoded:
+        raise ValueError(f"invalid cursor: missing keys {decoded!r}")
+    return decoded
+
+
+def _clamp_limit(limit: int) -> int:
+    if limit < 1:
+        return 1
+    if limit > MAX_PAGE_LIMIT:
+        return MAX_PAGE_LIMIT
+    return limit
+
+
+def _sort_key(s: "Session") -> tuple[int, str, str]:
+    """Sort key matching the server's ORDER BY (last_active DESC NULLS LAST,
+    id DESC). Returned as a positive tuple suitable for `sorted(..., reverse=True)`:
+
+      (la_present, la_or_empty, id)
+
+    With reverse=True:
+      - Rows with last_active sort first (la_present=1 > 0).
+      - Within those, larger last_active first.
+      - Tiebreak by larger id.
+      - NULL last_active rows sweep to the tail (la_present=0), still
+        ordered by id DESC.
+    """
+    la = s.last_active
+    return (1 if la else 0, la or "", s.id)
+
+
+def _passes_cursor(s: "Session", cursor: Optional[dict]) -> bool:
+    """True if `s` comes strictly AFTER the cursor's row in the global
+    ordering. Mirrors the server's WHERE predicate exactly so a cursor
+    minted on one side walks the same logical rows on the other."""
+    if cursor is None:
+        return True
+    cur_la = cursor.get("la")
+    cur_id = cursor["id"]
+    s_la = s.last_active
+
+    if cur_la is None:
+        # Cursor sits in the NULL tail. Only NULL-la rows with smaller
+        # id are still to be emitted.
+        return s_la is None and s.id < cur_id
+
+    # Cursor is in the non-null prefix. Three cases:
+    if s_la is None:
+        # NULL-la rows always sort AFTER any non-null cursor — emit.
+        return True
+    if s_la < cur_la:
+        return True
+    if s_la == cur_la and s.id < cur_id:
+        return True
+    return False
 
 
 # ------------------------------------------------------------------ #
@@ -121,6 +214,33 @@ class SessionStore(Protocol):
         `since` is ISO-8601; matched against `last_active`. Implementations
         may be lazy (returning an iterator) or eager (a list); callers
         should treat it as one-shot iterable.
+
+        For paged consumption (e.g. scripting or chaining cursors with
+        the remote backend), prefer `page()` — `list()` always materialises
+        the first page only, with no cursor surface.
+        """
+        ...
+
+    def page(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        cursor: Optional[str] = None,
+    ) -> tuple[list[Session], Optional[str]]:
+        """Return one page of sessions, plus the cursor for the next page.
+
+        Sort: `(last_active DESC NULLS LAST, id DESC)` — same on every
+        backend so cursors are interchangeable. `limit` is clamped to
+        [1, MAX_PAGE_LIMIT] (matching the orchestrator). `cursor` is an
+        opaque token from a prior call; pass `None` for the first page.
+
+        Returns `(items, next_cursor)`. `next_cursor is None` when this
+        is the last page. The cursor format is byte-compatible with
+        `theseus:orchestrator/public_api/track.py` so a cursor minted on
+        either side walks the same logical rows on the other.
         """
         ...
 
@@ -225,7 +345,29 @@ class LocalSessionStore:
         since: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> list[Session]:
-        out: list[Session] = []
+        # Backed by `page()` so sort+filter semantics stay identical to
+        # the cursor-paginated path. `limit=None` means "first page using
+        # the default limit"; callers wanting more should use `page()`.
+        page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
+        items, _ = self.page(tool=tool, cwd=cwd, since=since, limit=page_limit)
+        return items
+
+    def page(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        cursor: Optional[str] = None,
+    ) -> tuple[list[Session], Optional[str]]:
+        limit = _clamp_limit(limit)
+        cur = _decode_cursor(cursor)
+
+        # Materialize-then-sort. The local stub holds at most a few
+        # thousand rows in `index.jsonl`; an O(n log n) sort per call is
+        # cheap and lets us mirror the server's predicate exactly.
+        rows: list[Session] = []
         for s in self._read_index():
             if tool is not None and s.tool != tool:
                 continue
@@ -233,12 +375,20 @@ class LocalSessionStore:
                 continue
             if since is not None and (s.last_active or "") < since:
                 continue
-            out.append(s)
-        # Most-recent first.
-        out.sort(key=lambda s: s.last_active or s.started_at or "", reverse=True)
-        if limit is not None:
-            out = out[:limit]
-        return out
+            rows.append(s)
+        rows.sort(key=_sort_key, reverse=True)
+        rows = [s for s in rows if _passes_cursor(s, cur)]
+
+        # Fetch limit+1 to detect "more pages exist", same trick as server.
+        page = rows[: limit + 1]
+        has_more = len(page) > limit
+        page = page[:limit]
+        next_cursor = (
+            _encode_cursor(page[-1].last_active, page[-1].id)
+            if has_more and page
+            else None
+        )
+        return page, next_cursor
 
     def get(self, id: str) -> Optional[Session]:
         # Exact match first.
@@ -492,7 +642,25 @@ class NativeFilesSessionStore:
         since: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> list[Session]:
-        out: list[Session] = []
+        # Same trick as LocalSessionStore.list: defer to page() so sort
+        # and filter semantics are identical.
+        page_limit = limit if limit is not None else DEFAULT_PAGE_LIMIT
+        items, _ = self.page(tool=tool, cwd=cwd, since=since, limit=page_limit)
+        return items
+
+    def page(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        cursor: Optional[str] = None,
+    ) -> tuple[list[Session], Optional[str]]:
+        limit = _clamp_limit(limit)
+        cur = _decode_cursor(cursor)
+
+        rows: list[Session] = []
         for source, build_session in self._sources_with_session_builders():
             if tool is not None and source.name != tool:
                 continue
@@ -513,12 +681,20 @@ class NativeFilesSessionStore:
                     continue
                 if since is not None and (s.last_active or "") < since:
                     continue
-                out.append(s)
+                rows.append(s)
 
-        out.sort(key=lambda s: s.last_active or s.started_at or "", reverse=True)
-        if limit is not None:
-            out = out[:limit]
-        return out
+        rows.sort(key=_sort_key, reverse=True)
+        rows = [s for s in rows if _passes_cursor(s, cur)]
+
+        page = rows[: limit + 1]
+        has_more = len(page) > limit
+        page = page[:limit]
+        next_cursor = (
+            _encode_cursor(page[-1].last_active, page[-1].id)
+            if has_more and page
+            else None
+        )
+        return page, next_cursor
 
     def get(self, id: str) -> Optional[Session]:
         # Two-pass: exact match, then unique prefix.
@@ -655,10 +831,33 @@ class ChainedSessionStore:
                     continue
                 seen.add(s.id)
                 out.append(s)
-        out.sort(key=lambda s: s.last_active or s.started_at or "", reverse=True)
+        out.sort(key=_sort_key, reverse=True)
         if "limit" in kwargs and kwargs["limit"] is not None:
-            out = out[:kwargs["limit"]]
+            out = out[: kwargs["limit"]]
         return out
+
+    def page(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
+        cursor: Optional[str] = None,
+    ) -> tuple[list[Session], Optional[str]]:
+        # Cursor pagination across multiple stores requires a k-way
+        # merge with a composite cursor (one per backing store), which
+        # we don't need yet — the only paged consumer (`flt track ls
+        # --cursor`) targets a single backend at a time. If you want
+        # paged scripting, pick `--source native` / `stub` / `remote`
+        # explicitly. The interactive picker uses `list()` (eager merge)
+        # and never sees a cursor.
+        raise NotImplementedError(
+            "ChainedSessionStore.page() is intentionally unimplemented: "
+            "use --source native|stub|remote to paginate against a single "
+            "backend, or call .list() for the eager-merge view used by "
+            "the picker."
+        )
 
     def get(self, id: str) -> Optional[Session]:
         ambiguous: list[str] = []

--- a/fleet/track/unified.py
+++ b/fleet/track/unified.py
@@ -1,0 +1,370 @@
+"""Unified event format for AI coding sessions.
+
+Every format we ingest (claude, codex, cursor, opencode) parses into the
+same `Event` discriminated union. Each event carries:
+
+  - a small set of typed fields representing the **semantic kernel**
+    shared across formats (user said X, assistant said Y, tool was
+    called with args Z, etc.);
+  - a `source` tag identifying which CLI produced it;
+  - a `raw` blob containing the original row, so anything the kernel
+    doesn't model survives round-trip via the source's `serialize()`.
+
+Design constraints (re-stated for any reader of this file):
+
+  1. **Best-effort, never crash.** Unknown event subtypes parse as
+     `OpaqueEvent(original_type=...)` rather than raising. Malformed
+     JSON in a session file is logged + skipped.
+
+  2. **Lossy is OK.** claude → unified → codex deliberately drops
+     claude-specific concepts that codex can't render
+     (e.g. `parentUuid` branching). Round-trip *to the same source*
+     should be near-faithful via `raw`; round-trip across sources is
+     always lossy by construction.
+
+  3. **Linear iteration.** The unified stream is linear (a list, not a
+     tree). Tree-shaped sources (claude) flatten by walking the longest
+     leaf path; `parent_id` is preserved on each event so consumers that
+     care about branches can rebuild the tree.
+
+  4. **Source-agnostic kernel.** Field names borrow from neither claude
+     nor codex specifically. Where they diverge (e.g. claude uses
+     `tool_use_id`, codex uses `call_id`) we pick a neutral term
+     (`tool_call_id`).
+
+The kernel will grow over time as use cases demand. Today's set is
+"the events all four formats agreed on" — anything format-specific
+lives in `raw` and is recovered on serialize.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Mapping, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ------------------------------------------------------------------ #
+# Helpers (used by multiple events)                                    #
+# ------------------------------------------------------------------ #
+
+
+class ToolSpec(BaseModel):
+    """A tool the agent had available at session start.
+
+    Borrows attribute names from OpenTelemetry GenAI semantic conventions
+    (`gen_ai.tool.call.*`) and OpenInference's tool span shape, so emitting
+    OTel-compatible spans from this data later is a flat re-key.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    name: str
+    description: Optional[str] = None
+    input_schema: Optional[dict] = None  # JSON Schema
+
+# ------------------------------------------------------------------ #
+# Source tags                                                          #
+# ------------------------------------------------------------------ #
+
+Source = Literal["claude", "codex", "cursor", "opencode", "unknown"]
+
+
+# ------------------------------------------------------------------ #
+# Base                                                                 #
+# ------------------------------------------------------------------ #
+
+
+class _EventBase(BaseModel):
+    """Common fields on every event.
+
+    `model_config(extra="allow")` is intentional: a future format we
+    haven't seen yet may carry fields we'll want to read without bumping
+    the schema.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    source: Source
+    # Stable id from the source if any. claude.uuid for top-level rows;
+    # for events derived from one row's content blocks we suffix `#i`
+    # so the (id, parent_id) chain stays unique.
+    id: Optional[str] = None
+    parent_id: Optional[str] = None
+    # ISO-8601 string. Kept as string (not datetime) so we don't
+    # silently re-format it on round-trip.
+    timestamp: Optional[str] = None
+    # Original source row (or sub-row) as a dict. Source serializers use
+    # this to reconstruct format-specific fields the kernel doesn't model.
+    raw: Mapping[str, Any] = Field(default_factory=dict)
+    # True when the event was synthesized by a parser as a derived view
+    # (e.g. claude.parse fabricates a SessionStart from the first row's
+    # metadata; that synthesized event has no original row to round-trip
+    # back to). Same-source serializers skip these to keep the output
+    # byte-identical to the input. Cross-source serializers ignore the
+    # flag and synthesize freely.
+    synthesized: bool = False
+
+
+# ------------------------------------------------------------------ #
+# Lifecycle / metadata                                                 #
+# ------------------------------------------------------------------ #
+
+
+class SessionStart(_EventBase):
+    type: Literal["session_start"] = "session_start"
+    # Anything the format gives us about session-level context.
+    cwd: Optional[str] = None
+    model: Optional[str] = None
+    agent_version: Optional[str] = None
+    git_branch: Optional[str] = None
+    # System / developer instructions configured at session start.
+    user_instructions: Optional[str] = None
+    # Tools the agent had access to. Populated where the source format
+    # surfaces them (codex's tool catalog, claude system prompts that
+    # enumerate); empty when the source doesn't expose them as data.
+    tools_available: list[ToolSpec] = Field(default_factory=list)
+
+
+class SessionEnd(_EventBase):
+    type: Literal["session_end"] = "session_end"
+    stop_reason: Optional[str] = None
+
+
+class TurnStart(_EventBase):
+    """One agent "turn": a user message → some number of assistant outputs.
+
+    codex emits explicit task_started / task_complete events; claude
+    treats turns implicitly (a `user` row begins one). On parse, we
+    synthesize TurnStart / TurnEnd for sources that don't emit them so
+    consumers can rely on turn boundaries existing.
+    """
+
+    type: Literal["turn_start"] = "turn_start"
+    turn_id: Optional[str] = None
+    cwd: Optional[str] = None
+    model: Optional[str] = None
+
+
+class TurnEnd(_EventBase):
+    type: Literal["turn_end"] = "turn_end"
+    turn_id: Optional[str] = None
+    aborted: bool = False
+
+
+# ------------------------------------------------------------------ #
+# Conversation                                                         #
+# ------------------------------------------------------------------ #
+
+
+class UserMessage(_EventBase):
+    type: Literal["user_message"] = "user_message"
+    text: str
+    # Format-specific extras (image refs, file paths, etc.) live in raw.
+
+
+class AssistantMessage(_EventBase):
+    type: Literal["assistant_message"] = "assistant_message"
+    text: str
+    # codex.event_msg.agent_message has phase ∈ {commentary, final, ...}
+    # claude has no phase; we leave it None.
+    phase: Optional[str] = None
+    # Model that produced this message. Populated where parseable
+    # (claude `assistant.message.model`, codex's tracked turn context).
+    # None when the source doesn't say.
+    model: Optional[str] = None
+
+
+class AssistantReasoning(_EventBase):
+    """Model thinking / chain-of-thought.
+
+    claude exposes plaintext via `thinking` content blocks. codex stores
+    encrypted reasoning blobs (`encrypted_content`); the plaintext
+    streamed-event-msg variant (`agent_reasoning`) is also captured but
+    on a separate event.
+    """
+
+    type: Literal["assistant_reasoning"] = "assistant_reasoning"
+    text: Optional[str] = None
+    encrypted: bool = False
+    encrypted_content: Optional[str] = None
+
+
+# ------------------------------------------------------------------ #
+# Tool use                                                             #
+# ------------------------------------------------------------------ #
+
+
+class ToolCall(_EventBase):
+    type: Literal["tool_call"] = "tool_call"
+    tool_call_id: str
+    name: str
+    # Parsed JSON; codex stores `arguments` as a JSON string at the wire
+    # level. We parse on ingest so consumers get a dict.
+    input: dict = Field(default_factory=dict)
+
+
+class ToolResult(_EventBase):
+    type: Literal["tool_result"] = "tool_result"
+    # Empty string when the source row didn't carry one — codex
+    # function_call_output and exec_command_end both use call_id, but
+    # claude's tool_result references tool_use_id. Both map here.
+    tool_call_id: str
+    output: str = ""
+    is_error: bool = False
+    # Shell-tool extras when the source provides them.
+    exit_code: Optional[int] = None
+    duration_ms: Optional[int] = None
+
+
+# ------------------------------------------------------------------ #
+# Telemetry                                                            #
+# ------------------------------------------------------------------ #
+
+
+class TokenUsage(_EventBase):
+    type: Literal["token_usage"] = "token_usage"
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    cache_read_tokens: Optional[int] = None
+    cache_write_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    # OTel `gen_ai.provider.name` analog. "anthropic" / "openai" / etc.
+    provider: Optional[str] = None
+    # Wall-clock latency of the inference call producing these tokens,
+    # if the source records it. claude doesn't expose this directly;
+    # codex carries it in some event_msg variants.
+    latency_ms: Optional[int] = None
+
+
+# ------------------------------------------------------------------ #
+# File operations                                                      #
+# ------------------------------------------------------------------ #
+
+
+class FileEdit(_EventBase):
+    """A model-driven file edit, captured at edit-apply time.
+
+    claude: `file-history-snapshot` rows.
+    codex: `event_msg.patch_apply_end` rows.
+
+    We standardize on a unified-diff representation when the source
+    provides one; pre/post content is optional for sources that only
+    snapshot end-state.
+    """
+
+    type: Literal["file_edit"] = "file_edit"
+    path: str
+    diff: Optional[str] = None
+    pre_content: Optional[str] = None
+    post_content: Optional[str] = None
+
+
+# ------------------------------------------------------------------ #
+# Lifecycle catch-all + opaque                                         #
+# ------------------------------------------------------------------ #
+
+
+class Operator(_EventBase):
+    """Human-in-the-loop intervention.
+
+    Borrowed from Inspect AI's `operator` event class. Examples we
+    surface today: claude permission-mode toggles, future explicit
+    permission grants/denials. Distinct from `Lifecycle` because
+    operator events are user-driven; lifecycles are agent/runtime-driven.
+    """
+
+    type: Literal["operator"] = "operator"
+    action: str         # e.g. "permission_mode", "permission_grant", "interrupt"
+    detail: Optional[str] = None
+    # Optional structured payload (e.g. the new mode value, the granted
+    # tool name). Free-form so source-specific shapes survive round-trip.
+    metadata: dict = Field(default_factory=dict)
+
+
+class Attachment(_EventBase):
+    """User-attached blob (image, file, snippet) provided as input.
+
+    Distinct from `FileEdit` (which is a model-driven write to disk).
+    Inspect AI separates messages from attachments by reference id;
+    we follow the same pattern: `content` is inline payload (base64
+    for images), `ref` points to an external blob the source carries
+    out-of-band. At least one of `content` or `ref` is set, never both empty.
+    """
+
+    type: Literal["attachment"] = "attachment"
+    media_type: str          # e.g. "image/png", "text/plain", "application/pdf"
+    name: Optional[str] = None
+    content: Optional[str] = None  # base64 (images) or text (small)
+    ref: Optional[str] = None      # external reference (blob id, file path)
+
+
+class Lifecycle(_EventBase):
+    """Source-specific lifecycle events that don't map to a kernel concept
+    but are worth tagging by name (rather than being fully opaque)."""
+
+    type: Literal["lifecycle"] = "lifecycle"
+    name: str
+    """The original event name in the source format. Examples:
+       claude: 'pr_link', 'ai_title', 'last_prompt', 'queue_operation'
+       codex:  'thread_name_updated', 'error', 'context_compacted'
+    Tests assert on these names; serializers use them to round-trip."""
+
+
+class OpaqueEvent(_EventBase):
+    """Last-resort wrapper for source events we don't recognize at all.
+    Always preserves `raw` verbatim so the source serializer can
+    round-trip without losing data."""
+
+    type: Literal["opaque"] = "opaque"
+    original_type: str = ""
+
+
+# ------------------------------------------------------------------ #
+# Discriminated union                                                  #
+# ------------------------------------------------------------------ #
+
+
+Event = Annotated[
+    Union[
+        SessionStart,
+        SessionEnd,
+        TurnStart,
+        TurnEnd,
+        UserMessage,
+        AssistantMessage,
+        AssistantReasoning,
+        ToolCall,
+        ToolResult,
+        TokenUsage,
+        FileEdit,
+        Operator,
+        Attachment,
+        Lifecycle,
+        OpaqueEvent,
+    ],
+    Field(discriminator="type"),
+]
+
+
+# Convenience for consumers that want to hold a list of mixed events
+# without writing the union out every time.
+EventList = list[
+    Union[
+        SessionStart,
+        SessionEnd,
+        TurnStart,
+        TurnEnd,
+        UserMessage,
+        AssistantMessage,
+        AssistantReasoning,
+        ToolCall,
+        ToolResult,
+        TokenUsage,
+        FileEdit,
+        Operator,
+        Attachment,
+        Lifecycle,
+        OpaqueEvent,
+    ]
+]

--- a/fleet/track/unified.py
+++ b/fleet/track/unified.py
@@ -1,5 +1,23 @@
 """Unified event format for AI coding sessions.
 
+# Cross-codebase shared schema
+
+This module — together with `fleet.track.sources` — is **the single
+source of truth for the unified Event schema and per-source parsers**.
+
+The orchestrator (`theseus`) imports these modules directly to parse
+sessions uploaded from clients into `Session` records. Do NOT fork the
+schema or parsers in the orchestrator; depend on this package and bump
+the SDK pin when adding new event types or source quirks. Bidirectional
+drift would silently produce stale or incompatible session records on
+the server.
+
+Public surface for orchestrator consumption:
+  - `fleet.track.unified.Event` (discriminated union) and its variants
+  - `fleet.track.unified.SessionMetadata` schema (in `store.py` for now;
+    move here if the orchestrator import path becomes a hot spot)
+  - `fleet.track.sources.{ClaudeSource, CodexSource, ...}` for parsing
+
 Every format we ingest (claude, codex, cursor, opencode) parses into the
 same `Event` discriminated union. Each event carries:
 

--- a/fleet/track/uploader.py
+++ b/fleet/track/uploader.py
@@ -1,0 +1,168 @@
+"""Upload worker pool.
+
+Scrubs file content locally, then PUTs to presigned S3 URLs.
+8 concurrent workers. Reads only complete lines from active JSONL files.
+
+`Transport` is the seam tests fake. Production uses `HttpxTransport`,
+backed by an `httpx.Client`; tests use `httpx.MockTransport` or a
+purpose-built `RecordingTransport`.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable, Optional, Protocol
+
+import httpx
+
+from .scrubber import scrub_bytes
+
+log = logging.getLogger("fleet.track.uploader")
+
+WORKERS = 8
+# Per-phase timeouts: connect/read can be short, write is generous for
+# large JSONL files on slow connections.
+DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=300.0, pool=10.0)
+
+
+# ------------------------------------------------------------------ #
+# Transport seam                                                       #
+# ------------------------------------------------------------------ #
+
+
+class Transport(Protocol):
+    """Minimum surface needed to PUT a presigned URL."""
+
+    def put(self, url: str, content: bytes) -> int:
+        """Return HTTP status. Raise httpx.RequestError on network failure."""
+
+
+class HttpxTransport:
+    """Production transport: a real httpx.Client.
+
+    Wraps any caller-provided client (so tests can inject MockTransport)
+    or constructs one if none is given.
+    """
+
+    def __init__(self, client: Optional[httpx.Client] = None) -> None:
+        self._client = client or httpx.Client(timeout=DEFAULT_TIMEOUT)
+        self._owns_client = client is None
+
+    def put(self, url: str, content: bytes) -> int:
+        resp = self._client.put(
+            url,
+            content=content,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        return resp.status_code
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+# ------------------------------------------------------------------ #
+# Read + scrub                                                         #
+# ------------------------------------------------------------------ #
+
+
+def _read_safe(path: Path) -> Optional[bytes]:
+    """Read file content safely for active JSONL files.
+
+    Truncates to last complete newline so a partial JSON line at EOF
+    (mid-write by the agent) doesn't get uploaded as malformed JSON.
+    """
+    try:
+        data = path.read_bytes()
+    except OSError as e:
+        log.warning("read failed %s: %s", path, e)
+        return None
+
+    if path.suffix == ".jsonl" and data and not data.endswith(b"\n"):
+        last_nl = data.rfind(b"\n")
+        if last_nl > 0:
+            data = data[: last_nl + 1]
+
+    return data
+
+
+def upload_one(path: Path, presigned_url: str, transport: Transport) -> bool:
+    """Scrub and upload a single file. Returns True on success."""
+    data = _read_safe(path)
+    if data is None:
+        return False
+
+    scrubbed = scrub_bytes(data)
+
+    try:
+        status = transport.put(presigned_url, scrubbed)
+        if status not in (200, 204):
+            log.warning("upload %s → HTTP %s", path.name, status)
+            return False
+        return True
+    except httpx.RequestError as e:
+        log.warning("upload %s network error: %s", path.name, e)
+        return False
+
+
+# ------------------------------------------------------------------ #
+# Worker pool                                                          #
+# ------------------------------------------------------------------ #
+
+
+class UploadPool:
+    """Thread pool for concurrent uploads with result callbacks."""
+
+    def __init__(
+        self,
+        on_done: Callable[[str, str], None],
+        on_failed: Callable[[str, str, str], None],
+        transport: Optional[Transport] = None,
+    ) -> None:
+        self._on_done = on_done
+        self._on_failed = on_failed
+        self._transport: Transport = transport or HttpxTransport()
+        self._pool = ThreadPoolExecutor(max_workers=WORKERS, thread_name_prefix="track-upload")
+        self._in_flight: dict[str, Future] = {}
+        self._lock = threading.Lock()
+
+    def submit(self, rel_path: str, sha256: str, abs_path: Path, presigned_url: str) -> None:
+        future = self._pool.submit(self._run, rel_path, sha256, abs_path, presigned_url)
+        with self._lock:
+            self._in_flight[rel_path] = future
+
+    def _run(self, rel_path: str, sha256: str, abs_path: Path, presigned_url: str) -> None:
+        try:
+            ok = upload_one(abs_path, presigned_url, self._transport)
+            if ok:
+                log.debug("uploaded %s", rel_path)
+                self._on_done(rel_path, sha256)
+            else:
+                self._on_failed(rel_path, sha256, "upload returned failure")
+        except Exception as e:
+            log.exception("upload error %s", rel_path)
+            self._on_failed(rel_path, sha256, str(e))
+        finally:
+            with self._lock:
+                self._in_flight.pop(rel_path, None)
+
+    def in_flight_count(self) -> int:
+        with self._lock:
+            return len(self._in_flight)
+
+    def drain(self, timeout: float = 30.0) -> None:
+        """Wait for all in-flight uploads to complete."""
+        with self._lock:
+            futures = list(self._in_flight.values())
+        for f in futures:
+            try:
+                f.result(timeout=timeout)
+            except Exception:
+                pass
+
+    def shutdown(self) -> None:
+        self.drain()
+        self._pool.shutdown(wait=False)

--- a/fleet/track/watcher.py
+++ b/fleet/track/watcher.py
@@ -1,0 +1,108 @@
+"""FSEvents (Mac) / inotify (Linux) file watcher with per-path debouncing.
+
+Uses watchdog for cross-platform support.
+Debounce window: 2.5s per path — batches rapid JSONL appends into one event.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Callable
+
+try:
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+    WATCHDOG_AVAILABLE = True
+except ImportError:
+    WATCHDOG_AVAILABLE = False
+
+from .sources import WATCH_ROOTS, EXCLUDE_PATTERNS
+
+log = logging.getLogger("fleet.track.watcher")
+
+DEBOUNCE_SECS = 2.5
+EXTENSIONS = {".jsonl", ".json", ".txt"}
+
+
+class _DebounceHandler:
+    """Accumulates file events and fires callback after DEBOUNCE_SECS of quiet."""
+
+    def __init__(self, callback: Callable[[list[Path]], None]) -> None:
+        self._callback = callback
+        self._pending: dict[str, float] = {}  # path → last-seen time
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._flush_loop, daemon=True)
+        self._thread.start()
+
+    def touch(self, path: str) -> None:
+        with self._lock:
+            self._pending[path] = time.monotonic()
+
+    def _flush_loop(self) -> None:
+        while True:
+            time.sleep(0.5)
+            now = time.monotonic()
+            ready: list[Path] = []
+            with self._lock:
+                expired = [p for p, t in self._pending.items() if now - t >= DEBOUNCE_SECS]
+                for p in expired:
+                    del self._pending[p]
+                    ready.append(Path(p))
+            if ready:
+                try:
+                    self._callback(ready)
+                except Exception:
+                    log.exception("debounce callback error")
+
+
+class FileWatcher:
+    """Watches source directories and calls callback with changed paths."""
+
+    def __init__(self, callback: Callable[[list[Path]], None]) -> None:
+        if not WATCHDOG_AVAILABLE:
+            raise RuntimeError("watchdog not installed — run: pip install watchdog")
+
+        self._debounce = _DebounceHandler(callback)
+        self._observer = Observer()
+        self._handler = _EventHandler(self._debounce)
+
+    def start(self) -> None:
+        for root in WATCH_ROOTS:
+            if root.is_dir():
+                self._observer.schedule(self._handler, str(root), recursive=True)
+                log.info("watching %s", root)
+            else:
+                log.debug("skip watch (not found): %s", root)
+        self._observer.start()
+
+    def stop(self) -> None:
+        self._observer.stop()
+        self._observer.join(timeout=5)
+
+
+if WATCHDOG_AVAILABLE:
+    class _EventHandler(FileSystemEventHandler):
+        def __init__(self, debounce: _DebounceHandler) -> None:
+            self._debounce = debounce
+
+        def on_modified(self, event: FileSystemEvent) -> None:
+            self._handle(event)
+
+        def on_created(self, event: FileSystemEvent) -> None:
+            self._handle(event)
+
+        def _handle(self, event: FileSystemEvent) -> None:
+            if event.is_directory:
+                return
+            path = Path(str(event.src_path))
+            if path.suffix not in EXTENSIONS:
+                return
+            if any(excl in path.parts for excl in EXCLUDE_PATTERNS):
+                return
+            self._debounce.touch(str(path))
+else:
+    class _EventHandler:  # type: ignore[no-redef]
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ flt = "fleet.cli:main"
 cli = [
     "typer>=0.9.0",
     "rich>=10.0.0",
+    "watchdog>=4.0.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,12 @@ cli = [
     "typer>=0.9.0",
     "rich>=10.0.0",
     "watchdog>=4.0.0",
+    "textual>=0.50.0",
 ]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-mock>=3.14.0",
     "black>=22.0.0",
     "isort>=5.0.0",
     "mypy>=1.0.0",
@@ -53,6 +55,7 @@ dev = [
     "python-dotenv>=1.1.1",
     "typer>=0.9.0",
     "rich>=10.0.0",
+    "textual>=0.50.0",
 ]
 playwright = [
     "playwright>=1.40.0",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+import stat
+
+from fleet import auth
+
+
+def test_save_credentials_writes_private_file(tmp_path, monkeypatch):
+    credentials_file = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth, "CREDENTIALS_FILE", credentials_file)
+
+    auth.save_credentials({"access_token": "token"})
+
+    assert json.loads(credentials_file.read_text()) == {"access_token": "token"}
+    assert stat.S_IMODE(credentials_file.stat().st_mode) == 0o600

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from fleet.cli import _mask_secret
+
+
+def test_mask_secret_redacts_short_values():
+    assert _mask_secret("short-key") == "[redacted]"
+
+
+def test_mask_secret_keeps_prefix_and_suffix_for_long_values():
+    assert _mask_secret("abcdefgh1234567890") == "abcdefgh...7890"

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -58,7 +58,10 @@ def test_get_manifest_returns_files_dict():
         assert request.headers.get("x-device-id") == "dev1"
         return httpx.Response(
             200,
-            json={"root_hash": "abc", "files": {".claude/x.jsonl": "h1", ".codex/y.jsonl": "h2"}},
+            json={
+                "root_hash": "abc",
+                "files": {".claude/x.jsonl": "h1", ".codex/y.jsonl": "h2"},
+            },
         )
 
     api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
@@ -116,8 +119,92 @@ def test_get_upload_urls_chunks_above_server_cap():
     urls = api.get_upload_urls("dev1", paths)
 
     # Three chunks expected: 100 + 100 + 50.
-    assert requests_received == [SERVER_UPLOAD_URL_BATCH_CAP, SERVER_UPLOAD_URL_BATCH_CAP, 50]
+    assert requests_received == [
+        SERVER_UPLOAD_URL_BATCH_CAP,
+        SERVER_UPLOAD_URL_BATCH_CAP,
+        50,
+    ]
     assert len(urls) == 250
+
+
+def test_upsert_session_posts_relative_path_and_session_payload():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(204)
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    api.upsert_session(
+        device_id="dev1",
+        path=".codex/sessions/rollout-2026-05-05T00-00-00-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+        session={
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "tool": "codex",
+            "cwd": "/tmp/project",
+            "event_count": 3,
+            "metadata": {"title": "demo"},
+        },
+    )
+
+    assert captured["url"] == (
+        "http://test/v1/track/sessions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    )
+    assert captured["body"]["device_id"] == "dev1"
+    assert captured["body"]["path"].startswith(".codex/sessions/")
+    assert captured["body"]["session"]["tool"] == "codex"
+
+
+def test_list_sessions_sends_filters_and_returns_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": "s1",
+                        "tool": "claude",
+                        "last_active": "2026-05-05T00:00:00Z",
+                    }
+                ],
+                "next_cursor": "next",
+            },
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.list_sessions(tool="claude", query="fleet", limit=25, cursor="cur")
+
+    assert captured["params"] == {
+        "tool": "claude",
+        "query": "fleet",
+        "limit": "25",
+        "cursor": "cur",
+    }
+    assert out["items"][0]["id"] == "s1"
+    assert out["next_cursor"] == "next"
+
+
+def test_download_session_content_uses_presigned_url_without_auth_headers():
+    seen: list[tuple[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((str(request.url), request.headers.get("x-jwt-token")))
+        if request.url.path == "/v1/track/sessions/s1/content":
+            return httpx.Response(200, json={"url": "https://s3.test/session"})
+        if str(request.url) == "https://s3.test/session":
+            return httpx.Response(200, content=b'{"ok": true}\n')
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    assert api.download_session_content("s1") == b'{"ok": true}\n'
+    assert seen == [
+        ("http://test/v1/track/sessions/s1/content", "jwt-abc"),
+        ("https://s3.test/session", None),
+    ]
 
 
 def test_unauthenticated_raises_track_api_error():
@@ -131,7 +218,9 @@ def test_unauthenticated_raises_track_api_error():
 
 def test_4xx_response_raises_with_detail_message():
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(403, json={"detail": "Track requires user-scoped credentials."})
+        return httpx.Response(
+            403, json={"detail": "Track requires user-scoped credentials."}
+        )
 
     api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
     with pytest.raises(TrackAPIError) as ei:

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -1,0 +1,164 @@
+"""Unit tests for api.py — uses httpx.MockTransport, no network."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional, Tuple
+
+import httpx
+import pytest
+
+from fleet.track.api import (
+    SERVER_UPLOAD_URL_BATCH_CAP,
+    TrackAPIClient,
+    TrackAPIError,
+)
+
+
+def _auth() -> Optional[Tuple[str, str]]:
+    return ("jwt-abc", "team-1")
+
+
+def _no_auth() -> Optional[Tuple[str, str]]:
+    return None
+
+
+def _client_with_handler(handler):
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport, base_url="http://test")
+
+
+def test_provision_sends_expected_payload_and_headers():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"device_id": "dev1", "team_id": "team-1", "user_id": "user-1"},
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.provision("dev1")
+
+    assert out == {"device_id": "dev1", "team_id": "team-1", "user_id": "user-1"}
+    assert captured["url"] == "http://test/v1/track/provision"
+    assert captured["headers"]["x-jwt-token"] == "jwt-abc"
+    assert captured["headers"]["x-team-id"] == "team-1"
+    assert captured["body"]["device_id"] == "dev1"
+    assert "hostname" in captured["body"]
+    assert "platform" in captured["body"]
+
+
+def test_get_manifest_returns_files_dict():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.headers.get("x-device-id") == "dev1"
+        return httpx.Response(
+            200,
+            json={"root_hash": "abc", "files": {".claude/x.jsonl": "h1", ".codex/y.jsonl": "h2"}},
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    files = api.get_manifest("dev1")
+    assert files == {".claude/x.jsonl": "h1", ".codex/y.jsonl": "h2"}
+
+
+def test_get_manifest_empty_on_first_run():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"root_hash": "", "files": {}})
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    assert api.get_manifest("dev1") == {}
+
+
+def test_get_upload_urls_round_trips():
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"urls": {p: f"https://s3/{p}?sig=x" for p in body["paths"]}},
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    urls = api.get_upload_urls("dev1", [".claude/a.jsonl", ".codex/b.jsonl"])
+    assert urls == {
+        ".claude/a.jsonl": "https://s3/.claude/a.jsonl?sig=x",
+        ".codex/b.jsonl": "https://s3/.codex/b.jsonl?sig=x",
+    }
+
+
+def test_get_upload_urls_empty_paths_skips_request():
+    called = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["n"] += 1
+        return httpx.Response(200, json={"urls": {}})
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    assert api.get_upload_urls("dev1", []) == {}
+    assert called["n"] == 0
+
+
+def test_get_upload_urls_chunks_above_server_cap():
+    """Server caps at 100; client must chunk so one logical request → many HTTP calls."""
+    requests_received: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests_received.append(len(body["paths"]))
+        return httpx.Response(200, json={"urls": {p: f"u/{p}" for p in body["paths"]}})
+
+    paths = [f"f{i}.jsonl" for i in range(250)]  # 250 > cap of 100
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    urls = api.get_upload_urls("dev1", paths)
+
+    # Three chunks expected: 100 + 100 + 50.
+    assert requests_received == [SERVER_UPLOAD_URL_BATCH_CAP, SERVER_UPLOAD_URL_BATCH_CAP, 50]
+    assert len(urls) == 250
+
+
+def test_unauthenticated_raises_track_api_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_no_auth)
+    with pytest.raises(TrackAPIError, match="Not authenticated"):
+        api.provision("dev1")
+
+
+def test_4xx_response_raises_with_detail_message():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "Track requires user-scoped credentials."})
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    with pytest.raises(TrackAPIError) as ei:
+        api.provision("dev1")
+    assert "403" in str(ei.value)
+    assert "user-scoped" in str(ei.value)
+
+
+def test_5xx_response_includes_status_in_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="upstream exploded")
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    with pytest.raises(TrackAPIError) as ei:
+        api.get_manifest("dev1")
+    assert "500" in str(ei.value)
+
+
+def test_context_manager_closes_owned_client():
+    """When the API client constructs its own httpx.Client, exiting the context
+    closes it. When client is injected, we must not close the caller's."""
+    api_owned = TrackAPIClient(auth_provider=_auth)
+    api_owned.close()  # must not raise
+
+    injected = httpx.Client(base_url="http://test")
+    with TrackAPIClient(client=injected, auth_provider=_auth):
+        pass
+    # Injected client was NOT owned by the API; should still be usable.
+    assert not injected.is_closed
+    injected.close()

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -1,0 +1,58 @@
+"""Unit tests for flt track CLI helpers."""
+
+from __future__ import annotations
+
+import json
+import socket
+import uuid
+
+import pytest
+import typer
+
+from fleet.track import cli
+from fleet.track.api import TrackAPIError
+from fleet.track.paths import TrackPaths
+
+
+def test_enable_persists_generated_device_id_before_provision_retry(
+    tmp_path,
+    monkeypatch,
+):
+    """A failed first provision must not make the next enable use a new device."""
+    paths = TrackPaths.under(tmp_path)
+    seen_device_ids: list[str] = []
+
+    class FailingTrackAPIClient:
+        def provision(self, device_id: str) -> dict:
+            seen_device_ids.append(device_id)
+            raise TrackAPIError("network down")
+
+    monkeypatch.setattr(cli.TrackPaths, "default", lambda: paths)
+    monkeypatch.setattr("fleet.auth.get_valid_token", lambda: ("jwt", "team-1"))
+    monkeypatch.setattr(cli, "TrackAPIClient", FailingTrackAPIClient)
+    monkeypatch.setattr(socket, "gethostname", lambda: "Dev Laptop")
+    monkeypatch.setattr(
+        cli.uuid,
+        "uuid4",
+        lambda: uuid.UUID("11111111-2222-3333-4444-555555555555"),
+    )
+
+    with pytest.raises(typer.Exit):
+        cli.enable()
+
+    config = json.loads(paths.config_file.read_text())
+    assert config["device_id"] == "dev-laptop-11111111"
+
+    monkeypatch.setattr(
+        cli.uuid,
+        "uuid4",
+        lambda: uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+    )
+
+    with pytest.raises(typer.Exit):
+        cli.enable()
+
+    assert seen_device_ids == ["dev-laptop-11111111", "dev-laptop-11111111"]
+    assert json.loads(paths.config_file.read_text())["device_id"] == (
+        "dev-laptop-11111111"
+    )

--- a/tests/track/test_compactor.py
+++ b/tests/track/test_compactor.py
@@ -197,7 +197,7 @@ def test_compactor_drops_oldest_when_over_budget():
     assert len(out) < len(events)
 
 
-def test_compactor_skips_oversized_tail_event_and_keeps_smaller_older_events():
+def test_compactor_keeps_contiguous_recent_suffix_when_middle_event_is_oversized():
     events = [
         UserMessage(source="claude", text="older small"),
         UserMessage(source="claude", text="oversized"),
@@ -215,7 +215,7 @@ def test_compactor_skips_oversized_tail_event_and_keeps_smaller_older_events():
 
     out = c.compact(events)
 
-    assert [e.text for e in out] == ["older small", "newer small"]
+    assert [e.text for e in out] == ["newer small"]
 
 
 def test_compactor_summary_can_be_disabled():

--- a/tests/track/test_compactor.py
+++ b/tests/track/test_compactor.py
@@ -76,8 +76,12 @@ def test_estimate_event_tokens_includes_tool_input():
         ToolCall(source="claude", tool_call_id="t", name="Bash", input={})
     )
     big_input = estimate_event_tokens(
-        ToolCall(source="claude", tool_call_id="t", name="Bash",
-                  input={"command": "x" * 4000})
+        ToolCall(
+            source="claude",
+            tool_call_id="t",
+            name="Bash",
+            input={"command": "x" * 4000},
+        )
     )
     assert big_input > bare
 
@@ -115,9 +119,13 @@ def test_compactor_drop_flags_independent():
     ]
     c = TruncationCompactor(
         budget=_generous_budget(),
-        cfg=TruncationConfig(drop_lifecycle=False, drop_attachments=False,
-                              drop_reasoning=False, drop_opaque=False,
-                              drop_token_usage=False),
+        cfg=TruncationConfig(
+            drop_lifecycle=False,
+            drop_attachments=False,
+            drop_reasoning=False,
+            drop_opaque=False,
+            drop_token_usage=False,
+        ),
     )
     out = c.compact(events)
     assert len(out) == 2  # nothing dropped
@@ -189,6 +197,27 @@ def test_compactor_drops_oldest_when_over_budget():
     assert len(out) < len(events)
 
 
+def test_compactor_skips_oversized_tail_event_and_keeps_smaller_older_events():
+    events = [
+        UserMessage(source="claude", text="older small"),
+        UserMessage(source="claude", text="oversized"),
+        UserMessage(source="claude", text="newer small"),
+    ]
+
+    def estimate(ev):
+        return 300 if getattr(ev, "text", "") == "oversized" else 100
+
+    c = TruncationCompactor(
+        budget=TokenBudget(target=1_200, margin=1.0),
+        cfg=TruncationConfig(summarize_dropped=False),
+        token_estimator=estimate,
+    )
+
+    out = c.compact(events)
+
+    assert [e.text for e in out] == ["older small", "newer small"]
+
+
 def test_compactor_summary_can_be_disabled():
     events: list = []
     for i in range(20):
@@ -207,10 +236,17 @@ def test_compactor_summary_includes_dropped_metadata():
     events: list = []
     for i in range(10):
         events.append(UserMessage(source="claude", text=f"q{i}"))
-        events.append(ToolCall(source="claude", tool_call_id=f"t{i}", name="Bash",
-                                input={"command": "x" * 200}))
-        events.append(ToolResult(source="claude", tool_call_id=f"t{i}",
-                                  output="y" * 200))
+        events.append(
+            ToolCall(
+                source="claude",
+                tool_call_id=f"t{i}",
+                name="Bash",
+                input={"command": "x" * 200},
+            )
+        )
+        events.append(
+            ToolResult(source="claude", tool_call_id=f"t{i}", output="y" * 200)
+        )
         events.append(AssistantMessage(source="claude", text=f"a{i}"))
 
     # Tight budget so we drop a bunch of turns.

--- a/tests/track/test_compactor.py
+++ b/tests/track/test_compactor.py
@@ -1,0 +1,251 @@
+"""Tests for the Compactor protocol and TruncationCompactor."""
+
+from __future__ import annotations
+
+from fleet.track.compactor import (
+    KNOWN_MODELS,
+    TokenBudget,
+    TruncationCompactor,
+    TruncationConfig,
+    budget_for,
+    estimate_event_tokens,
+    estimate_tokens,
+)
+from fleet.track.unified import (
+    AssistantMessage,
+    Attachment,
+    AssistantReasoning,
+    Lifecycle,
+    OpaqueEvent,
+    SessionStart,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+    UserMessage,
+)
+
+
+# ------------------------------------------------------------------ #
+# Token budget                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_token_budget_usable_applies_margin():
+    b = TokenBudget(target=100_000, margin=0.85)
+    assert b.usable == 85_000
+
+
+def test_budget_for_known_model():
+    b = budget_for("codex", "gpt-5")
+    assert b.target == KNOWN_MODELS["gpt-5"]
+
+
+def test_budget_for_unknown_model_uses_tool_default():
+    b = budget_for("codex", "future-model-no-one-knows")
+    assert b.target == 200_000  # codex default
+
+
+def test_budget_for_unknown_tool_uses_conservative_fallback():
+    b = budget_for("future-tool", None)
+    assert b.target == 100_000
+
+
+def test_budget_for_claude_opus_4_7_is_million():
+    """The 1M-context model should get the full window in its budget."""
+    b = budget_for("claude", "claude-opus-4-7")
+    assert b.target == 1_000_000
+
+
+# ------------------------------------------------------------------ #
+# Token estimation                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_estimate_tokens_returns_at_least_one():
+    assert estimate_tokens("a") >= 1
+
+
+def test_estimate_event_tokens_includes_text_and_overhead():
+    short = estimate_event_tokens(UserMessage(source="claude", text="hi"))
+    long = estimate_event_tokens(UserMessage(source="claude", text="x" * 4000))
+    assert long > short
+
+
+def test_estimate_event_tokens_includes_tool_input():
+    bare = estimate_event_tokens(
+        ToolCall(source="claude", tool_call_id="t", name="Bash", input={})
+    )
+    big_input = estimate_event_tokens(
+        ToolCall(source="claude", tool_call_id="t", name="Bash",
+                  input={"command": "x" * 4000})
+    )
+    assert big_input > bare
+
+
+# ------------------------------------------------------------------ #
+# TruncationCompactor — drop noise                                     #
+# ------------------------------------------------------------------ #
+
+
+def _generous_budget() -> TokenBudget:
+    return TokenBudget(target=10_000_000, margin=1.0)  # effectively unlimited
+
+
+def test_compactor_drops_attachments_lifecycle_reasoning():
+    events: list = [
+        UserMessage(source="claude", text="ask"),
+        AssistantReasoning(source="claude", text="think"),
+        Lifecycle(source="claude", name="ai_title"),
+        Attachment(source="claude", media_type="image/png"),
+        OpaqueEvent(source="claude", original_type="future"),
+        TokenUsage(source="claude", input_tokens=1, output_tokens=1),
+        AssistantMessage(source="claude", text="answer"),
+    ]
+    c = TruncationCompactor(budget=_generous_budget())
+    out = c.compact(events)
+    types = [e.type for e in out]
+    assert types == ["user_message", "assistant_message"]
+
+
+def test_compactor_drop_flags_independent():
+    """Each drop flag controls only its own type."""
+    events = [
+        UserMessage(source="claude", text="x"),
+        Lifecycle(source="claude", name="x"),
+    ]
+    c = TruncationCompactor(
+        budget=_generous_budget(),
+        cfg=TruncationConfig(drop_lifecycle=False, drop_attachments=False,
+                              drop_reasoning=False, drop_opaque=False,
+                              drop_token_usage=False),
+    )
+    out = c.compact(events)
+    assert len(out) == 2  # nothing dropped
+
+
+# ------------------------------------------------------------------ #
+# TruncationCompactor — output truncation                              #
+# ------------------------------------------------------------------ #
+
+
+def test_compactor_truncates_large_tool_results():
+    big = "x" * 10_000
+    c = TruncationCompactor(
+        budget=_generous_budget(),
+        cfg=TruncationConfig(max_tool_output_chars=100),
+    )
+    events = [ToolResult(source="claude", tool_call_id="t", output=big)]
+    out = c.compact(events)
+    assert len(out) == 1
+    assert len(out[0].output) < len(big)
+    assert "truncated" in out[0].output
+
+
+def test_compactor_no_truncation_when_cap_is_none():
+    big = "x" * 10_000
+    c = TruncationCompactor(
+        budget=_generous_budget(),
+        cfg=TruncationConfig(max_tool_output_chars=None),
+    )
+    events = [ToolResult(source="claude", tool_call_id="t", output=big)]
+    out = c.compact(events)
+    assert out[0].output == big
+
+
+# ------------------------------------------------------------------ #
+# TruncationCompactor — budget targeting                               #
+# ------------------------------------------------------------------ #
+
+
+def test_compactor_keeps_everything_when_under_budget():
+    events: list = [SessionStart(source="claude", id="s")]
+    for i in range(5):
+        events.append(UserMessage(source="claude", text=f"q{i}"))
+        events.append(AssistantMessage(source="claude", text=f"a{i}"))
+
+    # Generous budget: nothing should be dropped (and no summary).
+    c = TruncationCompactor(budget=_generous_budget())
+    out = c.compact(events)
+    assert len(out) == len(events)
+    assert all("session summary" not in getattr(e, "text", "") for e in out)
+
+
+def test_compactor_drops_oldest_when_over_budget():
+    """A tight budget should keep tail events, drop early ones, prepend a summary."""
+    events: list = [SessionStart(source="claude", id="s")]
+    for i in range(20):
+        events.append(UserMessage(source="claude", text="x" * 500))
+        events.append(AssistantMessage(source="claude", text="y" * 500))
+
+    # Budget tight enough that we can't fit all 40 large messages.
+    c = TruncationCompactor(budget=TokenBudget(target=2_000, margin=1.0))
+    out = c.compact(events)
+
+    # Head: SessionStart preserved.
+    assert out[0].type == "session_start"
+    # Summary present.
+    assert any("session summary" in getattr(e, "text", "").lower() for e in out)
+    # Output is shorter than input.
+    assert len(out) < len(events)
+
+
+def test_compactor_summary_can_be_disabled():
+    events: list = []
+    for i in range(20):
+        events.append(UserMessage(source="claude", text="x" * 500))
+
+    c = TruncationCompactor(
+        budget=TokenBudget(target=2_000, margin=1.0),
+        cfg=TruncationConfig(summarize_dropped=False),
+    )
+    out = c.compact(events)
+    # No summary message present.
+    assert not any("session summary" in getattr(e, "text", "").lower() for e in out)
+
+
+def test_compactor_summary_includes_dropped_metadata():
+    events: list = []
+    for i in range(10):
+        events.append(UserMessage(source="claude", text=f"q{i}"))
+        events.append(ToolCall(source="claude", tool_call_id=f"t{i}", name="Bash",
+                                input={"command": "x" * 200}))
+        events.append(ToolResult(source="claude", tool_call_id=f"t{i}",
+                                  output="y" * 200))
+        events.append(AssistantMessage(source="claude", text=f"a{i}"))
+
+    # Tight budget so we drop a bunch of turns.
+    c = TruncationCompactor(budget=TokenBudget(target=1_500, margin=1.0))
+    out = c.compact(events)
+
+    summaries = [e for e in out if "session summary" in getattr(e, "text", "").lower()]
+    assert len(summaries) == 1
+    s = summaries[0].text
+    # Spot-check structural fields appear.
+    assert "user messages" in s
+    assert "tool calls" in s
+    assert "Bash" in s
+
+
+def test_compactor_preserves_session_start_at_head():
+    """SessionStart at the very front survives even with a tight budget."""
+    events: list = [SessionStart(source="claude", id="s")]
+    for _ in range(50):
+        events.append(UserMessage(source="claude", text="x" * 1000))
+
+    c = TruncationCompactor(budget=TokenBudget(target=500, margin=1.0))
+    out = c.compact(events)
+    assert out[0].type == "session_start"
+
+
+# ------------------------------------------------------------------ #
+# Compactor protocol shape                                             #
+# ------------------------------------------------------------------ #
+
+
+def test_truncation_compactor_satisfies_protocol():
+    """TruncationCompactor implements the Compactor protocol structurally."""
+    from fleet.track.compactor import Compactor
+
+    c: Compactor = TruncationCompactor(budget=_generous_budget())
+    out = c.compact([UserMessage(source="claude", text="x")])
+    assert len(out) == 1

--- a/tests/track/test_converter.py
+++ b/tests/track/test_converter.py
@@ -1,0 +1,218 @@
+"""Cross-format converter tests.
+
+Locks in the field-set requirements we discovered empirically by
+actually trying `claude --resume` and `codex exec resume` on
+converter output:
+
+  - claude resume scans `~/.claude/projects/<encoded-resolved-cwd>/<sessionId>.jsonl`.
+    Every row must carry `sessionId` matching the filename.
+  - codex resume reads the file by UUID. The first row must be
+    `session_meta` with the strict struct:
+        id, timestamp, cwd, originator, cli_version, source,
+        model_provider, base_instructions={"text": "..."}.
+    A plain-string `base_instructions` trips
+    `rollout does not start with session metadata`.
+
+These tests don't actually call claude/codex — they assert the
+converter produces the structures those CLIs require.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fleet.track.converter import _encode_claude_cwd, convert
+from fleet.track.sources import ClaudeSource, CodexSource
+
+
+def _build_claude_fixture(tmp_path: Path) -> Path:
+    rows = [
+        {"type": "user", "uuid": "u1", "parentUuid": None,
+         "sessionId": "src-session", "cwd": "/some/path", "gitBranch": "main",
+         "version": "1.0", "timestamp": "2026-04-30T00:00:00Z",
+         "message": {"role": "user", "content": "hi"}},
+        {"type": "assistant", "uuid": "a1", "parentUuid": "u1",
+         "timestamp": "2026-04-30T00:00:01Z",
+         "message": {"role": "assistant", "content": [
+             {"type": "text", "text": "yo"}
+         ]}},
+    ]
+    f = tmp_path / "claude.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+def _build_codex_fixture(tmp_path: Path) -> Path:
+    rows = [
+        {"timestamp": "2026-04-30T00:00:00Z", "type": "session_meta",
+         "payload": {"id": "src-session", "cwd": "/some/path", "cli_version": "0.5",
+                     "base_instructions": {"text": "you are codex"}}},
+        {"timestamp": "2026-04-30T00:00:01Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user",
+                     "content": [{"type": "input_text", "text": "hi"}]}},
+        {"timestamp": "2026-04-30T00:00:02Z", "type": "response_item",
+         "payload": {"type": "message", "role": "assistant",
+                     "content": [{"type": "output_text", "text": "yo"}]}},
+    ]
+    f = tmp_path / "codex.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+# ------------------------------------------------------------------ #
+# CWD encoding                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_encode_claude_cwd_handles_dots_and_slashes():
+    """Real claude project dirs encode `/Users/foo/.config` as `-Users-foo--config`."""
+    assert _encode_claude_cwd("/Users/foo/.config") == "-Users-foo--config"
+    assert _encode_claude_cwd("/private/tmp/abc") == "-private-tmp-abc"
+    assert _encode_claude_cwd("/Users/trenthaines/git/fleet-sdk") == "-Users-trenthaines-git-fleet-sdk"
+
+
+# ------------------------------------------------------------------ #
+# claude as target                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_codex_to_claude_produces_resumeable_layout(tmp_path: Path):
+    """codex source → claude target: every row has sessionId; suggested
+    path is under projects/<encoded-cwd>/<session>.jsonl."""
+    src = _build_codex_fixture(tmp_path)
+    result = convert(
+        from_source=CodexSource(),
+        to_source=ClaudeSource(),
+        in_path=src,
+        home=tmp_path,
+        target_cwd="/private/tmp/test-resume",
+        new_session_id="test-uuid-1",
+    )
+    # Suggested path
+    expected_dir = tmp_path / ".claude" / "projects" / "-private-tmp-test-resume"
+    assert result.suggested_path.parent == expected_dir
+    assert result.suggested_path.name == "test-uuid-1.jsonl"
+    assert result.session_id == "test-uuid-1"
+
+    # Every row carries the new session id
+    lines = [json.loads(l) for l in result.bytes.decode().splitlines() if l.strip()]
+    assert lines  # non-empty
+    for line in lines:
+        sid = line.get("sessionId")
+        if sid is not None:
+            assert sid == "test-uuid-1"
+
+    # Every user/assistant row carries cwd matching target
+    for line in lines:
+        if line.get("type") in ("user", "assistant"):
+            assert line.get("cwd") == "/private/tmp/test-resume"
+
+
+def test_claude_target_resolves_symlinked_cwd(tmp_path: Path):
+    """`/tmp` should resolve to `/private/tmp` on macOS — claude indexes
+    by the resolved path, so the converter must propagate the resolved form."""
+    if not Path("/tmp").is_symlink():
+        # On Linux /tmp isn't a symlink; nothing to verify here.
+        return
+    src = _build_codex_fixture(tmp_path)
+    result = convert(
+        from_source=CodexSource(),
+        to_source=ClaudeSource(),
+        in_path=src,
+        home=tmp_path,
+        target_cwd="/tmp/should-resolve",
+        new_session_id="x",
+    )
+    # /tmp resolves to /private/tmp on darwin
+    assert "private" in str(result.suggested_path)
+
+
+# ------------------------------------------------------------------ #
+# codex as target                                                      #
+# ------------------------------------------------------------------ #
+
+
+def test_claude_to_codex_first_row_is_valid_session_meta(tmp_path: Path):
+    """codex exec resume rejects files whose first row's payload doesn't
+    deserialize into the session-meta struct. Lock in the field set."""
+    src = _build_claude_fixture(tmp_path)
+    result = convert(
+        from_source=ClaudeSource(),
+        to_source=CodexSource(),
+        in_path=src,
+        home=tmp_path,
+        target_cwd="/private/tmp/test-resume",
+        new_session_id="test-uuid-2",
+    )
+
+    lines = [json.loads(l) for l in result.bytes.decode().splitlines() if l.strip()]
+    first = lines[0]
+
+    # Top-level shape
+    assert first["type"] == "session_meta"
+    assert "timestamp" in first
+    payload = first["payload"]
+
+    # Required payload fields (audited from real codex sessions; missing
+    # any of them caused codex to reject with "does not start with
+    # session metadata"):
+    required = {"id", "timestamp", "cwd", "originator", "cli_version",
+                "source", "model_provider", "base_instructions"}
+    assert set(payload.keys()) >= required, f"missing: {required - set(payload.keys())}"
+
+    # base_instructions must be {text: str}, NOT a plain string.
+    assert isinstance(payload["base_instructions"], dict)
+    assert "text" in payload["base_instructions"]
+
+    # id and cwd reflect the converter args
+    assert payload["id"] == "test-uuid-2"
+    assert payload["cwd"] == "/private/tmp/test-resume"
+
+
+def test_codex_target_suggested_path_is_dated(tmp_path: Path):
+    """codex layout: ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl."""
+    src = _build_claude_fixture(tmp_path)
+    result = convert(
+        from_source=ClaudeSource(),
+        to_source=CodexSource(),
+        in_path=src,
+        home=tmp_path,
+        target_cwd="/x",
+        new_session_id="abc",
+    )
+    p = result.suggested_path
+    # path must be under tmp_path/.codex/sessions/YYYY/MM/DD/
+    rel = p.relative_to(tmp_path / ".codex" / "sessions")
+    parts = rel.parts
+    assert len(parts) == 4  # YYYY, MM, DD, file
+    assert parts[3].startswith("rollout-")
+    assert parts[3].endswith("-abc.jsonl")
+
+
+# ------------------------------------------------------------------ #
+# Round-trip via converter                                             #
+# ------------------------------------------------------------------ #
+
+
+def test_converter_event_count_preserved(tmp_path: Path):
+    """All events in the source file survive conversion + re-parse."""
+    src = _build_claude_fixture(tmp_path)
+    result = convert(
+        from_source=ClaudeSource(),
+        to_source=CodexSource(),
+        in_path=src,
+        home=tmp_path,
+        target_cwd="/x",
+        new_session_id="rt",
+    )
+
+    in_events = list(ClaudeSource().parse(src))
+    # Re-parse the converted bytes
+    out_path = tmp_path / "converted.jsonl"
+    out_path.write_bytes(result.bytes)
+    out_events = list(CodexSource().parse(out_path))
+
+    # Every input event should produce at least one output event.
+    # (Synthesized SessionStart from the parser becomes a session_meta row.)
+    assert len(out_events) >= len(in_events)

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -1,0 +1,101 @@
+"""Tests for the v1 daemon one-shot sync path."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+from fleet.track.api import TrackAPIClient
+from fleet.track.daemon import Daemon
+from fleet.track.merkle import HashCache, MerkleTree
+from fleet.track.paths import TrackPaths
+from fleet.track.queue import UploadQueue
+
+
+def _auth() -> Optional[Tuple[str, str]]:
+    return ("jwt", "team")
+
+
+class RecordingTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes]] = []
+        self._lock = threading.Lock()
+
+    def put(self, url: str, content: bytes) -> int:
+        with self._lock:
+            self.calls.append((url, content))
+        return 200
+
+
+def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    rel_path = (
+        ".codex/sessions/"
+        "rollout-2026-05-05T00-00-00-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl"
+    )
+    session_file = tmp_path / rel_path
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        '{"type":"session_meta","payload":{"id":"s1","cwd":"/tmp"}}\n'
+    )
+
+    api_requests: list[tuple[str, dict]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path.endswith("/v1/track/manifest"):
+            return httpx.Response(200, json={"root_hash": "", "files": {}})
+        if req.method == "POST" and req.url.path.endswith("/v1/track/upload-urls"):
+            body = json.loads(req.content)
+            api_requests.append((req.url.path, body))
+            return httpx.Response(
+                200,
+                json={"urls": {p: f"https://s3.test/{p}" for p in body["paths"]}},
+            )
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[session_file])
+    transport = RecordingTransport()
+
+    daemon = Daemon(
+        paths,
+        queue=queue,
+        cache=cache,
+        tree=tree,
+        api=api,
+        upload_transport=transport,
+    )
+
+    result = daemon.run_once(device_id="dev1")
+
+    assert result.in_sync is False
+    assert result.changed_paths == (rel_path,)
+
+    uploaded_urls = [url for url, _ in transport.calls]
+    assert uploaded_urls == [
+        f"https://s3.test/{rel_path}",
+        "https://s3.test/manifest.json",
+    ]
+
+    manifest = json.loads(transport.calls[-1][1])
+    assert manifest["device_id"] == "dev1"
+    assert manifest["files"] == {rel_path: result.local_map[rel_path]}
+
+    upload_url_paths = [body["paths"] for _, body in api_requests]
+    assert upload_url_paths == [[rel_path], ["manifest.json"]]
+
+    queue.close()
+    cache.close()

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -46,6 +46,7 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
     )
 
     api_requests: list[tuple[str, dict]] = []
+    metadata_upserts: list[dict] = []
 
     def handler(req: httpx.Request) -> httpx.Response:
         if req.method == "GET" and req.url.path.endswith("/v1/track/manifest"):
@@ -57,6 +58,9 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
                 200,
                 json={"urls": {p: f"https://s3.test/{p}" for p in body["paths"]}},
             )
+        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
+            metadata_upserts.append(json.loads(req.content))
+            return httpx.Response(204)
         raise AssertionError(f"unexpected request: {req.method} {req.url}")
 
     api = TrackAPIClient(
@@ -96,6 +100,48 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
 
     upload_url_paths = [body["paths"] for _, body in api_requests]
     assert upload_url_paths == [[rel_path], ["manifest.json"]]
+    assert len(metadata_upserts) == 1
+    upsert = metadata_upserts[0]
+    assert upsert["device_id"] == "dev1"
+    assert upsert["path"] == rel_path
+    assert upsert["session"]["id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    assert upsert["session"]["tool"] == "codex"
+    assert upsert["session"]["cwd"] == "/tmp"
+    assert upsert["session"]["event_count"] == 1
+    assert upsert["session"]["metadata"]["origin_cwd"] == "/tmp"
+
+    queue.close()
+    cache.close()
+
+
+def test_upload_done_uses_callback_digest_instead_of_stale_cache(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree)
+
+    rel_path = ".codex/sessions/2026/05/05/rollout-session.jsonl"
+    cache._conn.execute(
+        """
+        INSERT OR REPLACE INTO file_hashes (path, mtime, size, sha256, last_seen)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (rel_path, 0.0, 0, "stale-digest", 0),
+    )
+    cache._conn.commit()
+    metadata_calls: list[tuple[str, str]] = []
+
+    def record_metadata(path: str, digest: str) -> None:
+        metadata_calls.append((path, digest))
+
+    daemon._upsert_session_metadata = record_metadata  # type: ignore[method-assign]
+
+    daemon._on_upload_done(rel_path, "fresh-digest")
+
+    assert daemon._confirmed_map[rel_path] == "fresh-digest"
+    assert metadata_calls == [(rel_path, "fresh-digest")]
 
     queue.close()
     cache.close()

--- a/tests/track/test_drainer.py
+++ b/tests/track/test_drainer.py
@@ -1,0 +1,145 @@
+"""Unit tests for QueueDrainer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+from fleet.track.api import TrackAPIClient
+from fleet.track.drainer import QueueDrainer
+from fleet.track.paths import TrackPaths
+from fleet.track.queue import UploadQueue
+
+
+def _auth() -> Optional[Tuple[str, str]]:
+    return ("jwt", "team")
+
+
+class FakePool:
+    """Pool stand-in that records every submit() instead of actually uploading."""
+
+    def __init__(self):
+        self.submissions: list[tuple[str, str, Path, str]] = []
+
+    def submit(self, rel_path: str, sha256: str, abs_path: Path, presigned_url: str) -> None:
+        self.submissions.append((rel_path, sha256, abs_path, presigned_url))
+
+
+def _build(tmp_path: Path, url_handler):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    transport = httpx.MockTransport(url_handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    api = TrackAPIClient(client=client, auth_provider=_auth)
+
+    queue = UploadQueue(paths)
+    pool = FakePool()
+    drainer = QueueDrainer(paths=paths, queue=queue, api=api, pool=pool)  # type: ignore[arg-type]
+    return drainer, queue, pool, paths
+
+
+def test_drain_empty_queue(tmp_path: Path):
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"urls": {}})
+
+    drainer, queue, pool, _ = _build(tmp_path, handler)
+    result = drainer.drain_once("dev1")
+    assert result.claimed == 0
+    assert result.submitted == 0
+    assert pool.submissions == []
+    queue.close()
+
+
+def test_drain_submits_each_item_with_its_url(tmp_path: Path):
+    def handler(req: httpx.Request) -> httpx.Response:
+        import json as j
+        body = j.loads(req.content)
+        return httpx.Response(
+            200,
+            json={"urls": {p: f"https://s3/{p}?sig=x" for p in body["paths"]}},
+        )
+
+    drainer, queue, pool, paths = _build(tmp_path, handler)
+    queue.enqueue("a.jsonl", "h1")
+    queue.enqueue("b.jsonl", "h2")
+
+    result = drainer.drain_once("dev1")
+    assert result.claimed == 2
+    assert result.submitted == 2
+    assert result.failed == 0
+    assert {s[0] for s in pool.submissions} == {"a.jsonl", "b.jsonl"}
+    # Submitted abs paths are rooted at the test home.
+    for rel, _sha, abs_path, _url in pool.submissions:
+        assert abs_path == paths.home / rel
+    queue.close()
+
+
+def test_drain_marks_failed_when_no_url_returned(tmp_path: Path):
+    """Server returns an empty url map → every claimed item is marked failed."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"urls": {}})
+
+    drainer, queue, pool, _ = _build(tmp_path, handler)
+    queue.enqueue("a.jsonl", "h1")
+
+    result = drainer.drain_once("dev1")
+    assert result.claimed == 1
+    assert result.submitted == 0
+    assert result.failed == 1
+    assert pool.submissions == []
+    # Item is now pending again with a backoff timer (mark_failed sets pending if attempts < MAX).
+    stats = queue.stats()
+    # At least one of pending/failed accounts for it.
+    assert (stats.get("pending", 0) + stats.get("failed", 0)) == 1
+    queue.close()
+
+
+def test_drain_marks_all_failed_on_api_error(tmp_path: Path):
+    """If the API itself errors, every claimed item is marked failed (will retry)."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="upstream broken")
+
+    drainer, queue, pool, _ = _build(tmp_path, handler)
+    queue.enqueue("a.jsonl", "h1")
+    queue.enqueue("b.jsonl", "h2")
+
+    result = drainer.drain_once("dev1")
+    assert result.claimed == 2
+    assert result.submitted == 0
+    assert result.failed == 2
+    assert pool.submissions == []
+    queue.close()
+
+
+def test_drain_respects_batch_size(tmp_path: Path):
+    """Configured batch_size caps how many items get claimed in one pass."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        import json as j
+        body = j.loads(req.content)
+        return httpx.Response(
+            200, json={"urls": {p: f"https://s3/{p}" for p in body["paths"]}}
+        )
+
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    transport = httpx.MockTransport(handler)
+    api = TrackAPIClient(
+        client=httpx.Client(transport=transport, base_url="http://test"),
+        auth_provider=_auth,
+    )
+    queue = UploadQueue(paths)
+    pool = FakePool()
+    drainer = QueueDrainer(paths=paths, queue=queue, api=api, pool=pool, batch_size=3)  # type: ignore[arg-type]
+
+    for i in range(10):
+        queue.enqueue(f"f{i}.jsonl", f"h{i}")
+
+    result = drainer.drain_once("dev1")
+    assert result.claimed == 3
+    queue.close()

--- a/tests/track/test_format_claude.py
+++ b/tests/track/test_format_claude.py
@@ -1,0 +1,357 @@
+"""ClaudeSource.parse tests — every row type, every content block, robustness corpus."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fleet.track.sources import ClaudeSource
+
+
+def _write(tmp_path: Path, lines: list[dict]) -> Path:
+    f = tmp_path / "session.jsonl"
+    f.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return f
+
+
+def _parse(tmp_path: Path, lines: list[dict]):
+    f = _write(tmp_path, lines)
+    return list(ClaudeSource(home=tmp_path).parse(f))
+
+
+# ------------------------------------------------------------------ #
+# SessionStart synthesis                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_first_row_synthesizes_session_start(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "sessionId": "s1", "cwd": "/tmp", "gitBranch": "main",
+         "version": "0.5", "message": {"role": "user", "content": "hi"}, "timestamp": "2026-04-30T00:00:00Z"},
+    ])
+    assert events[0].type == "session_start"
+    assert events[0].cwd == "/tmp"
+    assert events[0].agent_version == "0.5"
+    assert events[0].git_branch == "main"
+    assert events[1].type == "user_message"
+    assert events[1].text == "hi"
+
+
+def test_no_session_start_when_metadata_missing(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "system", "uuid": "x", "message": "boot"},
+    ])
+    assert events[0].type == "lifecycle"
+    assert events[0].name == "system"
+
+
+# ------------------------------------------------------------------ #
+# user content shapes                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_user_string_content(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hello"}},
+    ])
+    user_msgs = [e for e in events if e.type == "user_message"]
+    assert len(user_msgs) == 1
+    assert user_msgs[0].text == "hello"
+
+
+def test_user_text_block(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "message": {"role": "user",
+            "content": [{"type": "text", "text": "wrapped"}]}},
+    ])
+    msgs = [e for e in events if e.type == "user_message"]
+    assert len(msgs) == 1
+    assert msgs[0].text == "wrapped"
+
+
+def test_user_tool_result_block(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "tc1",
+             "content": "exit code 0", "is_error": False}
+        ]}},
+    ])
+    results = [e for e in events if e.type == "tool_result"]
+    assert len(results) == 1
+    assert results[0].tool_call_id == "tc1"
+    assert results[0].output == "exit code 0"
+    assert results[0].is_error is False
+
+
+def test_user_tool_result_with_block_content(tmp_path: Path):
+    """tool_result.content can be a list of typed blocks (text, image)."""
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "tc1", "content": [
+                {"type": "text", "text": "line one"},
+                {"type": "image", "source": {"data": "..."}}
+            ]}
+        ]}},
+    ])
+    results = [e for e in events if e.type == "tool_result"]
+    assert len(results) == 1
+    assert "line one" in results[0].output
+    assert "[image]" in results[0].output
+
+
+def test_user_image_block_becomes_attachment(tmp_path: Path):
+    """User-attached image surfaces as a first-class Attachment event."""
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": [
+            {"type": "image", "source": {"data": "BASE64_DATA",
+                                         "media_type": "image/png"}}
+        ]}},
+    ])
+    atts = [e for e in events if e.type == "attachment"]
+    assert len(atts) == 1
+    assert atts[0].media_type == "image/png"
+    assert atts[0].content == "BASE64_DATA"
+
+
+def test_user_with_multiple_blocks_yields_multiple_events(tmp_path: Path):
+    """One row, three blocks → three events with sub-id suffixes."""
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "tc1", "content": "ok"},
+            {"type": "tool_result", "tool_use_id": "tc2", "content": "ok"},
+            {"type": "text", "text": "trailing note"},
+        ]}},
+    ])
+    derived = [e for e in events if e.type in ("tool_result", "user_message")]
+    assert len(derived) == 3
+    # First sub-event keeps the row's uuid; rest are suffixed.
+    assert derived[0].id == "u1"
+    assert derived[1].id == "u1#1"
+    assert derived[2].id == "u1#2"
+
+
+# ------------------------------------------------------------------ #
+# assistant content shapes                                             #
+# ------------------------------------------------------------------ #
+
+
+def test_assistant_text_block(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant",
+            "content": [{"type": "text", "text": "answer"}]}},
+    ])
+    msgs = [e for e in events if e.type == "assistant_message"]
+    assert len(msgs) == 1
+    assert msgs[0].text == "answer"
+
+
+def test_assistant_thinking_block(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant",
+            "content": [{"type": "thinking", "thinking": "let me reason..."}]}},
+    ])
+    reasoning = [e for e in events if e.type == "assistant_reasoning"]
+    assert len(reasoning) == 1
+    assert reasoning[0].text == "let me reason..."
+
+
+def test_assistant_tool_use_block(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_01", "name": "Bash",
+             "input": {"command": "ls", "description": "list"}}
+        ]}},
+    ])
+    calls = [e for e in events if e.type == "tool_call"]
+    assert len(calls) == 1
+    assert calls[0].tool_call_id == "toolu_01"
+    assert calls[0].name == "Bash"
+    assert calls[0].input == {"command": "ls", "description": "list"}
+
+
+def test_assistant_with_thinking_text_and_tool_use(tmp_path: Path):
+    """Real claude assistant rows often interleave all three block types."""
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": [
+            {"type": "thinking", "thinking": "I should..."},
+            {"type": "text", "text": "OK, running:"},
+            {"type": "tool_use", "id": "tu1", "name": "Bash", "input": {"command": "ls"}},
+        ]}},
+    ])
+    derived = [e for e in events if e.type in ("assistant_reasoning", "assistant_message", "tool_call")]
+    assert [e.type for e in derived] == ["assistant_reasoning", "assistant_message", "tool_call"]
+    assert derived[0].id == "a1"
+    assert derived[1].id == "a1#1"
+    assert derived[2].id == "a1#2"
+
+
+# ------------------------------------------------------------------ #
+# Lifecycle row types                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_lifecycle_row_types_all_named_correctly(tmp_path: Path):
+    """Pure-lifecycle row types (no kernel-level meaning) round-trip
+    through Lifecycle. permission-mode and attachment are now
+    promoted to Operator and Attachment respectively — see their
+    own tests below."""
+    cases = [
+        ("system", "system"),
+        ("last-prompt", "last_prompt"),
+        ("ai-title", "ai_title"),
+        ("custom-title", "custom_title"),
+        ("agent-name", "agent_name"),
+        ("queue-operation", "queue_operation"),
+        ("pr-link", "pr_link"),
+        ("progress", "progress"),
+    ]
+    for raw_type, expected_name in cases:
+        events = _parse(tmp_path, [{"type": raw_type, "uuid": "x"}])
+        assert events[0].type == "lifecycle"
+        assert events[0].name == expected_name, f"raw={raw_type}"
+
+
+def test_permission_mode_row_becomes_operator(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "permission-mode", "uuid": "x", "permissionMode": "acceptEdits"},
+    ])
+    assert events[0].type == "operator"
+    assert events[0].action == "permission_mode"
+    assert events[0].detail == "acceptEdits"
+
+
+def test_attachment_row_becomes_attachment_event(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "attachment", "uuid": "x",
+         "attachment": {"type": "image/png", "name": "diagram.png",
+                        "path": "/tmp/diagram.png"}},
+    ])
+    assert events[0].type == "attachment"
+    assert events[0].media_type == "image/png"
+    assert events[0].name == "diagram.png"
+    assert events[0].ref == "/tmp/diagram.png"
+
+
+def test_assistant_message_carries_model(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1",
+         "message": {"role": "assistant", "model": "claude-opus-4-7",
+                     "content": [{"type": "text", "text": "hi"}]}},
+    ])
+    msgs = [e for e in events if e.type == "assistant_message"]
+    assert msgs[0].model == "claude-opus-4-7"
+
+
+# ------------------------------------------------------------------ #
+# file-history-snapshot                                                #
+# ------------------------------------------------------------------ #
+
+
+def test_file_history_snapshot_single_file(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "file-history-snapshot", "uuid": "fh1",
+         "snapshot": {"path": "src/foo.py", "diff": "@@ -1 +1 @@", "pre": "old", "post": "new"}},
+    ])
+    edits = [e for e in events if e.type == "file_edit"]
+    assert len(edits) == 1
+    assert edits[0].path == "src/foo.py"
+    assert edits[0].diff == "@@ -1 +1 @@"
+
+
+def test_file_history_snapshot_list(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "file-history-snapshot", "uuid": "fh1", "snapshot": [
+            {"path": "a.py", "post": "x"},
+            {"path": "b.py", "post": "y"},
+        ]},
+    ])
+    edits = [e for e in events if e.type == "file_edit"]
+    assert [e.path for e in edits] == ["a.py", "b.py"]
+
+
+def test_file_history_snapshot_no_snapshot_falls_back_to_lifecycle(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "file-history-snapshot", "uuid": "fh1"},
+    ])
+    assert events[0].type == "lifecycle"
+    assert events[0].name == "file_history_snapshot"
+
+
+# ------------------------------------------------------------------ #
+# parent_id / tree                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_parent_id_propagates_from_parent_uuid(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "user", "uuid": "u1", "parentUuid": None,
+         "message": {"role": "user", "content": "first"}},
+        {"type": "assistant", "uuid": "a1", "parentUuid": "u1",
+         "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}},
+    ])
+    msgs = [e for e in events if e.type in ("user_message", "assistant_message")]
+    assert msgs[0].id == "u1"
+    assert msgs[0].parent_id is None
+    assert msgs[1].id == "a1"
+    assert msgs[1].parent_id == "u1"
+
+
+# ------------------------------------------------------------------ #
+# Robustness                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_malformed_line_is_skipped(tmp_path: Path):
+    f = tmp_path / "session.jsonl"
+    f.write_text(
+        json.dumps({"type": "user", "uuid": "u1", "message": {"content": "good"}}) + "\n"
+        + "this is not json\n"
+        + json.dumps({"type": "assistant", "uuid": "a1",
+                      "message": {"content": [{"type": "text", "text": "after"}]}}) + "\n"
+    )
+    events = list(ClaudeSource(home=tmp_path).parse(f))
+    msgs = [e for e in events if e.type in ("user_message", "assistant_message")]
+    assert len(msgs) == 2
+
+
+def test_unknown_top_level_type_is_opaque(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "totally-new-event-type", "uuid": "x"},
+    ])
+    op = [e for e in events if e.type == "opaque"]
+    assert len(op) == 1
+    assert op[0].original_type == "totally-new-event-type"
+
+
+def test_unknown_assistant_block_is_opaque(tmp_path: Path):
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant",
+            "content": [{"type": "future_block", "data": 1}]}},
+    ])
+    op = [e for e in events if e.type == "opaque"]
+    assert len(op) == 1
+    assert "future_block" in op[0].original_type
+
+
+def test_empty_file_yields_no_events(tmp_path: Path):
+    f = tmp_path / "empty.jsonl"
+    f.write_text("")
+    events = list(ClaudeSource(home=tmp_path).parse(f))
+    assert events == []
+
+
+def test_missing_file_yields_no_events_and_no_raise(tmp_path: Path):
+    """Parse on a path that doesn't exist must not raise."""
+    src = ClaudeSource(home=tmp_path)
+    events = list(src.parse(tmp_path / "ghost.jsonl"))
+    assert events == []
+
+
+def test_assistant_with_string_content_not_list(tmp_path: Path):
+    """If claude ever emits string content for assistant — surface as opaque, no crash."""
+    events = _parse(tmp_path, [
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": "weird"}},
+    ])
+    op = [e for e in events if e.type == "opaque"]
+    assert len(op) == 1
+    assert op[0].original_type == "assistant_unknown_content_shape"

--- a/tests/track/test_format_codex.py
+++ b/tests/track/test_format_codex.py
@@ -1,0 +1,477 @@
+"""CodexSource.parse tests — every payload type, robustness corpus."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fleet.track.sources import CodexSource
+
+
+def _write(tmp_path: Path, lines: list[dict]) -> Path:
+    f = tmp_path / "session.jsonl"
+    f.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return f
+
+
+def _parse(tmp_path: Path, lines: list[dict]):
+    f = _write(tmp_path, lines)
+    return list(CodexSource(home=tmp_path).parse(f))
+
+
+def _evt(timestamp="2026-04-30T00:00:00Z", **kw):
+    return {"timestamp": timestamp, **kw}
+
+
+# ------------------------------------------------------------------ #
+# Top-level types                                                      #
+# ------------------------------------------------------------------ #
+
+
+def test_session_meta_becomes_session_start(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="session_meta",
+        payload={"id": "sess1", "cwd": "/tmp", "cli_version": "0.5", "base_instructions": "you are codex"},
+    )])
+    assert events[0].type == "session_start"
+    # id is the row-unique synthetic id (used for serializer dedup);
+    # the codex session id lives in raw.
+    assert events[0].raw["payload"]["id"] == "sess1"
+    assert events[0].cwd == "/tmp"
+    assert events[0].agent_version == "0.5"
+    assert events[0].user_instructions == "you are codex"
+
+
+def test_session_meta_with_dict_base_instructions(tmp_path: Path):
+    """codex sometimes wraps base_instructions as {text: '...'}."""
+    events = _parse(tmp_path, [_evt(
+        type="session_meta",
+        payload={"id": "s", "base_instructions": {"text": "hi"}},
+    )])
+    assert events[0].user_instructions == "hi"
+
+
+def test_turn_context_becomes_turn_start(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="turn_context",
+        payload={"turn_id": "t1", "cwd": "/x", "model": "gpt-5", "approval_policy": "never"},
+    )])
+    assert events[0].type == "turn_start"
+    assert events[0].turn_id == "t1"
+    assert events[0].cwd == "/x"
+    assert events[0].model == "gpt-5"
+
+
+# ------------------------------------------------------------------ #
+# response_item                                                        #
+# ------------------------------------------------------------------ #
+
+
+def test_response_item_message_user(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "message", "role": "user",
+                 "content": [{"type": "input_text", "text": "hi"}]},
+    )])
+    msgs = [e for e in events if e.type == "user_message"]
+    assert msgs[0].text == "hi"
+
+
+def test_response_item_message_developer_treated_as_user(tmp_path: Path):
+    """developer-role messages are system instructions; we map them to user_message
+    so the unified stream is monotonic (codex injects them mid-conversation)."""
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "message", "role": "developer",
+                 "content": [{"type": "input_text", "text": "<perms>do this</perms>"}]},
+    )])
+    assert events[0].type == "user_message"
+
+
+def test_response_item_message_assistant(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "message", "role": "assistant",
+                 "content": [{"type": "output_text", "text": "answer"}]},
+    )])
+    msgs = [e for e in events if e.type == "assistant_message"]
+    assert msgs[0].text == "answer"
+
+
+def test_response_item_function_call(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "function_call", "call_id": "c1", "name": "exec_command",
+                 "arguments": json.dumps({"cmd": "ls", "workdir": "/"})},
+    )])
+    calls = [e for e in events if e.type == "tool_call"]
+    assert calls[0].tool_call_id == "c1"
+    assert calls[0].name == "exec_command"
+    assert calls[0].input == {"cmd": "ls", "workdir": "/"}
+
+
+def test_response_item_function_call_with_malformed_args(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "function_call", "call_id": "c1", "name": "n", "arguments": "{not json"},
+    )])
+    assert events[0].input == {}  # tolerated
+
+
+def test_response_item_function_call_output(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "function_call_output", "call_id": "c1", "output": "OK\n"},
+    )])
+    assert events[0].type == "tool_result"
+    assert events[0].tool_call_id == "c1"
+    assert events[0].output == "OK\n"
+
+
+def test_response_item_reasoning_encrypted(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "reasoning", "summary": [], "encrypted_content": "abc=="},
+    )])
+    r = events[0]
+    assert r.type == "assistant_reasoning"
+    assert r.encrypted is True
+    assert r.encrypted_content == "abc=="
+    assert r.text is None
+
+
+def test_response_item_reasoning_with_summary(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "reasoning",
+                 "summary": [{"type": "summary_text", "text": "checking foo"}]},
+    )])
+    assert events[0].text == "checking foo"
+
+
+def test_response_item_compacted_is_lifecycle(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item", payload={"type": "compacted"}
+    )])
+    assert events[0].type == "lifecycle"
+    assert events[0].name == "context_compacted"
+
+
+def test_response_item_custom_tool_call(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "custom_tool_call", "id": "c1", "name": "my_tool",
+                 "input": json.dumps({"x": 1})},
+    )])
+    assert events[0].type == "tool_call"
+    assert events[0].name == "my_tool"
+    assert events[0].input == {"x": 1}
+
+
+def test_response_item_web_search_call(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "web_search_call", "id": "w1",
+                 "action": {"query": "fleet sdk", "num": 5}},
+    )])
+    assert events[0].type == "tool_call"
+    assert events[0].input == {"query": "fleet sdk", "num": 5}
+
+
+def test_response_item_tool_search_call(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "tool_search_call", "call_id": "ts1",
+                 "arguments": {"query": "github"}},
+    )])
+    assert events[0].type == "tool_call"
+    assert events[0].input == {"query": "github"}
+
+
+def test_response_item_tool_search_output(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "tool_search_output", "call_id": "ts1",
+                 "tools": [{"type": "function", "name": "github_get"}]},
+    )])
+    assert events[0].type == "tool_result"
+    assert events[0].tool_call_id == "ts1"
+    assert "github_get" in events[0].output
+
+
+# ------------------------------------------------------------------ #
+# event_msg                                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_event_msg_user_message(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "user_message", "message": "hi"},
+    )])
+    assert events[0].type == "user_message"
+    assert events[0].text == "hi"
+
+
+def test_event_msg_user_message_with_inline_image(tmp_path: Path):
+    """codex inline image in `images` becomes an Attachment event."""
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "user_message", "message": "look",
+                 "images": ["BASE64_INLINE_IMAGE"],
+                 "local_image_paths": ["/tmp/x.png"]},
+    )])
+    by_type = {e.type for e in events}
+    assert "user_message" in by_type
+    atts = [e for e in events if e.type == "attachment"]
+    assert len(atts) == 2
+    inline = next(a for a in atts if a.content)
+    ref = next(a for a in atts if a.ref)
+    assert inline.content == "BASE64_INLINE_IMAGE"
+    assert ref.ref == "/tmp/x.png"
+    assert ref.media_type == "image/png"
+
+
+def test_event_msg_agent_message_with_phase(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "agent_message", "message": "OK", "phase": "commentary"},
+    )])
+    assert events[0].type == "assistant_message"
+    assert events[0].phase == "commentary"
+
+
+def test_event_msg_agent_reasoning(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "agent_reasoning", "text": "thinking"},
+    )])
+    assert events[0].type == "assistant_reasoning"
+    assert events[0].text == "thinking"
+    assert events[0].encrypted is False
+
+
+def test_event_msg_task_lifecycle(tmp_path: Path):
+    events = _parse(tmp_path, [
+        _evt(type="event_msg", payload={"type": "task_started", "turn_id": "t1"}),
+        _evt(type="event_msg", payload={"type": "task_complete", "turn_id": "t1"}),
+        _evt(type="event_msg", payload={"type": "turn_aborted", "turn_id": "t2"}),
+    ])
+    assert events[0].type == "turn_start"
+    assert events[1].type == "turn_end"
+    assert events[1].aborted is False
+    assert events[2].type == "turn_end"
+    assert events[2].aborted is True
+
+
+def test_event_msg_token_count(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "token_count", "info": {
+            "last_token_usage": {"input_tokens": 100, "output_tokens": 50,
+                                 "cached_input_tokens": 80, "total_tokens": 150}
+        }},
+    )])
+    e = events[0]
+    assert e.type == "token_usage"
+    assert e.input_tokens == 100
+    assert e.output_tokens == 50
+    assert e.cache_read_tokens == 80
+    assert e.total_tokens == 150
+    assert e.provider == "openai"  # default when session_meta hasn't set one
+
+
+def test_token_count_provider_from_session_meta(tmp_path: Path):
+    """A session_meta row carrying `model_provider` should propagate to
+    subsequent token_count events."""
+    events = _parse(tmp_path, [
+        _evt(type="session_meta",
+             payload={"id": "s", "cwd": "/x", "model_provider": "azure-openai"}),
+        _evt(type="event_msg",
+             payload={"type": "token_count",
+                      "info": {"last_token_usage":
+                                   {"input_tokens": 1, "output_tokens": 2}}}),
+    ])
+    usage = next(e for e in events if e.type == "token_usage")
+    assert usage.provider == "azure-openai"
+
+
+def test_assistant_message_model_tracked_from_turn_context(tmp_path: Path):
+    """A turn_context with `model: gpt-5` should make later AssistantMessages
+    in the same span carry that model."""
+    events = _parse(tmp_path, [
+        _evt(type="turn_context",
+             payload={"turn_id": "t1", "cwd": "/x", "model": "gpt-5",
+                      "approval_policy": "never"}),
+        _evt(type="response_item",
+             payload={"type": "message", "role": "assistant",
+                      "content": [{"type": "output_text", "text": "answer"}]}),
+        _evt(type="event_msg",
+             payload={"type": "agent_message", "message": "answer", "phase": "final"}),
+    ])
+    asst = [e for e in events if e.type == "assistant_message"]
+    assert len(asst) == 2
+    assert all(a.model == "gpt-5" for a in asst)
+
+
+def test_approval_policy_change_emits_operator(tmp_path: Path):
+    """Mid-session approval_policy toggles surface as Operator events."""
+    events = _parse(tmp_path, [
+        _evt(type="turn_context",
+             payload={"turn_id": "t1", "approval_policy": "never"}),
+        _evt(type="turn_context",
+             payload={"turn_id": "t2", "approval_policy": "on-request"}),
+    ])
+    ops = [e for e in events if e.type == "operator"]
+    assert len(ops) == 1
+    assert ops[0].action == "approval_policy"
+    assert ops[0].detail == "on-request"
+    assert ops[0].metadata == {"previous": "never", "current": "on-request"}
+
+
+def test_no_operator_event_on_first_turn_context(tmp_path: Path):
+    """First turn_context establishes baseline; should NOT emit an Operator."""
+    events = _parse(tmp_path, [
+        _evt(type="turn_context",
+             payload={"turn_id": "t1", "approval_policy": "never"}),
+    ])
+    assert not any(e.type == "operator" for e in events)
+
+
+def test_event_msg_exec_command_end(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "exec_command_end", "call_id": "c1",
+                 "formatted_output": "files\n", "exit_code": 0,
+                 "duration": {"secs": 1, "nanos": 500000000}},
+    )])
+    e = events[0]
+    assert e.type == "tool_result"
+    assert e.tool_call_id == "c1"
+    assert e.output == "files\n"
+    assert e.exit_code == 0
+    assert e.duration_ms == 1500
+
+
+def test_event_msg_mcp_tool_call_end(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "mcp_tool_call_end", "call_id": "c1",
+                 "invocation": {"server": "github", "tool": "get_pr", "arguments": {"n": 1}},
+                 "duration": {"secs": 0, "nanos": 700000000},
+                 "result": {"Ok": {"content": [{"type": "text", "text": "PR data"}]}}},
+    )])
+    e = events[0]
+    assert e.type == "tool_result"
+    assert e.tool_call_id == "c1"
+    assert "PR data" in e.output
+    assert e.is_error is False
+    assert e.duration_ms == 700
+
+
+def test_event_msg_mcp_tool_call_end_with_error(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "mcp_tool_call_end", "call_id": "c1",
+                 "result": {"Err": {"reason": "timeout"}}},
+    )])
+    assert events[0].type == "tool_result"
+    assert events[0].is_error is True
+
+
+def test_event_msg_collab_agent_spawn_end(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "collab_agent_spawn_end", "call_id": "c1",
+                 "new_thread_id": "thread2", "new_agent_nickname": "Zeno",
+                 "new_agent_role": "default", "prompt": "do work"},
+    )])
+    e = events[0]
+    assert e.type == "tool_call"
+    assert e.tool_call_id == "c1"
+    assert e.name == "collab_agent.default"
+    assert e.input["agent_nickname"] == "Zeno"
+    assert e.input["prompt"] == "do work"
+
+
+def test_event_msg_collab_close_end(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "collab_close_end", "call_id": "c1",
+                 "status": {"completed": "all done"}},
+    )])
+    assert events[0].type == "tool_result"
+    assert events[0].output == "all done"
+
+
+def test_event_msg_lifecycle_types(tmp_path: Path):
+    cases = [
+        ("thread_name_updated", "thread_name_updated"),
+        ("error", "error"),
+        ("context_compacted", "context_compacted"),
+        ("patch_apply_end", "patch_apply_end"),
+    ]
+    for raw, expected_name in cases:
+        events = _parse(tmp_path, [_evt(type="event_msg", payload={"type": raw})])
+        assert events[0].type == "lifecycle"
+        assert events[0].name == expected_name, f"raw={raw}"
+
+
+# ------------------------------------------------------------------ #
+# Top-level compacted                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_top_level_compacted_is_lifecycle(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="compacted",
+        payload={"message": "", "replacement_history": [{"type": "message"}]},
+    )])
+    assert events[0].type == "lifecycle"
+    assert events[0].name == "context_compacted"
+
+
+# ------------------------------------------------------------------ #
+# Robustness                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_unknown_response_item_payload_is_opaque(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="response_item",
+        payload={"type": "future_payload_type", "stuff": 1},
+    )])
+    assert events[0].type == "opaque"
+    assert "future_payload_type" in events[0].original_type
+
+
+def test_unknown_event_msg_payload_is_opaque(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(
+        type="event_msg",
+        payload={"type": "future_event"},
+    )])
+    assert events[0].type == "opaque"
+
+
+def test_unknown_top_level_type_is_opaque(tmp_path: Path):
+    events = _parse(tmp_path, [_evt(type="future_top_level", payload={})])
+    assert events[0].type == "opaque"
+
+
+def test_malformed_json_lines_are_skipped(tmp_path: Path):
+    f = tmp_path / "session.jsonl"
+    f.write_text(
+        json.dumps(_evt(type="event_msg", payload={"type": "user_message", "message": "a"})) + "\n"
+        + "garbage line not json\n"
+        + json.dumps(_evt(type="event_msg", payload={"type": "agent_message", "message": "b"})) + "\n"
+    )
+    events = list(CodexSource(home=tmp_path).parse(f))
+    msgs = [e.text for e in events if e.type in ("user_message", "assistant_message")]
+    assert msgs == ["a", "b"]
+
+
+def test_empty_payload_does_not_raise(tmp_path: Path):
+    """Some rows may have payload=null."""
+    events = _parse(tmp_path, [{"type": "response_item", "timestamp": "t", "payload": None}])
+    # payload becomes {}, ptype is None, falls through to OpaqueEvent.
+    assert events[0].type == "opaque"

--- a/tests/track/test_format_roundtrip.py
+++ b/tests/track/test_format_roundtrip.py
@@ -1,0 +1,273 @@
+"""Round-trip and cross-format tests for the unified format.
+
+These tests use small synthetic fixtures to lock in invariants:
+  - parse → serialize → parse-again preserves the kernel events
+  - cross-format conversion never crashes
+  - structural events (turn boundaries, lifecycles) survive
+
+Real-world corpus tests (massive sample sweeps) live in scripts the dev
+runs locally, not in pytest — they take seconds and depend on the dev's
+own ~/.claude and ~/.codex contents.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fleet.track.sources import ClaudeSource, CodexSource
+
+
+# ------------------------------------------------------------------ #
+# Synthetic fixtures                                                   #
+# ------------------------------------------------------------------ #
+
+
+def _make_claude_session(tmp_path: Path) -> Path:
+    """A diverse claude session with every event class we model."""
+    rows = [
+        # SessionStart-eligible row
+        {"type": "user", "uuid": "u1", "parentUuid": None,
+         "sessionId": "s1", "cwd": "/tmp", "gitBranch": "main", "version": "0.5",
+         "timestamp": "2026-04-30T00:00:00Z",
+         "message": {"role": "user", "content": "hello, claude"}},
+        # Assistant with all three block types in one row
+        {"type": "assistant", "uuid": "a1", "parentUuid": "u1",
+         "timestamp": "2026-04-30T00:00:01Z",
+         "message": {"role": "assistant", "content": [
+             {"type": "thinking", "thinking": "I should look at the file"},
+             {"type": "text", "text": "Sure. Let me check."},
+             {"type": "tool_use", "id": "tu1", "name": "Read",
+              "input": {"file_path": "/etc/hosts"}},
+         ]}},
+        # User tool_result
+        {"type": "user", "uuid": "u2", "parentUuid": "a1",
+         "timestamp": "2026-04-30T00:00:02Z",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu1",
+              "content": "127.0.0.1 localhost\n", "is_error": False}
+         ]}},
+        # Assistant final text
+        {"type": "assistant", "uuid": "a2", "parentUuid": "u2",
+         "timestamp": "2026-04-30T00:00:03Z",
+         "message": {"role": "assistant", "content": [
+             {"type": "text", "text": "Found localhost in there."}
+         ]}},
+        # Lifecycle row types
+        {"type": "system", "uuid": "sys1"},
+        {"type": "permission-mode"},  # no uuid → uses synthetic L{n}
+        {"type": "attachment"},
+        {"type": "file-history-snapshot",
+         "snapshot": [{"path": "/x.py", "post": "new"}]},
+    ]
+    f = tmp_path / "claude.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+def _make_codex_session(tmp_path: Path) -> Path:
+    """A diverse codex session covering session_meta + all major payloads."""
+    rows = [
+        {"timestamp": "2026-04-30T00:00:00Z", "type": "session_meta",
+         "payload": {"id": "s1", "cwd": "/tmp", "cli_version": "0.5",
+                     "base_instructions": "you are codex"}},
+        {"timestamp": "2026-04-30T00:00:01Z", "type": "turn_context",
+         "payload": {"turn_id": "t1", "cwd": "/tmp", "model": "gpt-5"}},
+        {"timestamp": "2026-04-30T00:00:02Z", "type": "event_msg",
+         "payload": {"type": "task_started", "turn_id": "t1"}},
+        {"timestamp": "2026-04-30T00:00:03Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user",
+                     "content": [{"type": "input_text", "text": "list files"}]}},
+        {"timestamp": "2026-04-30T00:00:04Z", "type": "response_item",
+         "payload": {"type": "reasoning", "summary": [],
+                     "encrypted_content": "AAAA=="}},
+        {"timestamp": "2026-04-30T00:00:05Z", "type": "response_item",
+         "payload": {"type": "function_call", "call_id": "c1", "name": "exec_command",
+                     "arguments": json.dumps({"cmd": "ls"})}},
+        {"timestamp": "2026-04-30T00:00:06Z", "type": "event_msg",
+         "payload": {"type": "exec_command_end", "call_id": "c1",
+                     "formatted_output": "a\nb\n", "exit_code": 0,
+                     "duration": {"secs": 0, "nanos": 100000000}}},
+        {"timestamp": "2026-04-30T00:00:07Z", "type": "response_item",
+         "payload": {"type": "message", "role": "assistant",
+                     "content": [{"type": "output_text", "text": "two files"}]}},
+        {"timestamp": "2026-04-30T00:00:08Z", "type": "event_msg",
+         "payload": {"type": "token_count",
+                     "info": {"last_token_usage": {"input_tokens": 100,
+                                                    "output_tokens": 50}}}},
+        {"timestamp": "2026-04-30T00:00:09Z", "type": "event_msg",
+         "payload": {"type": "task_complete", "turn_id": "t1"}},
+    ]
+    f = tmp_path / "codex.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+# ------------------------------------------------------------------ #
+# Self-format roundtrip — byte-equal on synthetic fixtures             #
+# ------------------------------------------------------------------ #
+
+
+def _roundtrip_lines(src, f: Path) -> tuple[list[dict], list[dict]]:
+    """Return (orig_lines_parsed, rt_lines_parsed)."""
+    orig = [json.loads(l) for l in f.read_text().splitlines() if l.strip()]
+    events = list(src.parse(f))
+    out = src.serialize(events).decode("utf-8")
+    rt = [json.loads(l) for l in out.splitlines() if l.strip()]
+    return orig, rt
+
+
+def test_claude_self_roundtrip_byte_equal(tmp_path: Path):
+    f = _make_claude_session(tmp_path)
+    orig, rt = _roundtrip_lines(ClaudeSource(home=tmp_path), f)
+    assert len(orig) == len(rt)
+    for i, (o, r) in enumerate(zip(orig, rt)):
+        assert o == r, f"diff at line {i}: {o} != {r}"
+
+
+def test_codex_self_roundtrip_byte_equal(tmp_path: Path):
+    f = _make_codex_session(tmp_path)
+    orig, rt = _roundtrip_lines(CodexSource(home=tmp_path), f)
+    assert len(orig) == len(rt)
+    for i, (o, r) in enumerate(zip(orig, rt)):
+        assert o == r, f"diff at line {i}: {o} != {r}"
+
+
+# ------------------------------------------------------------------ #
+# Cross-format viability                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_claude_to_codex_does_not_crash(tmp_path: Path):
+    f = _make_claude_session(tmp_path)
+    claude = ClaudeSource(home=tmp_path)
+    codex = CodexSource(home=tmp_path)
+    events = list(claude.parse(f))
+    out = codex.serialize(events)
+    assert out  # non-empty
+    # Re-parse via codex; must yield events.
+    out_path = tmp_path / "converted.jsonl"
+    out_path.write_bytes(out)
+    re_events = list(codex.parse(out_path))
+    assert len(re_events) > 0
+
+
+def test_codex_to_claude_does_not_crash(tmp_path: Path):
+    f = _make_codex_session(tmp_path)
+    claude = ClaudeSource(home=tmp_path)
+    codex = CodexSource(home=tmp_path)
+    events = list(codex.parse(f))
+    out = claude.serialize(events)
+    assert out
+    out_path = tmp_path / "converted.jsonl"
+    out_path.write_bytes(out)
+    re_events = list(claude.parse(out_path))
+    assert len(re_events) > 0
+
+
+def test_claude_to_codex_preserves_kernel_events(tmp_path: Path):
+    """Every kernel-modeled event class on the claude side must survive
+    cross-format conversion to codex."""
+    f = _make_claude_session(tmp_path)
+    claude = ClaudeSource(home=tmp_path)
+    codex = CodexSource(home=tmp_path)
+
+    in_events = list(claude.parse(f))
+    out_path = tmp_path / "converted.jsonl"
+    out_path.write_bytes(codex.serialize(in_events))
+    re_events = list(codex.parse(out_path))
+
+    # Kernel types we expect to still be present (lifecycle becomes
+    # codex's event_msg.thread_name_updated which re-parses as Lifecycle).
+    in_kernel = {e.type for e in in_events
+                 if e.type in {"user_message", "assistant_message",
+                               "assistant_reasoning", "tool_call",
+                               "tool_result", "session_start"}}
+    out_kernel = {e.type for e in re_events}
+
+    for kind in in_kernel:
+        assert kind in out_kernel, f"{kind} lost in claude→codex conversion"
+
+
+def test_codex_to_claude_preserves_kernel_events(tmp_path: Path):
+    f = _make_codex_session(tmp_path)
+    claude = ClaudeSource(home=tmp_path)
+    codex = CodexSource(home=tmp_path)
+
+    in_events = list(codex.parse(f))
+    out_path = tmp_path / "converted.jsonl"
+    out_path.write_bytes(claude.serialize(in_events))
+    re_events = list(claude.parse(out_path))
+
+    in_kernel = {e.type for e in in_events
+                 if e.type in {"user_message", "assistant_message",
+                               "assistant_reasoning", "tool_call",
+                               "tool_result"}}
+    out_kernel = {e.type for e in re_events}
+
+    for kind in in_kernel:
+        assert kind in out_kernel, f"{kind} lost in codex→claude conversion"
+
+
+# ------------------------------------------------------------------ #
+# Lossiness invariants                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_claude_branch_structure_preserved_within_unified(tmp_path: Path):
+    """parent_id chain survives parse round-trip, even though codex output
+    won't preserve the tree structure."""
+    f = _make_claude_session(tmp_path)
+    src = ClaudeSource(home=tmp_path)
+    events = list(src.parse(f))
+
+    # Find the assistant event derived from u1
+    a1_events = [e for e in events if e.parent_id == "u1"]
+    assert a1_events  # something was parented under u1
+
+
+def test_event_count_consistent_across_self_roundtrip(tmp_path: Path):
+    """Same source → unified → same source → unified gives the same event count."""
+    for source_factory, fixture_factory in [
+        (lambda: ClaudeSource(home=tmp_path), _make_claude_session),
+        (lambda: CodexSource(home=tmp_path), _make_codex_session),
+    ]:
+        f = fixture_factory(tmp_path)
+        src = source_factory()
+        events1 = list(src.parse(f))
+        out = src.serialize(events1)
+        out_path = tmp_path / "out.jsonl"
+        out_path.write_bytes(out)
+        events2 = list(src.parse(out_path))
+        assert len(events1) == len(events2), \
+            f"{src.name}: {len(events1)} ≠ {len(events2)}"
+
+
+# ------------------------------------------------------------------ #
+# Robustness                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_claude_serialize_empty_event_list(tmp_path: Path):
+    src = ClaudeSource(home=tmp_path)
+    assert src.serialize([]) == b""
+
+
+def test_codex_serialize_empty_event_list(tmp_path: Path):
+    src = CodexSource(home=tmp_path)
+    assert src.serialize([]) == b""
+
+
+def test_serialize_handles_synthesized_session_start(tmp_path: Path):
+    """Parser-synthesized SessionStart has empty raw; codex serializer
+    should still emit it as a session_meta row."""
+    from fleet.track.unified import SessionStart
+
+    src = CodexSource(home=tmp_path)
+    out = src.serialize([
+        SessionStart(source="claude", id="s1", cwd="/tmp", agent_version="0.5",
+                     timestamp="2026-04-30T00:00:00Z"),
+    ])
+    line = json.loads(out.decode("utf-8").strip())
+    assert line["type"] == "session_meta"
+    assert line["payload"]["cwd"] == "/tmp"

--- a/tests/track/test_install.py
+++ b/tests/track/test_install.py
@@ -1,0 +1,85 @@
+"""Unit tests for install.py — pure rendering only, no shelling out."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fleet.track.install import (
+    PLIST_LABEL,
+    SYSTEMD_SERVICE,
+    flt_executable,
+    render_launchd_plist,
+    render_systemd_unit,
+)
+from fleet.track.paths import TrackPaths
+
+
+def _paths(tmp_path: Path) -> TrackPaths:
+    return TrackPaths.under(tmp_path)
+
+
+def test_render_launchd_plist_has_required_keys(tmp_path: Path):
+    body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+
+    assert PLIST_LABEL in body
+    assert "/usr/local/bin/flt" in body
+    assert "<key>RunAtLoad</key>" in body
+    assert "<true/>" in body
+    assert "<key>KeepAlive</key>" in body
+    assert str(tmp_path / ".fleet" / "track" / "daemon.log") in body
+    assert "<key>HOME</key>" in body
+    assert str(tmp_path) in body
+
+
+def test_render_launchd_plist_excludes_track_base_url_when_unset(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
+    body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert "FLEET_TRACK_BASE_URL" not in body
+
+
+def test_render_launchd_plist_includes_track_base_url_when_set(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://example.fleetai.com")
+    body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert "FLEET_TRACK_BASE_URL" in body
+    assert "https://example.fleetai.com" in body
+
+
+def test_render_systemd_unit_has_required_directives(tmp_path: Path):
+    body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+
+    assert "[Unit]" in body
+    assert "[Service]" in body
+    assert "[Install]" in body
+    assert "ExecStart=/usr/local/bin/flt track daemon" in body
+    assert "Restart=always" in body
+    assert f"append:{tmp_path}/.fleet/track/daemon.log" in body
+    assert SYSTEMD_SERVICE  # imported, sanity check
+
+
+def test_render_systemd_unit_excludes_track_base_url_when_unset(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
+    body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert "FLEET_TRACK_BASE_URL" not in body
+
+
+def test_render_systemd_unit_includes_track_base_url_when_set(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://dev.example.com")
+    body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert "Environment=FLEET_TRACK_BASE_URL=https://dev.example.com" in body
+
+
+def test_flt_executable_returns_a_string():
+    """Don't assert the value (it depends on the venv) but assert the shape."""
+    exe = flt_executable()
+    assert isinstance(exe, str)
+    assert exe  # non-empty
+
+
+def test_render_paths_use_paths_home(tmp_path: Path):
+    """Renderers must use the passed `paths`, not `Path.home()`, so two test runs
+    don't collide on the same plist body."""
+    a = render_launchd_plist(TrackPaths.under(tmp_path / "a"), "/x/flt")
+    b = render_launchd_plist(TrackPaths.under(tmp_path / "b"), "/x/flt")
+    assert a != b
+    assert str(tmp_path / "a") in a
+    assert str(tmp_path / "b") in b

--- a/tests/track/test_merkle.py
+++ b/tests/track/test_merkle.py
@@ -1,0 +1,120 @@
+"""Unit tests for merkle.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fleet.track.merkle import HashCache, MerkleTree
+from fleet.track.paths import TrackPaths
+
+
+def _paths(tmp_path: Path) -> TrackPaths:
+    return TrackPaths.under(tmp_path)
+
+
+def _write(home: Path, rel: str, content: str) -> Path:
+    """Write a file under home and return its absolute path."""
+    p = home / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    return p
+
+
+def test_compute_root_is_deterministic():
+    a = {"foo": "h1", "bar": "h2"}
+    b = {"bar": "h2", "foo": "h1"}  # same map, different insertion order
+    assert MerkleTree.compute_root(a) == MerkleTree.compute_root(b)
+
+
+def test_compute_root_changes_when_content_changes():
+    r1 = MerkleTree.compute_root({"foo": "h1"})
+    r2 = MerkleTree.compute_root({"foo": "h2"})
+    assert r1 != r2
+
+
+def test_compute_root_empty_map_is_stable():
+    assert MerkleTree.compute_root({}) == MerkleTree.compute_root({})
+
+
+def test_hashcache_compute_then_cache_hit(tmp_path: Path):
+    paths = _paths(tmp_path)
+    cache = HashCache(paths)
+
+    f = _write(tmp_path, "test_file.txt", "hello")
+    digest = cache.get_or_compute(f)
+    assert digest is not None
+
+    # Re-read should return same digest from cache (no file change).
+    digest2 = cache.get_or_compute(f)
+    assert digest == digest2
+
+    cache.close()
+
+
+def test_hashcache_invalidates_on_content_change(tmp_path: Path):
+    """Same path, different content (and thus different mtime+size) → new digest."""
+    import time
+
+    paths = _paths(tmp_path)
+    cache = HashCache(paths)
+
+    f = _write(tmp_path, "test_file.txt", "hello")
+    digest1 = cache.get_or_compute(f)
+
+    time.sleep(0.01)  # ensure mtime ticks
+    f.write_text("hello world")
+    digest2 = cache.get_or_compute(f)
+
+    assert digest1 != digest2
+    cache.close()
+
+
+def test_hashcache_get_stored_digest(tmp_path: Path):
+    paths = _paths(tmp_path)
+    cache = HashCache(paths)
+    f = _write(tmp_path, "x.txt", "abc")
+    cache.get_or_compute(f)
+    rel = "x.txt"
+    assert cache.get_stored_digest(rel) is not None
+    assert cache.get_stored_digest("nope.txt") is None
+    cache.close()
+
+
+def test_hashcache_nonexistent_file_returns_none(tmp_path: Path):
+    paths = _paths(tmp_path)
+    cache = HashCache(paths)
+    digest = cache.get_or_compute(tmp_path / "does-not-exist.txt")
+    assert digest is None
+    cache.close()
+
+
+def test_merkle_build_with_custom_iterator(tmp_path: Path):
+    """Inversion of control: pass a file iterator instead of calling iter_source_files."""
+    paths = _paths(tmp_path)
+    cache = HashCache(paths)
+
+    f1 = _write(tmp_path, "a.jsonl", '{"x": 1}\n')
+    f2 = _write(tmp_path, "b.jsonl", '{"y": 2}\n')
+
+    tree = MerkleTree(cache, file_iter=[f1, f2])
+    file_map, root = tree.build()
+
+    # Two files in the map, paths are relative to home.
+    assert len(file_map) == 2
+    assert "a.jsonl" in file_map
+    assert "b.jsonl" in file_map
+    # Root hash matches the deterministic computation.
+    assert root == MerkleTree.compute_root(file_map)
+    cache.close()
+
+
+def test_merkle_diff_finds_changed_and_new(tmp_path: Path):
+    paths = _paths(tmp_path)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+
+    local = {"a": "h1", "b": "h2", "c": "h3"}
+    remote = {"a": "h1", "b": "DIFFERENT"}  # b changed, c new, missing-on-remote
+    changed = tree.diff(local, remote)
+    assert set(changed) == {"b", "c"}
+    cache.close()

--- a/tests/track/test_paths.py
+++ b/tests/track/test_paths.py
@@ -1,0 +1,49 @@
+"""Unit tests for TrackPaths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fleet.track.paths import TrackPaths
+
+
+def test_default_uses_home():
+    paths = TrackPaths.default()
+    assert paths.home == Path.home()
+    assert paths.track_dir == Path.home() / ".fleet" / "track"
+
+
+def test_under_roots_everything_at_given_dir(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    assert paths.home == tmp_path
+    assert paths.track_dir == tmp_path / ".fleet" / "track"
+    assert paths.state_db == tmp_path / ".fleet" / "track" / "state.db"
+    assert paths.status_file == tmp_path / ".fleet" / "track" / "status.json"
+    assert paths.pid_file == tmp_path / ".fleet" / "track" / "daemon.pid"
+    assert paths.log_file == tmp_path / ".fleet" / "track" / "daemon.log"
+    assert paths.config_file == tmp_path / ".fleet" / "track" / "config.json"
+    assert paths.credentials_file == tmp_path / ".fleet" / "credentials.json"
+
+
+def test_under_does_not_create_directories(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    assert not paths.track_dir.exists()
+
+
+def test_ensure_track_dir_creates_and_is_idempotent(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    assert paths.track_dir.is_dir()
+    paths.ensure_track_dir()  # second call must not raise
+    assert paths.track_dir.is_dir()
+
+
+def test_frozen_dataclass_is_immutable(tmp_path: Path):
+    import dataclasses
+
+    paths = TrackPaths.under(tmp_path)
+    try:
+        paths.home = tmp_path / "elsewhere"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("TrackPaths should be frozen")

--- a/tests/track/test_picker.py
+++ b/tests/track/test_picker.py
@@ -1,0 +1,120 @@
+"""Picker tests — only the pure formatting bits.
+
+The actual fzf invocation is exercised manually; piping output through
+subprocess in unit tests would couple to fzf availability and is more
+trouble than it's worth.
+"""
+
+from __future__ import annotations
+
+from fleet.track.picker import _format_line, _human_when, _short_cwd, fzf_available
+from fleet.track.store import Session
+
+
+# ------------------------------------------------------------------ #
+# _short_cwd                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_short_cwd_takes_basename():
+    assert _short_cwd("/Users/me/git/fleet-sdk") == "fleet-sdk"
+
+
+def test_short_cwd_handles_root():
+    assert _short_cwd("/") == "?"
+
+
+def test_short_cwd_none():
+    assert _short_cwd(None) == "?"
+
+
+def test_short_cwd_truncates_long_basenames():
+    long_name = "a" * 50
+    out = _short_cwd(f"/x/{long_name}")
+    assert len(out) == 30
+
+
+# ------------------------------------------------------------------ #
+# _human_when                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_human_when_seconds():
+    from datetime import datetime, timezone, timedelta
+    ts = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+    out = _human_when(ts)
+    assert "s ago" in out
+
+
+def test_human_when_minutes():
+    from datetime import datetime, timezone, timedelta
+    ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    out = _human_when(ts)
+    assert "m ago" in out
+
+
+def test_human_when_hours():
+    from datetime import datetime, timezone, timedelta
+    ts = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+    out = _human_when(ts)
+    assert "h ago" in out
+
+
+def test_human_when_handles_z_suffix():
+    from datetime import datetime, timezone, timedelta
+    ts = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+    out = _human_when(ts)
+    assert "ago" in out
+
+
+def test_human_when_unparseable():
+    out = _human_when("not a timestamp")
+    assert out  # returned something, didn't raise
+
+
+def test_human_when_none():
+    assert _human_when(None) == ""
+
+
+# ------------------------------------------------------------------ #
+# _format_line                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_format_line_starts_with_short_id():
+    s = Session(id="abcd1234-5678", tool="claude", cwd="/x")
+    line = _format_line(s)
+    assert line.startswith("abcd1234")
+
+
+def test_format_line_marks_forks():
+    s = Session(id="x", tool="claude", forked_from="parent", fork_point=10)
+    line = _format_line(s)
+    assert "↳" in line
+
+
+def test_format_line_no_fork_marker_for_root():
+    s = Session(id="x", tool="claude")
+    line = _format_line(s)
+    assert "↳" not in line
+
+
+def test_format_line_includes_tool():
+    s = Session(id="x", tool="codex")
+    assert "codex" in _format_line(s)
+
+
+def test_format_line_includes_event_count():
+    s = Session(id="x", tool="claude", event_count=42)
+    assert "42e" in _format_line(s)
+
+
+# ------------------------------------------------------------------ #
+# fzf availability check                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_fzf_available_returns_bool():
+    """Doesn't matter if it's True or False on the test machine, just
+    that the call doesn't raise."""
+    assert isinstance(fzf_available(), bool)

--- a/tests/track/test_picker.py
+++ b/tests/track/test_picker.py
@@ -123,6 +123,48 @@ def test_format_line_includes_event_count():
     assert "42e" in _format_line(s)
 
 
+def test_format_line_includes_metadata_title():
+    s = Session(id="x", tool="claude", metadata={"title": "Implementing fleet-track sidecar"})
+    line = _format_line(s)
+    assert "Implementing fleet-track sidecar" in line
+
+
+def test_format_line_truncates_long_titles():
+    s = Session(
+        id="x", tool="claude",
+        metadata={"title": "x" * 200},
+    )
+    line = _format_line(s)
+    # Title cap is 60 — final char is the ellipsis.
+    assert "…" in line
+
+
+def test_format_line_collapses_newlines_in_title():
+    """Titles never break the fzf row — newlines and tabs collapse to spaces."""
+    s = Session(
+        id="x", tool="claude",
+        metadata={"title": "first line\nsecond line\twith tab"},
+    )
+    line = _format_line(s)
+    assert "\n" not in line
+    assert "first line second line with tab" in line
+
+
+def test_format_line_no_title_when_metadata_absent():
+    s = Session(id="x", tool="claude")
+    line = _format_line(s)
+    # Just shouldn't crash; trailing whitespace is fine.
+    assert line.startswith("x")
+
+
+def test_format_line_no_title_when_metadata_not_dict():
+    """Defensive: if metadata round-trips as something weird, don't crash."""
+    s = Session(id="x", tool="claude")
+    object.__setattr__(s, "metadata", "not-a-dict")  # bypass frozen for test
+    line = _format_line(s)
+    assert line.startswith("x")
+
+
 # ------------------------------------------------------------------ #
 # fzf availability check                                               #
 # ------------------------------------------------------------------ #

--- a/tests/track/test_picker.py
+++ b/tests/track/test_picker.py
@@ -2,12 +2,26 @@
 
 The actual fzf invocation is exercised manually; piping output through
 subprocess in unit tests would couple to fzf availability and is more
-trouble than it's worth.
+trouble than it's worth. (Tool-picker logic is exception: `pick_tool`
+takes a `runner` injection so we can verify ordering / labels / cancel.)
 """
 
 from __future__ import annotations
 
-from fleet.track.picker import _format_line, _human_when, _short_cwd, fzf_available
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from fleet.track.picker import (
+    _format_line,
+    _format_tool_line,
+    _human_when,
+    _short_cwd,
+    fzf_available,
+    installed_tools,
+    pick_tool,
+)
 from fleet.track.store import Session
 
 
@@ -118,3 +132,133 @@ def test_fzf_available_returns_bool():
     """Doesn't matter if it's True or False on the test machine, just
     that the call doesn't raise."""
     assert isinstance(fzf_available(), bool)
+
+
+# ------------------------------------------------------------------ #
+# installed_tools                                                      #
+# ------------------------------------------------------------------ #
+
+
+def test_installed_tools_returns_only_binaries_on_path():
+    def fake_which(name: str):
+        return f"/usr/bin/{name}" if name in {"claude", "codex"} else None
+
+    with mock.patch("fleet.track.picker.shutil.which", side_effect=fake_which):
+        assert installed_tools() == ["claude", "codex"]
+
+
+def test_installed_tools_canonical_order_independent_of_shutil():
+    """Even if shutil reports them in a different order, the function
+    returns the canonical [claude, codex, cursor, opencode] subset."""
+    found = {"opencode", "claude"}
+    with mock.patch(
+        "fleet.track.picker.shutil.which",
+        side_effect=lambda n: "/x" if n in found else None,
+    ):
+        assert installed_tools() == ["claude", "opencode"]
+
+
+def test_installed_tools_empty_when_nothing_on_path():
+    with mock.patch("fleet.track.picker.shutil.which", return_value=None):
+        assert installed_tools() == []
+
+
+# ------------------------------------------------------------------ #
+# _format_tool_line                                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_format_tool_line_marks_source_tool():
+    line = _format_tool_line("claude", source_tool="claude")
+    assert line.startswith("claude")
+    assert "(same as source)" in line
+
+
+def test_format_tool_line_marks_cross_tool_lossy():
+    line = _format_tool_line("codex", source_tool="claude")
+    assert line.startswith("codex")
+    assert "cross-tool: lossy" in line
+
+
+# ------------------------------------------------------------------ #
+# pick_tool                                                            #
+# ------------------------------------------------------------------ #
+
+
+class _FakeResult:
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def _runner_returning(stdout: str, returncode: int = 0):
+    """Build a runner callable that records its inputs and returns a
+    fixed FakeResult — analogue to subprocess.run for tests."""
+    captured: dict[str, Any] = {}
+
+    def runner(args, input, capture_output, text):
+        captured["args"] = args
+        captured["input"] = input
+        return _FakeResult(returncode=returncode, stdout=stdout)
+
+    runner.captured = captured  # type: ignore[attr-defined]
+    return runner
+
+
+@pytest.fixture(autouse=True)
+def _force_fzf_available(monkeypatch):
+    """Pretend fzf is installed for these tests so they run on any host."""
+    monkeypatch.setattr("fleet.track.picker.fzf_available", lambda: True)
+
+
+def test_pick_tool_returns_chosen_tool():
+    runner = _runner_returning("codex      cross-tool: lossy\n")
+    out = pick_tool("claude", available=["claude", "codex"], runner=runner)
+    assert out == "codex"
+
+
+def test_pick_tool_returns_none_on_cancel():
+    runner = _runner_returning("", returncode=130)  # ctrl-c
+    out = pick_tool("claude", available=["claude", "codex"], runner=runner)
+    assert out is None
+
+
+def test_pick_tool_lists_source_tool_first():
+    """Source tool must be on the first row so it's the default highlight."""
+    runner = _runner_returning("codex      cross-tool: lossy\n")
+    pick_tool("codex", available=["claude", "codex", "cursor"], runner=runner)
+    lines = runner.captured["input"].splitlines()
+    assert lines[0].startswith("codex")
+    # Remaining are claude/cursor in canonical order.
+    assert lines[1].startswith("claude")
+    assert lines[2].startswith("cursor")
+
+
+def test_pick_tool_falls_back_to_canonical_when_source_not_installed():
+    """If the source tool isn't available locally, the picker still
+    works — just no '(same as source)' row, all rows are cross-tool."""
+    runner = _runner_returning("claude     cross-tool: lossy\n")
+    pick_tool("opencode", available=["claude", "codex"], runner=runner)
+    lines = runner.captured["input"].splitlines()
+    assert lines[0].startswith("claude")
+    assert lines[1].startswith("codex")
+    assert "cross-tool: lossy" in lines[0]
+    assert "cross-tool: lossy" in lines[1]
+
+
+def test_pick_tool_returns_none_when_no_tools_available():
+    runner = _runner_returning("")
+    assert pick_tool("claude", available=[], runner=runner) is None
+
+
+def test_pick_tool_passes_header_to_fzf():
+    runner = _runner_returning("claude     (same as source)\n")
+    pick_tool(
+        "claude",
+        available=["claude", "codex"],
+        header="Resume abc123 in which tool?",
+        runner=runner,
+    )
+    args = runner.captured["args"]
+    assert "--header" in args
+    assert args[args.index("--header") + 1] == "Resume abc123 in which tool?"

--- a/tests/track/test_picker_page.py
+++ b/tests/track/test_picker_page.py
@@ -1,0 +1,318 @@
+"""Unit tests for the fzf-reload helper.
+
+The helper is the subprocess fzf invokes when the user presses
+right/left/alt-h. We test it directly via `main()` so we don't rely on
+`python -m` resolution or fzf being on the test host.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from fleet.track import _picker_page
+from fleet.track.paths import TrackPaths
+from fleet.track.store import LocalSessionStore, Session
+from fleet.track.unified import UserMessage
+
+
+# ------------------------------------------------------------------ #
+# Fixtures                                                              #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def stub_store(tmp_path: Path):
+    """A LocalSessionStore seeded with 7 sessions so we can paginate
+    in pages of 2."""
+    paths = TrackPaths.under(tmp_path)
+    store = LocalSessionStore(paths)
+    for i in range(7):
+        store.create(
+            Session(
+                id=f"s{i}",
+                tool="claude",
+                last_active=f"2026-04-3{i}T00:00:00Z",
+            ),
+            [UserMessage(source="claude", text=f"hi-{i}")],
+        )
+    return store, paths
+
+
+def _state_for(paths: TrackPaths, *, current_index: int = 0,
+               cursors=None, limit: int = 2, query: str = "") -> dict:
+    return {
+        "source": "stub",
+        "tool": None,
+        "cwd": None,
+        "since": None,
+        "query": query,
+        "limit": limit,
+        "current_index": current_index,
+        "cursors": cursors or [None],
+    }
+
+
+def _write_state(tmp_path: Path, state: dict) -> Path:
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps(state))
+    return p
+
+
+# Patch _resolve_store everywhere so the helper uses the test store.
+@pytest.fixture(autouse=True)
+def _patch_resolver(monkeypatch, request, stub_store):
+    """Wire `_resolve_store` to the per-test stub. Skip when a test
+    explicitly overrides resolver behavior (rare)."""
+    if "no_autopatch_resolver" in request.keywords:
+        yield
+        return
+    store, _paths = stub_store
+    monkeypatch.setattr(_picker_page, "_resolve_store", lambda src: store)
+    yield
+
+
+# ------------------------------------------------------------------ #
+# emit_page                                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_emit_first_resets_index_to_zero(stub_store, tmp_path: Path):
+    _store, paths = stub_store
+    state = _state_for(paths, current_index=2,
+                       cursors=[None, "cursor1", "cursor2"], limit=2)
+    lines, new_state = _picker_page._emit_page(state, "first")
+    assert new_state["current_index"] == 0
+    assert len(lines) == 2  # first page = 2 rows
+    # Latest sessions first (recency-DESC).
+    assert lines[0].startswith("s6")
+    assert lines[1].startswith("s5")
+
+
+def test_emit_next_advances_one_page(stub_store, tmp_path: Path):
+    _store, paths = stub_store
+    state = _state_for(paths, current_index=0, cursors=[None], limit=2)
+    lines, new_state = _picker_page._emit_page(state, "next")
+    assert new_state["current_index"] == 1
+    assert len(new_state["cursors"]) >= 2  # appended a new cursor
+    assert lines[0].startswith("s4")
+    assert lines[1].startswith("s3")
+
+
+def test_emit_next_at_last_page_is_noop(stub_store, tmp_path: Path):
+    """Walking past the last page must keep `current_index` and
+    `cursors` unchanged so left-arrow still goes back correctly."""
+    store, paths = stub_store
+    # Walk forward until we run out, then try one more `next`.
+    cursor = None
+    cursors = [None]
+    while True:
+        items, next_cursor = store.page(limit=2, cursor=cursor)
+        if next_cursor is None:
+            break
+        cursors.append(next_cursor)
+        cursor = next_cursor
+    final_idx = len(cursors) - 1
+    state = _state_for(paths, current_index=final_idx,
+                       cursors=cursors, limit=2)
+
+    lines, new_state = _picker_page._emit_page(state, "next")
+    assert new_state["current_index"] == final_idx  # unchanged
+    assert new_state["cursors"] == cursors          # unchanged
+    assert lines == []
+
+
+def test_emit_prev_decrements_index(stub_store, tmp_path: Path):
+    _store, paths = stub_store
+    state = _state_for(paths, current_index=2,
+                       cursors=[None, "cursorA", "cursorB"], limit=2)
+    # The cursors stored in state would be real strings; the helper
+    # passes them straight to store.page. Replace them with real ones.
+    store, _paths = stub_store
+    _, c1 = store.page(limit=2, cursor=None)        # cursor for page 1
+    _, c2 = store.page(limit=2, cursor=c1)          # cursor for page 2
+    state["cursors"] = [None, c1, c2]
+
+    lines, new_state = _picker_page._emit_page(state, "prev")
+    assert new_state["current_index"] == 1
+    # Page 1 = sessions 4 and 3 (after 6, 5 on page 0).
+    assert lines[0].startswith("s4")
+
+
+def test_emit_prev_at_first_page_is_noop(stub_store, tmp_path: Path):
+    _store, paths = stub_store
+    state = _state_for(paths, current_index=0, cursors=[None], limit=2)
+    lines, new_state = _picker_page._emit_page(state, "prev")
+    assert new_state["current_index"] == 0
+    assert lines == []
+
+
+def test_emit_unknown_direction_raises(stub_store, tmp_path: Path):
+    _store, paths = stub_store
+    state = _state_for(paths)
+    with pytest.raises(SystemExit):
+        _picker_page._emit_page(state, "sideways")
+
+
+def test_emit_query_resets_to_page_zero(stub_store, tmp_path: Path):
+    """`--direction query` always returns page 0 of the new filtered
+    set, regardless of where the user was paginated to before."""
+    _store, paths = stub_store
+    state = _state_for(paths, current_index=2,
+                       cursors=[None, "x", "y"], limit=2, query="")
+    lines, new_state = _picker_page._emit_page(state, "first")
+    assert new_state["current_index"] == 0
+    # cursors stack must reset (old cursors were for unfiltered set).
+    assert new_state["cursors"][0] is None
+
+
+def test_main_query_filters_results(stub_store, tmp_path: Path, capsys):
+    """Passing --direction query --query <q> filters via store.page."""
+    store, paths = stub_store
+    # Add a session that only matches a specific search term.
+    from fleet.track.unified import UserMessage
+    store.create(
+        Session(id="needle", tool="claude",
+                last_active="2026-05-01T00:00:00Z",
+                metadata={"title": "match-me-only"}),
+        [UserMessage(source="claude", text="x")],
+    )
+    state_path = _write_state(tmp_path, _state_for(paths, limit=10))
+    _picker_page.main([
+        "--state-file", str(state_path),
+        "--direction", "query",
+        "--query", "match-me-only",
+    ])
+    out = capsys.readouterr().out.strip().splitlines()
+    # Only the seeded session should appear.
+    assert any(line.startswith("needle") for line in out)
+    assert not any(line.startswith("s") for line in out)
+    # State persisted with the new query.
+    persisted = json.loads(state_path.read_text())
+    assert persisted["query"] == "match-me-only"
+    assert persisted["current_index"] == 0
+
+
+def test_main_query_empty_clears_filter(stub_store, tmp_path: Path, capsys):
+    """--query '' clears the filter (fzf passes empty when user
+    backspaces the whole query)."""
+    _store, paths = stub_store
+    # Pre-seed with an active query.
+    state_path = _write_state(
+        tmp_path, _state_for(paths, limit=10, query="something-restrictive"),
+    )
+    _picker_page.main([
+        "--state-file", str(state_path),
+        "--direction", "query",
+        "--query", "",
+    ])
+    out = capsys.readouterr().out.strip().splitlines()
+    # All sessions back.
+    assert len(out) == 7
+    persisted = json.loads(state_path.read_text())
+    assert persisted["query"] == ""
+
+
+# ------------------------------------------------------------------ #
+# main() — full subprocess analogue                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_main_writes_lines_and_persists_state(stub_store, tmp_path: Path, capsys):
+    _store, paths = stub_store
+    state_path = _write_state(tmp_path, _state_for(paths, limit=2))
+
+    rc = _picker_page.main([
+        "--state-file", str(state_path), "--direction", "next",
+    ])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    out_lines = captured.out.strip().splitlines()
+    assert len(out_lines) == 2  # one page
+
+    # State on disk now reflects index advancement.
+    new_state = json.loads(state_path.read_text())
+    assert new_state["current_index"] == 1
+
+
+def test_main_first_returns_to_page_zero(stub_store, tmp_path: Path, capsys):
+    _store, paths = stub_store
+    # Pre-seed advanced state.
+    state_path = _write_state(
+        tmp_path, _state_for(paths, current_index=3,
+                             cursors=[None, "x", "y", "z"], limit=2),
+    )
+    rc = _picker_page.main([
+        "--state-file", str(state_path), "--direction", "first",
+    ])
+    assert rc == 0
+    new_state = json.loads(state_path.read_text())
+    assert new_state["current_index"] == 0
+
+
+def test_main_at_boundary_re_emits_current_page(stub_store, tmp_path: Path, capsys):
+    """When `next` is called at the last page, the helper should still
+    print the current page so fzf's reload doesn't end up empty."""
+    store, paths = stub_store
+    cursor = None
+    cursors = [None]
+    while True:
+        _items, next_cursor = store.page(limit=2, cursor=cursor)
+        if next_cursor is None:
+            break
+        cursors.append(next_cursor)
+        cursor = next_cursor
+
+    state_path = _write_state(tmp_path, _state_for(
+        paths, current_index=len(cursors) - 1, cursors=cursors, limit=2,
+    ))
+    _picker_page.main([
+        "--state-file", str(state_path), "--direction", "next",
+    ])
+    out = capsys.readouterr().out.strip().splitlines()
+    # Some output (the re-emitted current page) — never empty.
+    assert len(out) >= 1
+
+
+def test_main_emitted_lines_match_format_line(stub_store, tmp_path: Path, capsys):
+    """The fzf-reload output must use the same _format_line as the
+    initial seed so first-token id parsing keeps working across pages."""
+    from fleet.track.picker import _format_line
+
+    _store, paths = stub_store
+    state_path = _write_state(tmp_path, _state_for(paths, limit=2))
+    _picker_page.main(["--state-file", str(state_path), "--direction", "next"])
+    out = capsys.readouterr().out.strip().splitlines()
+
+    store, _paths = stub_store
+    items, _ = store.page(limit=2, cursor=None)
+    next_cursor_used = json.loads(state_path.read_text())["cursors"][1]
+    items, _ = store.page(limit=2, cursor=next_cursor_used)
+    expected = [_format_line(s) for s in items]
+    assert out == expected
+
+
+# ------------------------------------------------------------------ #
+# Shell quoting helper                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_shell_quote_handles_spaces():
+    from fleet.track.picker import _shell_quote
+    assert _shell_quote("/path with spaces/x") == "'/path with spaces/x'"
+
+
+def test_shell_quote_handles_embedded_quotes():
+    from fleet.track.picker import _shell_quote
+    quoted = _shell_quote("it's tricky")
+    # Should round-trip through a shell — single-quote escape pattern.
+    assert "'\\''" in quoted
+
+
+def test_shell_quote_empty_is_empty_string_literal():
+    from fleet.track.picker import _shell_quote
+    assert _shell_quote("") == "''"

--- a/tests/track/test_picker_textual.py
+++ b/tests/track/test_picker_textual.py
@@ -1,0 +1,431 @@
+"""Unit tests for the Textual session/tool pickers.
+
+Drives the apps via `App.run_test()` (Textual's built-in pilot harness)
+so we don't need a real terminal. We assert on:
+
+  - Initial render: first page rows match `store.page()`.
+  - Live search: typing a query triggers a re-fetch and resets to page 0.
+  - Paging: `pagedown` advances; `pageup` rewinds; cursors are stacked.
+  - Submission: Enter exits with the highlighted Session.
+  - Cancellation: Escape exits with None.
+  - Tool picker: option ordering puts source-tool first; selection
+    returns the tool name; Escape cancels.
+
+The store is a real `LocalSessionStore` seeded with deterministic rows
+so we can pin the "page 0 / page 1" output exactly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual")
+
+from fleet.track.paths import TrackPaths  # noqa: E402
+from fleet.track.picker_textual import (  # noqa: E402
+    SessionPickerApp,
+    ToolPickerApp,
+)
+from fleet.track.store import LocalSessionStore, Session  # noqa: E402
+from fleet.track.unified import UserMessage  # noqa: E402
+
+
+# ------------------------------------------------------------------ #
+# Fixtures                                                              #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def stub_store(tmp_path: Path):
+    """A LocalSessionStore seeded with 7 sessions so we can paginate
+    in pages of 2 and exercise both forward and backward walks."""
+    paths = TrackPaths.under(tmp_path)
+    store = LocalSessionStore(paths)
+    for i in range(7):
+        store.create(
+            Session(
+                id=f"s{i}",
+                tool="claude",
+                last_active=f"2026-04-3{i}T00:00:00Z",
+                metadata={"title": f"title-{i}"},
+            ),
+            [UserMessage(source="claude", text=f"hi-{i}")],
+        )
+    return store
+
+
+async def _settle(app, pilot) -> None:
+    """Wait for any in-flight fetch worker to complete and the UI to
+    reflect its result. Tests use this anywhere they previously called
+    a single `pilot.pause()` — workers + run_in_executor mean the
+    pipeline takes a few ticks to settle."""
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+
+
+# ------------------------------------------------------------------ #
+# SessionPickerApp                                                      #
+# ------------------------------------------------------------------ #
+
+
+def _picker(stub_store, **kwargs) -> SessionPickerApp:
+    """Build a picker with debounce disabled — tests don't need to
+    simulate human typing speed."""
+    return SessionPickerApp(stub_store, debounce_s=0, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_initial_page_renders_first_page(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        assert app.current_index == 0
+        # 7 rows, limit 2 → first page has rows s6 and s5 (recency-DESC).
+        assert list(app.sessions_by_id) == ["s6", "s5"]
+
+
+@pytest.mark.asyncio
+async def test_right_arrow_advances_to_next_page(stub_store):
+    """Left/right arrows are the primary paging keys."""
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("right")
+        await _settle(app, pilot)
+        assert app.current_index == 1
+        assert list(app.sessions_by_id) == ["s4", "s3"]
+
+
+@pytest.mark.asyncio
+async def test_left_arrow_rewinds_one_page(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("right")
+        await _settle(app, pilot)
+        await pilot.press("right")
+        await _settle(app, pilot)
+        assert app.current_index == 2
+
+        await pilot.press("left")
+        await _settle(app, pilot)
+        assert app.current_index == 1
+        assert list(app.sessions_by_id) == ["s4", "s3"]
+
+
+@pytest.mark.asyncio
+async def test_pagedown_also_pages(stub_store):
+    """pgdn/pgup are aliases for left/right — both should work."""
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("pagedown")
+        await _settle(app, pilot)
+        assert app.current_index == 1
+        assert list(app.sessions_by_id) == ["s4", "s3"]
+
+
+@pytest.mark.asyncio
+async def test_left_at_first_page_is_noop(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("left")
+        await _settle(app, pilot)
+        assert app.current_index == 0
+
+
+@pytest.mark.asyncio
+async def test_right_at_last_page_is_noop(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        # 7 rows / 2 per page → 4 pages (indexes 0..3).
+        for _ in range(4):
+            await pilot.press("right")
+            await _settle(app, pilot)
+        last_idx = app.current_index
+        await pilot.press("right")
+        await _settle(app, pilot)
+        assert app.current_index == last_idx
+
+
+@pytest.mark.asyncio
+async def test_typing_query_resets_to_page_zero(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        # Walk forward first so we can verify the reset.
+        await pilot.press("right")
+        await _settle(app, pilot)
+        assert app.current_index == 1
+
+        # Type "title-6". Each keystroke triggers on_input_changed, which
+        # re-queries and resets to page 0.
+        for ch in "title-6":
+            await pilot.press(ch)
+        await _settle(app, pilot)
+        assert app.current_index == 0
+        assert app.query_text == "title-6"
+        # Only s6 matches that title.
+        assert list(app.sessions_by_id) == ["s6"]
+
+
+@pytest.mark.asyncio
+async def test_typing_updates_query_text_synchronously(stub_store):
+    """The Input's value (and our `query_text`) must reflect the
+    keystroke immediately — that's what makes typing feel snappy.
+    The store fetch happens in a worker after, but `query_text` is
+    set synchronously inside on_input_changed."""
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("a")
+        # Don't wait for the worker — just one tick for Input to fire.
+        await pilot.pause()
+        assert app.query_text == "a"
+
+
+@pytest.mark.asyncio
+async def test_clearing_query_restores_full_set(stub_store):
+    """When the user backspaces to an empty query, the picker must
+    revert to the unfiltered first page."""
+    app = _picker(stub_store, limit=10)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        for ch in "title-6":
+            await pilot.press(ch)
+        await _settle(app, pilot)
+        assert list(app.sessions_by_id) == ["s6"]
+
+        for _ in range(len("title-6")):
+            await pilot.press("backspace")
+        await _settle(app, pilot)
+        assert app.query_text == ""
+        # All 7 sessions back (limit=10 fits them all on one page).
+        assert len(app.sessions_by_id) == 7
+
+
+@pytest.mark.asyncio
+async def test_enter_submits_highlighted_session(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        # First row of page 0 is s6 (highest last_active).
+        await pilot.press("enter")
+        await pilot.pause()
+    assert isinstance(app.return_value, Session)
+    assert app.return_value.id == "s6"
+
+
+@pytest.mark.asyncio
+async def test_down_then_enter_submits_second_row(stub_store):
+    app = _picker(stub_store, limit=3)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+    assert app.return_value.id == "s5"
+
+
+@pytest.mark.asyncio
+async def test_escape_cancels_returning_none(stub_store):
+    app = _picker(stub_store, limit=2)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.return_value is None
+
+
+@pytest.mark.asyncio
+async def test_query_with_no_matches_renders_empty(stub_store):
+    app = _picker(stub_store, limit=10)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        for ch in "no-such-thing":
+            await pilot.press(ch)
+        await _settle(app, pilot)
+        assert app.sessions_by_id == {}
+        # Submitting an empty page must not crash and must not exit.
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_value is None  # still running effectively
+
+
+# ------------------------------------------------------------------ #
+# Live mode — store-side filtering for backends with too many rows     #
+# ------------------------------------------------------------------ #
+
+
+class _LiveStore:
+    """Stub that reports more rows than fit in a snapshot — forces the
+    picker into live mode. Tracks every page() call so tests can assert
+    the picker actually re-queries on each keystroke."""
+
+    def __init__(self, rows: list[Session]) -> None:
+        from fleet.track.store import _matches_query, _sort_key
+
+        self._rows_sorted = sorted(rows, key=_sort_key, reverse=True)
+        self._matches_query = _matches_query
+        self.calls: list[dict] = []
+
+    def page(
+        self, *, tool=None, cwd=None, since=None, query=None,
+        limit=20, cursor=None,
+    ):
+        self.calls.append({"query": query, "cursor": cursor, "limit": limit})
+        rows = self._rows_sorted
+        if query:
+            rows = [s for s in rows if self._matches_query(s, query)]
+        idx = int(cursor) if cursor else 0
+        page = rows[idx : idx + limit]
+        next_idx = idx + limit
+        next_cursor = str(next_idx) if next_idx < len(rows) else None
+        return page, next_cursor
+
+    def list(self, **_):
+        return list(self._rows_sorted)
+
+
+@pytest.mark.asyncio
+async def test_picker_falls_into_live_mode_when_snapshot_overflows():
+    """When the snapshot fetch returns a next_cursor (i.e. more rows
+    exist than fit), the picker must switch to live mode and serve
+    every keystroke + page action via store.page()."""
+    from fleet.track.store import Session
+
+    rows = [
+        Session(id=f"s{i:02d}", tool="claude",
+                last_active=f"2026-04-{(i % 28) + 1:02d}T00:00:00Z",
+                metadata={"title": f"item-{i}"})
+        for i in range(50)
+    ]
+    store = _LiveStore(rows)
+    app = SessionPickerApp(
+        store, limit=5, snapshot_limit=10, debounce_s=0,
+    )
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        # Snapshot fetch returned 10 rows + a cursor → live mode.
+        assert app._mode == "live"
+        # Initial render shows up to `limit` rows from the snapshot,
+        # NOT the full 10.
+        assert len(app.sessions_by_id) == 5
+
+        before = len(store.calls)
+        for ch in "item-7":
+            await pilot.press(ch)
+        await _settle(app, pilot)
+        # Each keystroke triggered a store.page() call (or coalesced via
+        # exclusive=True), and at least one fetch landed.
+        assert len(store.calls) > before
+        # Last call carried the typed query.
+        assert store.calls[-1]["query"] == "item-7"
+
+
+@pytest.mark.asyncio
+async def test_picker_live_mode_paging_uses_cursors():
+    """Right arrow in live mode should advance via the store's cursor
+    contract — picker holds a cursor stack, fetches next page on
+    advance, and prev page from the cached cursor."""
+    from fleet.track.store import Session
+
+    rows = [
+        Session(id=f"s{i:02d}", tool="claude",
+                last_active=f"2026-04-{(i % 28) + 1:02d}T00:00:00Z")
+        for i in range(20)
+    ]
+    store = _LiveStore(rows)
+    app = SessionPickerApp(
+        store, limit=4, snapshot_limit=4, debounce_s=0,
+    )
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        assert app._mode == "live"
+        first_page_ids = list(app.sessions_by_id)
+
+        await pilot.press("right")
+        await _settle(app, pilot)
+        second_page_ids = list(app.sessions_by_id)
+        assert first_page_ids != second_page_ids
+        assert app.current_index == 1
+
+        await pilot.press("left")
+        await _settle(app, pilot)
+        # Back to page 0, same rows as the first time.
+        assert list(app.sessions_by_id) == first_page_ids
+
+
+@pytest.mark.asyncio
+async def test_picker_local_store_uses_snapshot_mode(stub_store):
+    """With our seeded local stub (7 rows, snapshot_limit=2000), the
+    snapshot easily fits and the picker should pick snapshot mode —
+    every keystroke filters in-process, no further store calls."""
+    app = SessionPickerApp(stub_store, limit=2, debounce_s=0)
+    async with app.run_test() as pilot:
+        await _settle(app, pilot)
+        assert app._mode == "snapshot"
+        assert app._snapshot is not None
+        assert len(app._snapshot) == 7
+
+
+# ------------------------------------------------------------------ #
+# ToolPickerApp                                                         #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_tool_picker_source_tool_first():
+    """`pick_tool_textual` is responsible for ordering, but ToolPickerApp
+    just renders what it's given. We pass an already-ordered list."""
+    app = ToolPickerApp(
+        ["claude", "codex", "cursor"], source_tool="claude"
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Default highlight is the source tool's index.
+        from textual.widgets import OptionList
+        ol = app.query_one(OptionList)
+        assert ol.highlighted == 0  # "claude" sits at index 0
+
+
+@pytest.mark.asyncio
+async def test_tool_picker_enter_returns_id():
+    app = ToolPickerApp(
+        ["claude", "codex"], source_tool="claude"
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+    assert app.return_value == "claude"
+
+
+@pytest.mark.asyncio
+async def test_tool_picker_down_then_enter_picks_second():
+    app = ToolPickerApp(
+        ["claude", "codex"], source_tool="claude"
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+    assert app.return_value == "codex"
+
+
+@pytest.mark.asyncio
+async def test_tool_picker_escape_cancels():
+    app = ToolPickerApp(
+        ["claude", "codex"], source_tool="claude"
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.return_value is None

--- a/tests/track/test_queue.py
+++ b/tests/track/test_queue.py
@@ -1,0 +1,188 @@
+"""Unit tests for queue.py."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from fleet.track.paths import TrackPaths
+from fleet.track.queue import MAX_ATTEMPTS, QueueItem, UploadQueue
+
+
+def _q(tmp_path: Path) -> UploadQueue:
+    return UploadQueue(TrackPaths.under(tmp_path))
+
+
+def test_enqueue_then_claim(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    items = q.claim_batch(n=10)
+    assert len(items) == 1
+    assert items[0].path == "a.jsonl"
+    assert items[0].sha256 == "h1"
+    assert items[0].attempts == 0
+    q.close()
+
+
+def test_enqueue_idempotent_on_same_pair(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    q.enqueue("a.jsonl", "h1")
+    q.enqueue("a.jsonl", "h1")
+    items = q.claim_batch(n=10)
+    assert len(items) == 1
+    q.close()
+
+
+def test_claim_batch_marks_in_flight(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    q.claim_batch(n=10)
+    # Re-claim immediately must not return the same item again.
+    second = q.claim_batch(n=10)
+    assert second == []
+    assert q.stats() == {"in_flight": 1}
+    q.close()
+
+
+def test_mark_done_completes(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    q.claim_batch(n=10)
+    q.mark_done("a.jsonl", "h1")
+    assert q.stats() == {"done": 1}
+    q.close()
+
+
+def test_mark_done_prunes_older_versions_of_same_path(tmp_path: Path):
+    """When v2 succeeds, v1 still pending/failed at same path is pruned."""
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    time.sleep(0.01)  # ensure enqueued_at differs
+    q.enqueue("a.jsonl", "h2")
+
+    # Claim only h2 and mark done. h1 should be pruned because it was enqueued
+    # before h2 and is for the same path.
+    items = q.claim_batch(n=10)
+    h2_item = next(i for i in items if i.sha256 == "h2")
+    q.mark_done("a.jsonl", h2_item.sha256)
+
+    # h1 should be gone, h2 should be done.
+    stats = q.stats()
+    assert stats.get("done", 0) == 1
+    assert stats.get("pending", 0) == 0
+    q.close()
+
+
+def test_mark_done_keeps_newer_versions(tmp_path: Path):
+    """When v1 succeeds and v2 was enqueued AFTER, v2 stays."""
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    items = q.claim_batch(n=10)
+    time.sleep(0.01)
+    q.enqueue("a.jsonl", "h2")
+
+    q.mark_done("a.jsonl", items[0].sha256)
+
+    # h2 should still be pending (newer enqueue).
+    pending = q.claim_batch(n=10)
+    assert len(pending) == 1
+    assert pending[0].sha256 == "h2"
+    q.close()
+
+
+def test_mark_failed_retries_with_backoff(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    q.claim_batch(n=10)
+    q.mark_failed("a.jsonl", "h1", "boom")
+
+    # Failed once should be pending again (with future next_attempt_at).
+    stats = q.stats()
+    assert stats.get("pending", 0) == 1
+
+    # Cannot be claimed yet because backoff sets next_attempt_at in the future.
+    items = q.claim_batch(n=10)
+    assert items == []
+    q.close()
+
+
+def test_mark_failed_eventually_terminal(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    for _ in range(MAX_ATTEMPTS):
+        # Reset next_attempt_at so we can keep claiming for the test.
+        q._conn.execute(
+            "UPDATE queue SET status='pending', next_attempt_at=0 WHERE path=? AND sha256=?",
+            ("a.jsonl", "h1"),
+        )
+        q._conn.commit()
+        q.claim_batch(n=10)
+        q.mark_failed("a.jsonl", "h1", "fail")
+
+    stats = q.stats()
+    assert stats.get("failed", 0) == 1
+    q.close()
+
+
+def test_reset_failed_requeues(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    for _ in range(MAX_ATTEMPTS):
+        q._conn.execute(
+            "UPDATE queue SET status='pending', next_attempt_at=0 WHERE path=? AND sha256=?",
+            ("a.jsonl", "h1"),
+        )
+        q._conn.commit()
+        q.claim_batch(n=10)
+        q.mark_failed("a.jsonl", "h1", "fail")
+
+    assert q.stats().get("failed", 0) == 1
+    n = q.reset_failed()
+    assert n == 1
+    assert q.stats().get("failed", 0) == 0
+    q.close()
+
+
+def test_oldest_pending_age_when_empty(tmp_path: Path):
+    q = _q(tmp_path)
+    assert q.oldest_pending_age() is None
+    q.close()
+
+
+def test_oldest_pending_age_increases_over_time(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue("a.jsonl", "h1")
+    age = q.oldest_pending_age()
+    assert age is not None
+    assert age >= 0
+    q.close()
+
+
+def test_corrupt_db_is_wiped_and_reinit(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    # Make the file a non-sqlite so integrity_check fails.
+    paths.state_db.write_bytes(b"this is not a valid sqlite database")
+
+    # Should not raise; should wipe and start fresh.
+    q = UploadQueue(paths)
+    q.enqueue("a.jsonl", "h1")
+    assert q.stats() == {"pending": 1}
+    q.close()
+
+
+def test_separate_paths_separate_queues(tmp_path: Path):
+    """Two TrackPaths in different dirs must not share state."""
+    q1 = UploadQueue(TrackPaths.under(tmp_path / "one"))
+    q2 = UploadQueue(TrackPaths.under(tmp_path / "two"))
+
+    q1.enqueue("a.jsonl", "h1")
+
+    assert q1.stats().get("pending", 0) == 1
+    assert q2.stats().get("pending", 0) == 0
+
+    q1.close()
+    q2.close()

--- a/tests/track/test_reconciler.py
+++ b/tests/track/test_reconciler.py
@@ -1,0 +1,124 @@
+"""Unit tests for Reconciler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+from fleet.track.api import TrackAPIClient
+from fleet.track.merkle import HashCache, MerkleTree
+from fleet.track.paths import TrackPaths
+from fleet.track.queue import UploadQueue
+from fleet.track.reconciler import Reconciler
+
+
+def _auth() -> Optional[Tuple[str, str]]:
+    return ("jwt", "team")
+
+
+def _seed_file(home: Path, rel: str, content: str = "data") -> Path:
+    p = home / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    return p
+
+
+def _build_reconciler(tmp_path: Path, manifest_handler):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    transport = httpx.MockTransport(manifest_handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    api = TrackAPIClient(client=client, auth_provider=_auth)
+
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    f1 = _seed_file(tmp_path, ".claude/projects/x/a.jsonl", '{"a":1}\n')
+    f2 = _seed_file(tmp_path, ".claude/projects/x/b.jsonl", '{"b":2}\n')
+    tree = MerkleTree(cache, file_iter=[f1, f2])
+
+    return Reconciler(queue=queue, cache=cache, tree=tree, api=api), paths, queue, [f1, f2]
+
+
+def test_reconcile_first_run_enqueues_everything(tmp_path: Path):
+    """Empty remote manifest → all local files are 'changed' → all enqueued."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith("/manifest"):
+            return httpx.Response(200, json={"root_hash": "", "files": {}})
+        raise AssertionError(f"unexpected {req.url}")
+
+    reconciler, _paths, queue, files = _build_reconciler(tmp_path, handler)
+    result = reconciler.reconcile("dev1")
+
+    assert result.in_sync is False
+    assert len(result.changed_paths) == 2
+    # Both files are now in the queue as pending.
+    assert queue.stats().get("pending", 0) == 2
+    queue.close()
+
+
+def test_reconcile_when_in_sync_enqueues_nothing(tmp_path: Path):
+    """If remote root == local root, no uploads happen."""
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+
+    f1 = _seed_file(tmp_path, ".claude/projects/x/a.jsonl", "AAA")
+    tree = MerkleTree(cache, file_iter=[f1])
+    local_map, local_root = tree.build()
+
+    # Mock returns the EXACT local map as the "remote" manifest.
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"root_hash": local_root, "files": local_map})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    api = TrackAPIClient(client=client, auth_provider=_auth)
+
+    reconciler = Reconciler(queue=queue, cache=cache, tree=tree, api=api)
+    result = reconciler.reconcile("dev1")
+
+    assert result.in_sync is True
+    assert result.changed_paths == ()
+    assert queue.stats() == {}
+    queue.close()
+
+
+def test_reconcile_only_enqueues_changed_files(tmp_path: Path):
+    """Remote already has one file; only the other gets enqueued."""
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+
+    f1 = _seed_file(tmp_path, ".claude/projects/x/a.jsonl", "AAA")
+    f2 = _seed_file(tmp_path, ".claude/projects/x/b.jsonl", "BBB")
+    tree = MerkleTree(cache, file_iter=[f1, f2])
+
+    # Build local first to grab a real hash for f1; pretend that's already on remote.
+    local_map, _ = tree.build()
+    f1_rel = next(p for p in local_map if p.endswith("a.jsonl"))
+    remote_files = {f1_rel: local_map[f1_rel]}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"root_hash": "stale", "files": remote_files})
+
+    transport = httpx.MockTransport(handler)
+    api = TrackAPIClient(
+        client=httpx.Client(transport=transport, base_url="http://test"),
+        auth_provider=_auth,
+    )
+
+    reconciler = Reconciler(queue=queue, cache=cache, tree=tree, api=api)
+    result = reconciler.reconcile("dev1")
+
+    assert result.in_sync is False
+    assert len(result.changed_paths) == 1
+    assert result.changed_paths[0].endswith("b.jsonl")
+    assert queue.stats().get("pending", 0) == 1
+    queue.close()

--- a/tests/track/test_repos.py
+++ b/tests/track/test_repos.py
@@ -1,0 +1,452 @@
+"""Unit tests for repo capture, registry, and discovery.
+
+These tests don't shell to git for the URL-normalize / registry / scan
+paths — they construct repos in tmp_path with a fake `.git` dir + a
+file that mimics what `git remote get-url origin` would print.
+
+For the `capture_repo` paths we DO use real git to keep the test
+honest end-to-end; capture is module-cached so we reset the cache
+each test to avoid bleed-through.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from fleet.track import repos as repos_mod
+from fleet.track.paths import TrackPaths
+from fleet.track.repos import (
+    RepoRegistry,
+    _walk_for_repos,
+    capture_repo,
+    default_scan_roots,
+    normalize_repo_url,
+    resolve_repo_cwd,
+    scan_for_repo,
+)
+
+
+# ------------------------------------------------------------------ #
+# Fixtures                                                              #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture(autouse=True)
+def _reset_capture_cache():
+    """`capture_repo` memoizes per process. Reset between tests so
+    fixtures created in one test don't leak into another."""
+    repos_mod._capture_cache.clear()
+    yield
+    repos_mod._capture_cache.clear()
+
+
+def _make_repo(path: Path, *, origin_url: str | None = None) -> Path:
+    """Initialize a git repo at `path` with optional origin remote."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    if origin_url:
+        subprocess.run(
+            ["git", "remote", "add", "origin", origin_url],
+            cwd=path,
+            check=True,
+        )
+    return path
+
+
+# ------------------------------------------------------------------ #
+# normalize_repo_url                                                   #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "variant,expected",
+    [
+        ("git@github.com:fleet-ai/fleet-sdk.git", "github.com/fleet-ai/fleet-sdk"),
+        ("git@github.com:fleet-ai/fleet-sdk", "github.com/fleet-ai/fleet-sdk"),
+        (
+            "ssh://git@github.com/fleet-ai/fleet-sdk.git",
+            "github.com/fleet-ai/fleet-sdk",
+        ),
+        ("https://github.com/fleet-ai/fleet-sdk", "github.com/fleet-ai/fleet-sdk"),
+        ("https://github.com/fleet-ai/fleet-sdk.git", "github.com/fleet-ai/fleet-sdk"),
+        ("https://GITHUB.com/Fleet-AI/Fleet-SDK.git", "github.com/fleet-ai/fleet-sdk"),
+    ],
+)
+def test_normalize_collapses_equivalent_urls(variant: str, expected: str):
+    """All real-world remote-URL forms for the same repo must produce
+    the same key. Drift here is an outage waiting to happen — the
+    registry would split one repo into multiple keys and resume would
+    silently miss checkouts."""
+    assert normalize_repo_url(variant) == expected
+
+
+def test_normalize_handles_empty():
+    assert normalize_repo_url("") == ""
+
+
+def test_normalize_passes_through_unrecognized():
+    """Better to under-canonicalize than mangle. An odd URL we don't
+    recognize as ssh/scp/https comes out lowercased and `.git`-stripped
+    but otherwise intact."""
+    assert normalize_repo_url("Some/Weird/Path.git") == "some/weird/path"
+
+
+# ------------------------------------------------------------------ #
+# capture_repo                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_capture_returns_url_and_subpath(tmp_path: Path):
+    repo = _make_repo(
+        tmp_path / "myrepo",
+        origin_url="git@github.com:test/myrepo.git",
+    )
+    sub = repo / "src" / "deep"
+    sub.mkdir(parents=True)
+    info = capture_repo(str(sub))
+    assert info.url == "github.com/test/myrepo"
+    # Resolve symlinks for both sides since git rev-parse may return
+    # the resolved form on platforms where /tmp is a symlink (macOS).
+    assert Path(info.root).resolve() == repo.resolve()
+    assert info.subpath == "src/deep"
+    assert info.origin_cwd == str(sub)
+
+
+def test_capture_outside_git_repo_returns_none_url(tmp_path: Path):
+    info = capture_repo(str(tmp_path))
+    assert info.url is None
+    assert info.root is None
+    assert info.subpath == ""
+    assert info.origin_cwd == str(tmp_path)
+
+
+def test_capture_repo_without_origin(tmp_path: Path):
+    """Repo with no `origin` remote: root is found, url is None."""
+    repo = _make_repo(tmp_path / "no-origin")
+    info = capture_repo(str(repo))
+    assert info.url is None
+    assert info.root is not None  # root IS known
+
+
+def test_capture_caches_per_cwd(tmp_path: Path, monkeypatch):
+    """Second call must not shell out again."""
+    repo = _make_repo(tmp_path / "r", origin_url="git@github.com:t/r.git")
+    cwd = str(repo)
+    capture_repo(cwd)
+
+    calls = {"n": 0}
+    real = repos_mod._git
+
+    def counted(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(repos_mod, "_git", counted)
+
+    capture_repo(cwd)
+    assert calls["n"] == 0  # cached, no new git invocations
+
+
+def test_capture_upserts_into_registry(tmp_path: Path):
+    """Caller can pass a registry; capture stamps the (url, root) pair
+    into it as a side-effect so resume lookups succeed without an
+    explicit registry warm-up step."""
+    paths = TrackPaths.under(tmp_path / "fleet")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    repo = _make_repo(tmp_path / "r", origin_url="git@github.com:t/r.git")
+    capture_repo(str(repo), registry=reg)
+    hits = reg.lookup("github.com/t/r")
+    assert len(hits) == 1
+    assert hits[0].resolve() == repo.resolve()
+
+
+# ------------------------------------------------------------------ #
+# RepoRegistry                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_registry_round_trip(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    r = RepoRegistry(paths=paths)
+    repo_dir = tmp_path / "r"
+    repo_dir.mkdir()
+    r.upsert("github.com/test/r", str(repo_dir))
+
+    # New instance reads the persisted file.
+    r2 = RepoRegistry(paths=paths)
+    hits = r2.lookup("github.com/test/r")
+    assert len(hits) == 1
+    assert hits[0] == repo_dir
+
+
+def test_registry_lookup_filters_missing_paths(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    r = RepoRegistry(paths=paths)
+    real = tmp_path / "real"
+    real.mkdir()
+    r.upsert("k", str(real))
+    r.upsert("k", str(tmp_path / "nonexistent"))
+    hits = r.lookup("k")
+    assert hits == [real]
+
+
+def test_registry_upsert_idempotent_updates_freshness(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    r = RepoRegistry(paths=paths)
+    p = tmp_path / "r"
+    p.mkdir()
+    r.upsert("k", str(p))
+    first = json.loads((paths.track_dir / "repos.json").read_text())
+    first_seen = first["repos"]["k"][0]["last_seen"]
+    # Second upsert: must NOT add a duplicate; must update last_seen.
+    r.upsert("k", str(p))
+    second = json.loads((paths.track_dir / "repos.json").read_text())
+    entries = second["repos"]["k"]
+    assert len(entries) == 1
+    assert entries[0]["last_seen"] >= first_seen
+
+
+def test_registry_freshest_first(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    r = RepoRegistry(paths=paths)
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    r.upsert("k", str(a))
+    r.upsert("k", str(b))
+    # Touch `a` again so it's the freshest.
+    r.upsert("k", str(a))
+    hits = r.lookup("k")
+    assert hits == [a, b]
+
+
+def test_registry_handles_corrupt_file(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    (paths.track_dir / "repos.json").write_text("this is not json")
+    r = RepoRegistry(paths=paths)
+    # Should not crash; just acts as empty.
+    assert r.lookup("anything") == []
+    # And subsequent upserts work, replacing the bad file.
+    p = tmp_path / "r"
+    p.mkdir()
+    r.upsert("k", str(p))
+    assert r.lookup("k") == [p]
+
+
+def test_registry_known_paths_filters_dead(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    r = RepoRegistry(paths=paths)
+    alive = tmp_path / "alive"
+    alive.mkdir()
+    r.upsert("k1", str(alive))
+    r.upsert("k2", str(tmp_path / "dead"))
+    paths_seen = r.known_paths()
+    assert paths_seen == [alive]
+
+
+# ------------------------------------------------------------------ #
+# Scan                                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_scan_finds_matching_repo(tmp_path: Path):
+    a = _make_repo(tmp_path / "a", origin_url="git@github.com:t/a.git")
+    b = _make_repo(tmp_path / "b", origin_url="git@github.com:t/b.git")
+    hit = scan_for_repo("github.com/t/b", roots=[tmp_path])
+    assert hit is not None
+    assert hit.resolve() == b.resolve()
+    # And explicitly: didn't return `a`.
+    assert hit.resolve() != a.resolve()
+
+
+def test_scan_caches_hit_in_registry(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    repo = _make_repo(tmp_path / "r", origin_url="git@github.com:t/r.git")
+    hit = scan_for_repo("github.com/t/r", registry=reg, roots=[tmp_path])
+    assert hit is not None
+    # Registry now knows about it — second lookup short-circuits.
+    assert reg.lookup("github.com/t/r")[0].resolve() == repo.resolve()
+
+
+def test_scan_returns_none_when_no_match(tmp_path: Path):
+    _make_repo(tmp_path / "a", origin_url="git@github.com:t/a.git")
+    assert scan_for_repo("github.com/other/repo", roots=[tmp_path]) is None
+
+
+def test_scan_skips_ignored_dirs(tmp_path: Path):
+    """A repo nested under `node_modules` must NOT be reachable."""
+    inner = tmp_path / "outer" / "node_modules" / "buried"
+    _make_repo(inner, origin_url="git@github.com:t/buried.git")
+    hit = scan_for_repo("github.com/t/buried", roots=[tmp_path])
+    assert hit is None
+
+
+def test_scan_respects_depth_limit(tmp_path: Path):
+    """`max_depth=1` should not reach a repo that lives 3 dirs deep."""
+    deep = tmp_path / "a" / "b" / "c" / "deep"
+    _make_repo(deep, origin_url="git@github.com:t/deep.git")
+    assert scan_for_repo("github.com/t/deep", roots=[tmp_path], max_depth=1) is None
+    # But with default depth (4), it's reachable.
+    assert scan_for_repo("github.com/t/deep", roots=[tmp_path]) is not None
+
+
+def test_walk_yields_only_repo_roots(tmp_path: Path):
+    """Internal helper: must yield each repo dir once and stop at it
+    (don't keep descending into a repo's subdirs)."""
+    repo = _make_repo(tmp_path / "r", origin_url="git@github.com:t/r.git")
+    (repo / "src").mkdir()
+    (repo / "src" / "nested").mkdir()
+    yielded = list(_walk_for_repos(tmp_path, max_depth=4))
+    assert repo.resolve() in [p.resolve() for p in yielded]
+    # Nested non-repo dirs must NOT be yielded.
+    nested = repo / "src"
+    assert nested.resolve() not in [p.resolve() for p in yielded]
+
+
+# ------------------------------------------------------------------ #
+# default_scan_roots                                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_default_scan_roots_includes_known_parents(tmp_path: Path, monkeypatch):
+    """Auto-discovers parents of registered checkouts so users with
+    non-standard layouts still get covered."""
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    repo = tmp_path / "weird-place" / "myrepo"
+    repo.mkdir(parents=True)
+    reg.upsert("k", str(repo))
+    # Pretend $HOME is empty so only registry-derived roots show up.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "fakehome"))
+    (tmp_path / "fakehome").mkdir()
+    roots = default_scan_roots(reg)
+    assert any(r.resolve() == repo.parent.resolve() for r in roots)
+
+
+# ------------------------------------------------------------------ #
+# resolve_repo_cwd                                                      #
+# ------------------------------------------------------------------ #
+
+
+def test_resolve_uses_registry_when_present(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    reg.upsert("github.com/t/myrepo", str(repo))
+    out = resolve_repo_cwd(
+        repo_url="github.com/t/myrepo",
+        repo_subpath="",
+        origin_cwd="/fake/path",
+        registry=reg,
+        allow_scan=False,
+    )
+    assert out == str(repo)
+
+
+def test_resolve_appends_subpath(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    repo = tmp_path / "myrepo"
+    (repo / "src" / "deep").mkdir(parents=True)
+    reg.upsert("k", str(repo))
+    out = resolve_repo_cwd(
+        repo_url="k",
+        repo_subpath="src/deep",
+        origin_cwd=None,
+        registry=reg,
+        allow_scan=False,
+    )
+    assert out == str(repo / "src" / "deep")
+
+
+def test_resolve_falls_back_to_repo_root_when_subpath_missing(tmp_path: Path):
+    """Subpath might not exist on a different machine (renamed dir,
+    moved subdir). Landing at the repo root is still useful."""
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    reg.upsert("k", str(repo))
+    out = resolve_repo_cwd(
+        repo_url="k",
+        repo_subpath="renamed/dir",
+        origin_cwd=None,
+        registry=reg,
+        allow_scan=False,
+    )
+    assert out == str(repo)
+
+
+def test_resolve_falls_back_to_origin_cwd(tmp_path: Path):
+    """No repo_url, but origin_cwd exists locally — that's the
+    same-machine resume case (legacy or non-git sessions)."""
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    real = tmp_path / "place"
+    real.mkdir()
+    out = resolve_repo_cwd(
+        repo_url=None,
+        repo_subpath=None,
+        origin_cwd=str(real),
+        registry=reg,
+        allow_scan=False,
+    )
+    assert out == str(real)
+
+
+def test_resolve_returns_none_when_nothing_matches(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    out = resolve_repo_cwd(
+        repo_url="github.com/unknown/repo",
+        repo_subpath="",
+        origin_cwd="/does/not/exist",
+        registry=reg,
+        allow_scan=False,
+    )
+    assert out is None
+
+
+def test_resolve_prefers_origin_match_over_freshest(tmp_path: Path):
+    """Two checkouts of the same repo. The picker shows a session
+    whose origin_cwd is checkout A, but checkout B is freshest in
+    the registry. The resumer should pick A — the user opened the
+    session in A, so resuming there preserves continuity."""
+    paths = TrackPaths.under(tmp_path / "f")
+    paths.ensure_track_dir()
+    reg = RepoRegistry(paths=paths)
+    a = tmp_path / "ck-a"
+    b = tmp_path / "ck-b"
+    a.mkdir()
+    b.mkdir()
+    reg.upsert("k", str(a))
+    reg.upsert("k", str(b))  # b is freshest
+    out = resolve_repo_cwd(
+        repo_url="k",
+        repo_subpath="",
+        origin_cwd=str(a),
+        registry=reg,
+        allow_scan=False,
+    )
+    assert out == str(a)

--- a/tests/track/test_resumer.py
+++ b/tests/track/test_resumer.py
@@ -1,0 +1,300 @@
+"""Resumer tests — checkout creation + GC.
+
+Doesn't exec the actual claude/codex binaries; we test the
+file-shape side-effects (which path the checkout lands at, what's
+in the file, fork-lineage header) and call the GC logic directly.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from fleet.track.paths import TrackPaths
+from fleet.track.resumer import (
+    SUPPORTED_TOOLS,
+    _checkout_path,
+    _create_checkout,
+    gc_checkouts,
+)
+from fleet.track.store import LocalSessionStore, Session
+from fleet.track.unified import AssistantMessage, UserMessage
+
+
+def _store(tmp_path: Path) -> LocalSessionStore:
+    return LocalSessionStore(TrackPaths.under(tmp_path))
+
+
+def _seed(store: LocalSessionStore, *, tool: str, id: str, n_events: int = 3,
+          forked_from=None, fork_point=None, cwd="/private/tmp/r") -> Session:
+    events = [UserMessage(source=tool, text=f"u{i}") for i in range(n_events)]
+    s = Session(
+        id=id, tool=tool, cwd=cwd,
+        started_at="2026-04-30T00:00:00Z",
+        last_active="2026-04-30T01:00:00Z",
+        forked_from=forked_from,
+        fork_point=fork_point,
+    )
+    return store.create(s, events)
+
+
+# ------------------------------------------------------------------ #
+# Checkout path layout                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_checkout_path_for_claude(tmp_path: Path):
+    """Flat layout: claude requires checkouts directly under <encoded-cwd>/
+    (its scanner doesn't recurse into subdirs)."""
+    p = _checkout_path("claude", "/private/tmp/work", "abc-123", tmp_path)
+    assert p == tmp_path / ".claude" / "projects" / "-private-tmp-work" / "abc-123.jsonl"
+
+
+def test_checkout_path_for_codex(tmp_path: Path):
+    """Codex's scanner is recursive; checkouts can sit alongside native rollouts."""
+    p = _checkout_path("codex", "/private/tmp/work", "abc-123", tmp_path)
+    parts = p.relative_to(tmp_path / ".codex" / "sessions").parts
+    # YYYY/MM/DD/rollout-<ts>-abc-123.jsonl
+    assert len(parts) == 4
+    assert parts[3].startswith("rollout-")
+    assert parts[3].endswith("-abc-123.jsonl")
+
+
+def test_checkout_path_unknown_tool_raises(tmp_path: Path):
+    with pytest.raises(ValueError, match="Unknown target tool"):
+        _checkout_path("opencode", "/x", "id", tmp_path)
+
+
+# ------------------------------------------------------------------ #
+# Checkout creation — claude target                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_create_checkout_claude_writes_correct_path(tmp_path: Path):
+    store = _store(tmp_path)
+    s = _seed(store, tool="codex", id="src-1", cwd="/private/tmp/work")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=store, session=s, target_tool="claude", paths=paths)
+
+    assert info.target_tool == "claude"
+    assert info.forked_from == "src-1"
+    assert info.fork_point == 3
+    assert info.path.exists()
+    # Flat layout: directly in <encoded-cwd>/, not in a subdir.
+    assert info.path.parent.name == "-private-tmp-work"
+    assert info.path.parent.parent.name == "projects"
+
+
+def test_create_checkout_claude_embeds_fleet_meta_header(tmp_path: Path):
+    """First row of claude checkout should carry _fleet_meta so daemon
+    knows it's a fork."""
+    store = _store(tmp_path)
+    s = _seed(store, tool="codex", id="src-meta", cwd="/private/tmp/work")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=store, session=s, target_tool="claude", paths=paths)
+    first_line = info.path.read_text().splitlines()[0]
+    first = json.loads(first_line)
+
+    assert "_fleet_meta" in first
+    assert first["_fleet_meta"]["forked_from"] == "src-meta"
+    assert first["_fleet_meta"]["target_tool"] == "claude"
+    assert first["_fleet_meta"]["fork_point"] == 3
+
+
+def test_create_checkout_claude_rows_carry_ephemeral_session_id(tmp_path: Path):
+    """Every user/assistant row in the checkout must have sessionId
+    matching the ephemeral id (so claude --resume <eph-id> finds them)."""
+    store = _store(tmp_path)
+    s = _seed(store, tool="codex", id="src-rows")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=store, session=s, target_tool="claude", paths=paths)
+    rows = [json.loads(l) for l in info.path.read_text().splitlines() if l.strip()]
+    # Skip the header row (has _fleet_meta)
+    body_rows = [r for r in rows if "_fleet_meta" not in r]
+    msg_rows = [r for r in body_rows if r.get("type") in ("user", "assistant")]
+    assert msg_rows, "expected at least one converted message row"
+    for r in msg_rows:
+        assert r.get("sessionId") == info.ephemeral_id
+
+
+# ------------------------------------------------------------------ #
+# Checkout creation — codex target                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_create_checkout_codex_first_row_is_session_meta_with_meta(tmp_path: Path):
+    """codex requires session_meta as the first row; we inject the
+    fork meta INTO its payload (since we can't put a row above it)."""
+    store = _store(tmp_path)
+    s = _seed(store, tool="claude", id="src-cdx", cwd="/private/tmp/work")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=store, session=s, target_tool="codex", paths=paths)
+    first = json.loads(info.path.read_text().splitlines()[0])
+
+    assert first["type"] == "session_meta"
+    assert "_fleet_meta" in first["payload"]
+    assert first["payload"]["_fleet_meta"]["forked_from"] == "src-cdx"
+    assert first["payload"]["_fleet_meta"]["target_tool"] == "codex"
+
+
+def test_create_checkout_codex_payload_has_required_fields(tmp_path: Path):
+    """codex's deserializer rejects session_meta missing
+    base_instructions={text:...} et al. Verify the required set."""
+    store = _store(tmp_path)
+    s = _seed(store, tool="claude", id="src-req", cwd="/private/tmp/work")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=store, session=s, target_tool="codex", paths=paths)
+    first = json.loads(info.path.read_text().splitlines()[0])
+    payload = first["payload"]
+
+    required = {"id", "timestamp", "cwd", "originator", "cli_version",
+                "source", "model_provider", "base_instructions"}
+    assert set(payload.keys()) >= required
+    assert isinstance(payload["base_instructions"], dict)
+
+
+# ------------------------------------------------------------------ #
+# Branch / fork chain                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_checkout_includes_full_ancestor_chain(tmp_path: Path):
+    """A checkout off a forked session should include events from the
+    grandparent + parent + this session."""
+    store = _store(tmp_path)
+    _seed(store, tool="codex", id="A", n_events=5)
+    _seed(store, tool="claude", id="B", n_events=2, forked_from="A", fork_point=3)
+    paths = TrackPaths.under(tmp_path)
+
+    s = store.get("B")
+    assert s is not None
+    info = _create_checkout(store=store, session=s, target_tool="codex", paths=paths)
+
+    # Full chain: 3 from A + 2 from B = 5 input events.
+    # In codex output: 1 session_meta + 5 message rows = 6 rows total.
+    rows = [json.loads(l) for l in info.path.read_text().splitlines() if l.strip()]
+    msg_rows = [r for r in rows if r.get("type") == "response_item"
+                and r.get("payload", {}).get("type") == "message"]
+    assert len(msg_rows) == 5
+    # Texts come from A then B in chain order.
+    texts = [r["payload"]["content"][0]["text"] for r in msg_rows]
+    assert texts == ["u0", "u1", "u2", "u0", "u1"]
+
+
+# ------------------------------------------------------------------ #
+# CWD resolution                                                       #
+# ------------------------------------------------------------------ #
+
+
+def test_checkout_resolves_symlinked_cwd(tmp_path: Path):
+    """If the session's cwd is `/tmp/x` on macOS, the checkout's path
+    should reflect `/private/tmp/x` so claude finds it."""
+    if not Path("/tmp").is_symlink():
+        return  # Linux: nothing to verify
+    store = _store(tmp_path)
+    s = _seed(store, tool="codex", id="r1", cwd="/tmp/should-resolve")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=store, session=s, target_tool="claude", paths=paths)
+    assert "private" in str(info.path)
+
+
+# ------------------------------------------------------------------ #
+# GC                                                                   #
+# ------------------------------------------------------------------ #
+
+
+def _fleet_meta_row() -> str:
+    return json.dumps({
+        "_fleet_meta": {"forked_from": "x", "fork_point": 0,
+                        "ephemeral_id": "e", "target_tool": "claude"},
+        "type": "system",
+        "content": "fleet-track checkout",
+    })
+
+
+def _native_row() -> str:
+    return json.dumps({"type": "user", "uuid": "u1",
+                       "message": {"role": "user", "content": "hi"}})
+
+
+def test_gc_removes_old_marked_checkouts(tmp_path: Path):
+    """Files with `_fleet_meta` older than the cutoff get removed."""
+    cdir = tmp_path / ".claude" / "projects" / "-x"
+    cdir.mkdir(parents=True)
+    old = cdir / "old.jsonl"
+    new = cdir / "new.jsonl"
+    old.write_text(_fleet_meta_row() + "\n")
+    new.write_text(_fleet_meta_row() + "\n")
+    # Backdate `old`'s mtime by 30 hours.
+    import os
+    old_mtime = time.time() - 30 * 3600
+    os.utime(old, (old_mtime, old_mtime))
+
+    n = gc_checkouts(home=tmp_path, max_age_hours=24)
+    assert n == 1
+    assert not old.exists()
+    assert new.exists()
+
+
+def test_gc_no_op_when_no_checkouts(tmp_path: Path):
+    assert gc_checkouts(home=tmp_path, max_age_hours=24) == 0
+
+
+def test_gc_does_not_touch_native_sessions(tmp_path: Path):
+    """A file without `_fleet_meta` is a native session and never deleted,
+    even when older than the cutoff."""
+    cdir = tmp_path / ".claude" / "projects" / "-x"
+    cdir.mkdir(parents=True)
+    native = cdir / "native.jsonl"
+    native.write_text(_native_row() + "\n")
+    import os
+    old = time.time() - 100 * 3600  # 100 hours old
+    os.utime(native, (old, old))
+
+    n = gc_checkouts(home=tmp_path, max_age_hours=24)
+    assert n == 0
+    assert native.exists()  # untouched
+
+
+def test_gc_recognizes_codex_session_meta_inner_marker(tmp_path: Path):
+    """codex checkouts embed `_fleet_meta` inside session_meta.payload
+    (since session_meta MUST be the first row); GC must find it there too."""
+    cdir = tmp_path / ".codex" / "sessions" / "2026" / "05" / "01"
+    cdir.mkdir(parents=True)
+    f = cdir / "rollout-old-abc.jsonl"
+    f.write_text(json.dumps({
+        "timestamp": "x",
+        "type": "session_meta",
+        "payload": {
+            "id": "abc",
+            "_fleet_meta": {"forked_from": "src", "fork_point": 0,
+                            "ephemeral_id": "abc", "target_tool": "codex"},
+        },
+    }) + "\n")
+    import os
+    old = time.time() - 30 * 3600
+    os.utime(f, (old, old))
+
+    n = gc_checkouts(home=tmp_path, max_age_hours=24)
+    assert n == 1
+    assert not f.exists()
+
+
+# ------------------------------------------------------------------ #
+# Tool registry                                                        #
+# ------------------------------------------------------------------ #
+
+
+def test_supported_tools_set():
+    assert "claude" in SUPPORTED_TOOLS
+    assert "codex" in SUPPORTED_TOOLS
+

--- a/tests/track/test_scrubber.py
+++ b/tests/track/test_scrubber.py
@@ -1,0 +1,166 @@
+"""Unit tests for scrubber.py — assert specific named rules fire on specific inputs."""
+
+from __future__ import annotations
+
+import re
+
+from fleet.track.scrubber import (
+    DEFAULT_RULES,
+    Hit,
+    Rule,
+    scrub,
+    scrub_bytes,
+)
+
+
+def _fired(text: str) -> set[str]:
+    return scrub(text).fired_rules
+
+
+# ------------------------------------------------------------------ #
+# Per-rule assertions                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_aws_access_key_id():
+    assert "aws_access_key_id" in _fired("My key is AKIAIOSFODNN7EXAMPLE today")
+
+
+def test_aws_secret_access_key():
+    text = 'aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+    assert "aws_secret_access_key" in _fired(text)
+
+
+def test_anthropic_api_key():
+    assert "anthropic_api_key" in _fired("sk-ant-api03-aBcDeFgHiJkLmNoPqRsTuVwXyZ-12345")
+
+
+def test_openai_api_key():
+    assert "openai_api_key" in _fired("sk-abcdef0123456789ABCDEF0123456789")
+
+
+def test_github_token():
+    assert "github_token" in _fired("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")
+
+
+def test_slack_token():
+    assert "slack_token" in _fired("xoxb-1234567890-abcdefghijk")
+
+
+def test_jwt():
+    text = "Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    assert "jwt" in _fired(text)
+
+
+def test_private_key_block():
+    text = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----"
+    assert "private_key_block" in _fired(text)
+
+
+def test_connection_string():
+    assert "connection_string" in _fired("postgres://user:pass@host:5432/db")
+
+
+def test_home_path_macos_redacted():
+    result = scrub("the path is /Users/alice/Documents/foo")
+    assert "home_path_macos" in result.fired_rules
+    assert "alice" not in result.text
+    assert "/Users/[user]" in result.text
+
+
+def test_home_path_linux_redacted():
+    result = scrub("logs at /home/bob/app.log")
+    assert "home_path_linux" in result.fired_rules
+    assert "/home/[user]/app.log" in result.text
+
+
+# ------------------------------------------------------------------ #
+# Hit metadata                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_hits_carry_line_numbers():
+    text = "line 1\nline 2 has AKIAIOSFODNN7EXAMPLE\nline 3"
+    result = scrub(text)
+    assert any(h.rule == "aws_access_key_id" and h.line == 2 for h in result.hits)
+
+
+def test_hits_record_original_match_text():
+    result = scrub("AKIAIOSFODNN7EXAMPLE")
+    aws_hits = [h for h in result.hits if h.rule == "aws_access_key_id"]
+    assert aws_hits == [Hit(rule="aws_access_key_id", line=1, matched="AKIAIOSFODNN7EXAMPLE")]
+
+
+def test_no_hits_means_text_unchanged():
+    text = '{"hello": "world"}\n'
+    result = scrub(text)
+    assert result.hits == ()
+    assert result.text == text
+
+
+# ------------------------------------------------------------------ #
+# Subsitution behavior                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_aws_key_is_replaced():
+    result = scrub("AKIAIOSFODNN7EXAMPLE")
+    assert "AKIA" not in result.text
+    assert "[REDACTED_AWS_KEY]" in result.text
+
+
+def test_jsonl_structure_preserved():
+    """Scrubbing must not break JSON parsing of a JSONL line."""
+    import json
+
+    text = '{"key": "AKIAIOSFODNN7EXAMPLE", "other": 42}\n'
+    result = scrub(text)
+    parsed = json.loads(result.text.strip())
+    assert parsed["other"] == 42
+    assert "[REDACTED" in parsed["key"]
+
+
+def test_env_assignment_callable_replacement():
+    """The env_assignment_long_value rule uses a callable replacement that
+    preserves the variable name. Use a name that no other rule matches so the
+    substitution actually comes from this rule."""
+    text = "MY_LONG_THING=abcdefghij1234567890longvalue"
+    result = scrub(text)
+    assert "env_assignment_long_value" in result.fired_rules
+    assert "MY_LONG_THING=[REDACTED]" in result.text
+
+
+# ------------------------------------------------------------------ #
+# Custom rules                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_custom_rules_replace_default_set():
+    only_aws = (Rule("aws_access_key_id", re.compile(r"AKIA[0-9A-Z]{16}"), "[X]"),)
+    result = scrub("AKIAIOSFODNN7EXAMPLE and sk-abcdef0123456789ABCDEF0123456789", rules=only_aws)
+    assert "[X]" in result.text
+    # OpenAI rule isn't in the custom rule set, so the openai key remains.
+    assert "sk-abcdef" in result.text
+
+
+def test_default_rules_are_a_tuple():
+    """Frozen so the production set can't be mutated by an importer."""
+    assert isinstance(DEFAULT_RULES, tuple)
+
+
+# ------------------------------------------------------------------ #
+# scrub_bytes backward-compat                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_scrub_bytes_returns_bytes():
+    out = scrub_bytes(b'{"key": "AKIAIOSFODNN7EXAMPLE"}\n')
+    assert isinstance(out, bytes)
+    assert b"AKIA" not in out
+
+
+def test_scrub_bytes_handles_invalid_utf8():
+    # Decoded with errors="replace", scrubbed, re-encoded. Should not raise.
+    bad = b"\xff\xfe AKIAIOSFODNN7EXAMPLE \x80"
+    out = scrub_bytes(bad)
+    assert b"AKIA" not in out

--- a/tests/track/test_sources.py
+++ b/tests/track/test_sources.py
@@ -1,0 +1,208 @@
+"""Unit tests for the sources package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fleet.track.sources import (
+    DEFAULT_EXCLUDE_PATTERNS,
+    ClaudeSource,
+    CodexSource,
+    CursorSource,
+    Source,
+    SourceSummary,
+    default_sources,
+    relative_to_home,
+)
+
+
+# ------------------------------------------------------------------ #
+# Fixture helpers                                                      #
+# ------------------------------------------------------------------ #
+
+
+def _seed_claude(home: Path) -> None:
+    base = home / ".claude" / "projects" / "-some-cwd"
+    base.mkdir(parents=True)
+    (base / "abc.jsonl").write_text('{"role": "user"}\n')
+    (base / "session-env").write_text("FOO=bar")  # excluded
+
+
+def _seed_cursor(home: Path) -> None:
+    base = home / ".cursor" / "projects" / "p1" / "agent-transcripts" / "t1"
+    base.mkdir(parents=True)
+    (base / "session.jsonl").write_text('{"x": 1}\n')
+    (base / "session.txt").write_text("flat text")
+
+
+def _seed_codex(home: Path) -> None:
+    sessions = home / ".codex" / "sessions" / "2026" / "04" / "30"
+    archived = home / ".codex" / "archived_sessions"
+    sessions.mkdir(parents=True)
+    archived.mkdir(parents=True)
+    (sessions / "rollout-x.jsonl").write_text('{"type": "session_meta"}\n')
+    (archived / "rollout-old.jsonl").write_text('{"type": "session_meta"}\n')
+
+
+# ------------------------------------------------------------------ #
+# relative_to_home                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_relative_to_home_with_explicit_home(tmp_path: Path):
+    p = tmp_path / "a" / "b.txt"
+    assert relative_to_home(p, tmp_path) == "a/b.txt"
+
+
+def test_relative_to_home_raises_for_path_outside_home(tmp_path: Path):
+    with pytest.raises(ValueError):
+        relative_to_home(Path("/elsewhere/x.txt"), tmp_path)
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSource                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_claude_is_present_after_seed(tmp_path: Path):
+    s = ClaudeSource(home=tmp_path)
+    assert s.is_present() is False
+
+    _seed_claude(tmp_path)
+    assert s.is_present() is True
+
+
+def test_claude_iter_files_finds_jsonl_skips_excluded(tmp_path: Path):
+    _seed_claude(tmp_path)
+    s = ClaudeSource(home=tmp_path)
+    files = list(s.iter_files())
+    assert len(files) == 1
+    assert files[0].name == "abc.jsonl"
+
+
+def test_claude_read_for_upload_trims_partial_jsonl_line(tmp_path: Path):
+    _seed_claude(tmp_path)
+    s = ClaudeSource(home=tmp_path)
+    f = next(s.iter_files())
+    f.write_text('{"a": 1}\n{"partial":')  # mid-write
+    assert s.read_for_upload(f) == b'{"a": 1}\n'
+
+
+# ------------------------------------------------------------------ #
+# CursorSource                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_cursor_finds_both_jsonl_and_txt(tmp_path: Path):
+    _seed_cursor(tmp_path)
+    s = CursorSource(home=tmp_path)
+    files = sorted(f.name for f in s.iter_files())
+    assert files == ["session.jsonl", "session.txt"]
+
+
+def test_cursor_read_for_upload_only_trims_jsonl(tmp_path: Path):
+    _seed_cursor(tmp_path)
+    s = CursorSource(home=tmp_path)
+    files = {f.name: f for f in s.iter_files()}
+
+    files["session.txt"].write_text("flat text without newline")
+    assert s.read_for_upload(files["session.txt"]) == b"flat text without newline"
+
+    files["session.jsonl"].write_text('{"a":1}\n{"partial":')
+    assert s.read_for_upload(files["session.jsonl"]) == b'{"a":1}\n'
+
+
+# ------------------------------------------------------------------ #
+# CodexSource                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_codex_iter_yields_sessions_and_archived(tmp_path: Path):
+    _seed_codex(tmp_path)
+    s = CodexSource(home=tmp_path)
+    files = list(s.iter_files())
+    assert len(files) == 2
+    paths = {str(f.relative_to(tmp_path)) for f in files}
+    assert any("sessions/2026/04/30/rollout-x.jsonl" in p for p in paths)
+    assert any("archived_sessions/rollout-old.jsonl" in p for p in paths)
+
+
+def test_codex_is_present_when_only_sessions_exists(tmp_path: Path):
+    (tmp_path / ".codex" / "sessions").mkdir(parents=True)
+    assert CodexSource(home=tmp_path).is_present() is True
+
+
+def test_codex_is_present_when_only_archived_exists(tmp_path: Path):
+    (tmp_path / ".codex" / "archived_sessions").mkdir(parents=True)
+    assert CodexSource(home=tmp_path).is_present() is True
+
+
+def test_codex_is_absent_when_neither_exists(tmp_path: Path):
+    (tmp_path / ".codex").mkdir(parents=True)  # only the parent
+    assert CodexSource(home=tmp_path).is_present() is False
+
+
+# ------------------------------------------------------------------ #
+# Source.summary                                                       #
+# ------------------------------------------------------------------ #
+
+
+def test_summary_when_absent(tmp_path: Path):
+    s = ClaudeSource(home=tmp_path)
+    assert s.summary() == SourceSummary(name="claude", found=False)
+
+
+def test_summary_when_present_counts_files_and_bytes(tmp_path: Path):
+    _seed_claude(tmp_path)
+    s = ClaudeSource(home=tmp_path)
+    summary = s.summary()
+    assert summary.found is True
+    assert summary.files == 1
+    assert summary.bytes > 0
+    assert summary.newest_mtime is not None
+
+
+# ------------------------------------------------------------------ #
+# parse / serialize stubs                                              #
+# ------------------------------------------------------------------ #
+
+
+def test_serialize_returns_bytes(tmp_path: Path):
+    """`serialize` is implemented for claude/codex; cursor still raises
+    NotImplementedError until we have sample data."""
+    s = ClaudeSource(home=tmp_path)
+    out = s.serialize([])
+    assert out == b""
+
+    cursor = CursorSource(home=tmp_path)
+    with pytest.raises(NotImplementedError):
+        cursor.serialize([])
+
+
+# ------------------------------------------------------------------ #
+# default_sources                                                      #
+# ------------------------------------------------------------------ #
+
+
+def test_default_sources_returns_all_three(tmp_path: Path):
+    sources = default_sources(home=tmp_path)
+    names = [s.name for s in sources]
+    assert names == ["claude", "cursor", "codex"]
+
+
+def test_default_sources_use_provided_home(tmp_path: Path):
+    sources = default_sources(home=tmp_path)
+    assert all(str(s.root).startswith(str(tmp_path)) for s in sources)
+
+
+def test_exclude_patterns_is_immutable():
+    assert isinstance(DEFAULT_EXCLUDE_PATTERNS, frozenset)
+    assert "session-env" in DEFAULT_EXCLUDE_PATTERNS
+
+
+def test_source_is_abstract():
+    """Source ABC cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        Source()  # type: ignore[abstract]

--- a/tests/track/test_status.py
+++ b/tests/track/test_status.py
@@ -1,0 +1,104 @@
+"""Unit tests for status.py."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from fleet.track.paths import TrackPaths
+from fleet.track.status import (
+    STATUS_SCHEMA_VERSION,
+    TrackStatus,
+    clear_pid,
+    is_running,
+    read_status,
+    write_pid,
+    write_status,
+)
+
+
+def _paths(tmp_path: Path) -> TrackPaths:
+    return TrackPaths.under(tmp_path)
+
+
+def test_write_and_clear_pid(tmp_path: Path):
+    paths = _paths(tmp_path)
+    write_pid(paths)
+    assert paths.pid_file.read_text() == str(os.getpid())
+    clear_pid(paths)
+    assert not paths.pid_file.exists()
+
+
+def test_clear_pid_no_file_is_noop(tmp_path: Path):
+    paths = _paths(tmp_path)
+    paths.ensure_track_dir()
+    clear_pid(paths)  # must not raise
+
+
+def test_is_running_no_pid_file(tmp_path: Path):
+    assert is_running(_paths(tmp_path)) is False
+
+
+def test_is_running_with_dead_pid(tmp_path: Path):
+    paths = _paths(tmp_path)
+    paths.ensure_track_dir()
+    paths.pid_file.write_text("99999999")  # almost certainly dead
+    assert is_running(paths) is False
+
+
+def test_is_running_with_garbage_pid(tmp_path: Path):
+    paths = _paths(tmp_path)
+    paths.ensure_track_dir()
+    paths.pid_file.write_text("not-a-number")
+    assert is_running(paths) is False
+
+
+def test_is_running_with_self(tmp_path: Path):
+    paths = _paths(tmp_path)
+    write_pid(paths)
+    assert is_running(paths) is True
+
+
+def test_write_and_read_status(tmp_path: Path):
+    paths = _paths(tmp_path)
+    s = TrackStatus(pid=1234, state="syncing", queue_depth=5, files_total=10)
+    write_status(paths, s)
+    loaded = read_status(paths)
+    assert loaded is not None
+    assert loaded.pid == 1234
+    assert loaded.state == "syncing"
+    assert loaded.queue_depth == 5
+    assert loaded.files_total == 10
+    assert loaded.updated_at != ""  # set by write_status
+    assert loaded.schema_version == STATUS_SCHEMA_VERSION
+
+
+def test_read_status_missing_file(tmp_path: Path):
+    assert read_status(_paths(tmp_path)) is None
+
+
+def test_read_status_corrupt_file(tmp_path: Path):
+    paths = _paths(tmp_path)
+    paths.ensure_track_dir()
+    paths.status_file.write_text("not json{{")
+    assert read_status(paths) is None
+
+
+def test_read_status_ignores_unknown_fields(tmp_path: Path):
+    """A newer daemon adding a field shouldn't crash an older CLI."""
+    paths = _paths(tmp_path)
+    paths.ensure_track_dir()
+    paths.status_file.write_text(
+        json.dumps({"pid": 1, "state": "idle", "future_field": "surprise"})
+    )
+    s = read_status(paths)
+    assert s is not None
+    assert s.pid == 1
+
+
+def test_write_status_atomic_no_temp_files_left(tmp_path: Path):
+    paths = _paths(tmp_path)
+    write_status(paths, TrackStatus())
+    leftovers = list(paths.track_dir.glob(".status-*"))
+    assert leftovers == []

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import httpx
 import pytest
 
 from fleet.track.paths import TrackPaths
@@ -816,3 +817,92 @@ def test_chained_local_only_uses_eager_merge(tmp_path: Path):
     page, _ = chained.page(limit=10)
     # Both rows present; ordering by last_active DESC.
     assert {s.id for s in page} == {"a", "b"}
+
+
+# ------------------------------------------------------------------ #
+# RemoteSessionStore                                                   #
+# ------------------------------------------------------------------ #
+
+
+def _remote_api(handler):
+    from fleet.track.api import TrackAPIClient
+
+    return TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler),
+            base_url="http://test",
+        ),
+        auth_provider=lambda: ("jwt", "team"),
+    )
+
+
+def test_remote_store_pages_with_query_and_origin_device():
+    from fleet.track.store import RemoteSessionStore
+
+    captured: dict = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(req.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": "s1",
+                        "tool": "claude",
+                        "cwd": "/repo",
+                        "last_active": "2026-05-05T00:00:00Z",
+                        "event_count": 7,
+                        "device_id": "laptop-abc12345",
+                        "metadata": {"title": "FleetTrack"},
+                    }
+                ],
+                "next_cursor": "next",
+            },
+        )
+
+    store = RemoteSessionStore(api=_remote_api(handler))
+    items, cursor = store.page(query="fleet", limit=10)
+
+    assert captured["params"]["query"] == "fleet"
+    assert captured["params"]["limit"] == "10"
+    assert cursor == "next"
+    assert items[0].origin_device == "laptop-abc12345"
+    assert items[0].metadata["title"] == "FleetTrack"
+
+
+def test_remote_store_fetches_content_and_parses_events():
+    from fleet.track.store import RemoteSessionStore
+
+    sid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    native = (
+        '{"type":"session_meta","timestamp":"2026-05-05T00:00:00Z",'
+        '"payload":{"cwd":"/repo","cli_version":"1.0"}}\n'
+        '{"type":"response_item","timestamp":"2026-05-05T00:00:01Z",'
+        '"payload":{"type":"message","role":"user",'
+        '"content":[{"type":"input_text","text":"hello"}]}}\n'
+    ).encode()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == f"/v1/track/sessions/{sid}":
+            return httpx.Response(
+                200,
+                json={
+                    "id": sid,
+                    "tool": "codex",
+                    "cwd": "/repo",
+                    "last_active": "2026-05-05T00:00:01Z",
+                    "event_count": 2,
+                },
+            )
+        if req.url.path == f"/v1/track/sessions/{sid}/content":
+            return httpx.Response(200, json={"url": "https://s3.test/session"})
+        if str(req.url) == "https://s3.test/session":
+            return httpx.Response(200, content=native)
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    store = RemoteSessionStore(api=_remote_api(handler))
+    events = list(store.events(sid))
+
+    assert [e.type for e in events] == ["session_start", "user_message"]
+    assert events[1].text == "hello"

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -523,6 +523,68 @@ def test_list_uses_default_page_limit(tmp_path: Path):
     assert len(out) == DEFAULT_PAGE_LIMIT
 
 
+def test_page_query_filter_substring_match(tmp_path: Path):
+    """`query` is case-insensitive substring across id/tool/cwd/title."""
+    store = _store(tmp_path)
+    store.create(
+        _session(id="abc-fleet", cwd="/tmp/fleet-sdk",
+                 metadata={"title": "fleet-track sidecar"}),
+        [_msg("x")],
+    )
+    store.create(
+        _session(id="def-other", cwd="/tmp/theseus",
+                 metadata={"title": "session metadata index"}),
+        [_msg("x")],
+    )
+
+    items, _ = store.page(query="fleet", limit=10)
+    assert {s.id for s in items} == {"abc-fleet"}
+
+    items, _ = store.page(query="THESEUS", limit=10)  # case-insensitive
+    assert {s.id for s in items} == {"def-other"}
+
+    items, _ = store.page(query="metadata", limit=10)  # title field
+    assert {s.id for s in items} == {"def-other"}
+
+
+def test_page_query_empty_string_is_no_filter(tmp_path: Path):
+    """Empty query (what fzf passes when the user has typed nothing)
+    matches everything, like a missing query."""
+    store = _store(tmp_path)
+    store.create(_session(id="a"), [_msg("x")])
+    store.create(_session(id="b"), [_msg("x")])
+
+    items_none, _ = store.page(query=None, limit=10)
+    items_empty, _ = store.page(query="", limit=10)
+    assert {s.id for s in items_none} == {s.id for s in items_empty} == {"a", "b"}
+
+
+def test_page_query_paginates_within_filtered_set(tmp_path: Path):
+    """A cursor minted with a query must keep walking the same filtered
+    set, not leak unfiltered rows on subsequent pages."""
+    store = _store(tmp_path)
+    for i in range(4):
+        store.create(
+            _session(id=f"keep-{i}", tool="claude",
+                     last_active=f"2026-04-3{i}T00:00:00Z",
+                     metadata={"title": "keep-me"}),
+            [_msg("x")],
+        )
+    for i in range(3):
+        store.create(
+            _session(id=f"drop-{i}", tool="claude",
+                     last_active=f"2026-04-3{i}T00:00:00Z",
+                     metadata={"title": "drop-me"}),
+            [_msg("x")],
+        )
+
+    page1, cursor = store.page(query="keep-me", limit=2)
+    assert {s.id for s in page1} == {"keep-3", "keep-2"}
+    page2, cursor = store.page(query="keep-me", limit=2, cursor=cursor)
+    assert {s.id for s in page2} == {"keep-1", "keep-0"}
+    assert cursor is None
+
+
 def test_chained_page_raises(tmp_path: Path):
     """Cursor pagination across stores requires a k-way merge we
     haven't built; chained must raise loudly so callers fall back to

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -585,15 +585,69 @@ def test_page_query_paginates_within_filtered_set(tmp_path: Path):
     assert cursor is None
 
 
-def test_chained_page_raises(tmp_path: Path):
-    """Cursor pagination across stores requires a k-way merge we
-    haven't built; chained must raise loudly so callers fall back to
-    a single backend."""
+def test_chained_page_eager_merge_paginates(tmp_path: Path):
+    """ChainedSessionStore.page() eager-merges across backing stores
+    and paginates the merged view via cursor. Means the picker's
+    default `--source auto` honors page-size and paging just like a
+    single backend."""
     from fleet.track.store import ChainedSessionStore, NativeFilesSessionStore
 
-    paths = TrackPaths.under(tmp_path)
-    chained = ChainedSessionStore(
-        _store(tmp_path), NativeFilesSessionStore(home=tmp_path)
+    local = _store(tmp_path)
+    for i in range(3):
+        local.create(
+            _session(id=f"local-{i}", tool="claude",
+                     last_active=f"2026-04-3{i}T00:00:00Z"),
+            [_msg("x")],
+        )
+
+    chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
+
+    page1, cursor = chained.page(limit=2)
+    assert len(page1) == 2
+    assert cursor is not None
+    page2, cursor = chained.page(limit=2, cursor=cursor)
+    # 3 sessions total in chain; second page has the leftover one.
+    assert len(page2) == 1
+    assert cursor is None
+    seen = [s.id for s in page1] + [s.id for s in page2]
+    assert sorted(seen) == ["local-0", "local-1", "local-2"]
+
+
+def test_chained_page_dedupes_by_id(tmp_path: Path):
+    """When a session appears in multiple backing stores (e.g. native
+    and stub both have the same id), chained.page() emits it once."""
+    from fleet.track.store import ChainedSessionStore
+
+    local_a = _store(tmp_path)
+    local_b = LocalSessionStore(TrackPaths.under(tmp_path), name="other-store")
+    for store in (local_a, local_b):
+        store.create(
+            _session(id="shared", tool="claude",
+                     last_active="2026-04-30T00:00:00Z"),
+            [_msg("x")],
+        )
+
+    chained = ChainedSessionStore(local_a, local_b)
+    items, cursor = chained.page(limit=10)
+    assert [s.id for s in items] == ["shared"]
+    assert cursor is None
+
+
+def test_chained_page_query_filter(tmp_path: Path):
+    """Query filter applies before merging — and stays valid across
+    backing stores."""
+    from fleet.track.store import ChainedSessionStore, NativeFilesSessionStore
+
+    local = _store(tmp_path)
+    local.create(
+        _session(id="keep", metadata={"title": "match-me"}),
+        [_msg("x")],
     )
-    with pytest.raises(NotImplementedError, match="--source"):
-        chained.page(limit=10)
+    local.create(
+        _session(id="drop", metadata={"title": "ignore-me"}),
+        [_msg("x")],
+    )
+    chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
+
+    items, _ = chained.page(query="match-me", limit=10)
+    assert [s.id for s in items] == ["keep"]

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -1,0 +1,322 @@
+"""LocalSessionStore tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fleet.track.paths import TrackPaths
+from fleet.track.store import LocalSessionStore, Session
+from fleet.track.unified import (
+    AssistantMessage,
+    SessionStart,
+    ToolCall,
+    UserMessage,
+)
+
+
+def _store(tmp_path: Path) -> LocalSessionStore:
+    return LocalSessionStore(TrackPaths.under(tmp_path))
+
+
+def _session(**kw) -> Session:
+    return Session(
+        id=kw.pop("id", "test-1"),
+        tool=kw.pop("tool", "claude"),
+        cwd=kw.pop("cwd", "/tmp/x"),
+        started_at=kw.pop("started_at", "2026-04-30T00:00:00Z"),
+        last_active=kw.pop("last_active", "2026-04-30T00:00:01Z"),
+        **kw,
+    )
+
+
+def _msg(text: str, **kw) -> UserMessage:
+    return UserMessage(source="claude", text=text, **kw)
+
+
+# ------------------------------------------------------------------ #
+# create + get                                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_create_then_get(tmp_path: Path):
+    store = _store(tmp_path)
+    s = _session(id="s1")
+    store.create(s, [_msg("hi"), _msg("there")])
+
+    fetched = store.get("s1")
+    assert fetched is not None
+    assert fetched.id == "s1"
+    assert fetched.event_count == 2
+
+
+def test_get_missing_returns_none(tmp_path: Path):
+    store = _store(tmp_path)
+    assert store.get("nope") is None
+
+
+def test_get_by_unique_prefix(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="abc1234"), [_msg("a")])
+    store.create(_session(id="def5678"), [_msg("b")])
+    s = store.get("abc")
+    assert s is not None
+    assert s.id == "abc1234"
+
+
+def test_get_by_ambiguous_prefix_raises(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="abc111"), [_msg("a")])
+    store.create(_session(id="abc222"), [_msg("b")])
+    with pytest.raises(KeyError, match="Ambiguous"):
+        store.get("abc")
+
+
+def test_create_requires_id(tmp_path: Path):
+    store = _store(tmp_path)
+    with pytest.raises(ValueError, match="id"):
+        store.create(Session(id="", tool="claude"), [])
+
+
+# ------------------------------------------------------------------ #
+# events                                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_events_returns_what_was_stored(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="s1"), [
+        _msg("first"),
+        AssistantMessage(source="claude", text="answer"),
+    ])
+    events = list(store.events("s1"))
+    assert len(events) == 2
+    assert events[0].text == "first"
+    assert events[1].text == "answer"
+
+
+def test_events_for_missing_session_raises(tmp_path: Path):
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        list(store.events("nope"))
+
+
+def test_events_skips_corrupt_lines(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="s1"), [_msg("ok")])
+    # Append garbage to the events file.
+    f = TrackPaths.under(tmp_path).track_dir / "local-store" / "sessions" / "s1.jsonl"
+    with open(f, "a") as fp:
+        fp.write("not json{{\n")
+        fp.write('{"missing": "type"}\n')
+    # Should still yield the valid event without raising.
+    events = list(store.events("s1"))
+    assert len(events) == 1
+
+
+# ------------------------------------------------------------------ #
+# Branches / forks                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_fork_walks_ancestor_chain(tmp_path: Path):
+    store = _store(tmp_path)
+    # Root session: 5 user messages
+    store.create(
+        _session(id="root", tool="codex"),
+        [_msg(f"root-{i}") for i in range(5)],
+    )
+    # Fork at event 3, claude added 2 events
+    store.create(
+        _session(id="fork1", tool="claude", forked_from="root", fork_point=3),
+        [_msg("claude-a"), _msg("claude-b")],
+    )
+
+    events = list(store.events("fork1"))
+    # Expected: first 3 from root, then 2 from fork1 = 5 total.
+    assert len(events) == 5
+    assert [e.text for e in events] == [
+        "root-0", "root-1", "root-2", "claude-a", "claude-b",
+    ]
+
+
+def test_fork_chain_three_levels(tmp_path: Path):
+    """codex(0..10) → claude(0..3) → codex(0..2)."""
+    store = _store(tmp_path)
+    store.create(_session(id="A", tool="codex"),
+                 [_msg(f"A-{i}") for i in range(10)])
+    store.create(
+        _session(id="B", tool="claude", forked_from="A", fork_point=4),
+        [_msg(f"B-{i}") for i in range(3)],
+    )
+    store.create(
+        _session(id="C", tool="codex", forked_from="B", fork_point=2),
+        [_msg(f"C-{i}") for i in range(2)],
+    )
+
+    events = list(store.events("C"))
+    # A 0..4, B 0..2, C 0..2
+    expected = ["A-0", "A-1", "A-2", "A-3", "B-0", "B-1", "C-0", "C-1"]
+    assert [e.text for e in events] == expected
+
+
+def test_fork_chain_with_dangling_parent_does_not_crash(tmp_path: Path):
+    """If parent is deleted, chain walk gracefully truncates."""
+    store = _store(tmp_path)
+    store.create(_session(id="A"), [_msg("A1"), _msg("A2"), _msg("A3")])
+    store.create(
+        _session(id="B", forked_from="A", fork_point=2),
+        [_msg("B1")],
+    )
+    # Delete the parent.
+    store.delete("A")
+    # Chain walk on B finds only B's own events; doesn't raise.
+    events = list(store.events("B"))
+    assert [e.text for e in events] == ["B1"]
+
+
+def test_fork_cycle_truncates(tmp_path: Path):
+    """Defensive: a synthetic cycle in forked_from doesn't infinite-loop."""
+    store = _store(tmp_path)
+    store.create(_session(id="X", forked_from="Y", fork_point=1), [_msg("X1")])
+    store.create(_session(id="Y", forked_from="X", fork_point=1), [_msg("Y1")])
+    # Whichever direction we walk, it stops.
+    list(store.events("X"))  # must not hang
+    list(store.events("Y"))
+
+
+# ------------------------------------------------------------------ #
+# list                                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_list_returns_all(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="a"), [_msg("a")])
+    store.create(_session(id="b"), [_msg("b")])
+    ids = sorted(s.id for s in store.list())
+    assert ids == ["a", "b"]
+
+
+def test_list_filters_by_tool(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="c1", tool="claude"), [_msg("a")])
+    store.create(_session(id="c2", tool="codex"), [_msg("b")])
+    claude_only = list(store.list(tool="claude"))
+    assert len(claude_only) == 1
+    assert claude_only[0].id == "c1"
+
+
+def test_list_filters_by_cwd(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="a", cwd="/x"), [_msg("a")])
+    store.create(_session(id="b", cwd="/y"), [_msg("b")])
+    only_x = list(store.list(cwd="/x"))
+    assert {s.id for s in only_x} == {"a"}
+
+
+def test_list_filters_by_since(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="old", last_active="2025-01-01T00:00:00Z"), [_msg("a")])
+    store.create(_session(id="new", last_active="2026-04-30T00:00:00Z"), [_msg("b")])
+    recent = list(store.list(since="2026-01-01T00:00:00Z"))
+    assert {s.id for s in recent} == {"new"}
+
+
+def test_list_sorts_most_recent_first(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="old", last_active="2025-01-01T00:00:00Z"), [_msg("a")])
+    store.create(_session(id="new", last_active="2026-04-30T00:00:00Z"), [_msg("b")])
+    out = list(store.list())
+    assert [s.id for s in out] == ["new", "old"]
+
+
+def test_list_limit(tmp_path: Path):
+    store = _store(tmp_path)
+    for i in range(5):
+        store.create(_session(id=f"s{i}", last_active=f"2026-04-3{i}T00:00:00Z"), [_msg("x")])
+    out = list(store.list(limit=3))
+    assert len(out) == 3
+
+
+# ------------------------------------------------------------------ #
+# append                                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_append_extends_session(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="s1"), [_msg("first")])
+    store.append("s1", [_msg("second"), _msg("third")])
+    events = list(store.events("s1"))
+    assert [e.text for e in events] == ["first", "second", "third"]
+
+
+def test_append_to_missing_raises(tmp_path: Path):
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        store.append("nope", [_msg("x")])
+
+
+# ------------------------------------------------------------------ #
+# delete                                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_delete_removes_session(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="s1"), [_msg("a")])
+    assert store.delete("s1") is True
+    assert store.get("s1") is None
+
+
+def test_delete_returns_false_for_missing(tmp_path: Path):
+    store = _store(tmp_path)
+    assert store.delete("nope") is False
+
+
+def test_delete_does_not_cascade_to_children(tmp_path: Path):
+    """Deleting a parent leaves children's `forked_from` dangling but
+    the child still exists and its events still walk gracefully."""
+    store = _store(tmp_path)
+    store.create(_session(id="A"), [_msg("a1"), _msg("a2"), _msg("a3")])
+    store.create(_session(id="B", forked_from="A", fork_point=2), [_msg("b1")])
+
+    store.delete("A")
+    assert store.get("A") is None
+    assert store.get("B") is not None  # child still exists
+
+
+# ------------------------------------------------------------------ #
+# Persistence + tolerance                                              #
+# ------------------------------------------------------------------ #
+
+
+def test_index_persists_across_store_instances(tmp_path: Path):
+    """Reopening a store sees previously-created sessions."""
+    paths = TrackPaths.under(tmp_path)
+    s1 = LocalSessionStore(paths)
+    s1.create(_session(id="s1"), [_msg("a")])
+
+    s2 = LocalSessionStore(paths)
+    fetched = s2.get("s1")
+    assert fetched is not None
+    assert fetched.event_count == 1
+
+
+def test_index_ignores_unknown_fields(tmp_path: Path):
+    """An older store reading a session written by a newer schema
+    must not crash."""
+    import json as j
+    store = _store(tmp_path)
+    store.create(_session(id="s1"), [_msg("a")])
+    # Manually append a row with extra fields.
+    paths = TrackPaths.under(tmp_path)
+    extra = {"id": "s2", "tool": "claude", "future_field": "surprise",
+             "started_at": "2026-04-30T00:00:00Z"}
+    with open(paths.track_dir / "local-store" / "index.jsonl", "a") as f:
+        f.write(j.dumps(extra) + "\n")
+    # Should still read both sessions.
+    ids = {s.id for s in store.list()}
+    assert ids == {"s1", "s2"}

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -10,8 +10,6 @@ from fleet.track.paths import TrackPaths
 from fleet.track.store import LocalSessionStore, Session
 from fleet.track.unified import (
     AssistantMessage,
-    SessionStart,
-    ToolCall,
     UserMessage,
 )
 
@@ -86,10 +84,13 @@ def test_create_requires_id(tmp_path: Path):
 
 def test_events_returns_what_was_stored(tmp_path: Path):
     store = _store(tmp_path)
-    store.create(_session(id="s1"), [
-        _msg("first"),
-        AssistantMessage(source="claude", text="answer"),
-    ])
+    store.create(
+        _session(id="s1"),
+        [
+            _msg("first"),
+            AssistantMessage(source="claude", text="answer"),
+        ],
+    )
     events = list(store.events("s1"))
     assert len(events) == 2
     assert events[0].text == "first"
@@ -137,15 +138,18 @@ def test_fork_walks_ancestor_chain(tmp_path: Path):
     # Expected: first 3 from root, then 2 from fork1 = 5 total.
     assert len(events) == 5
     assert [e.text for e in events] == [
-        "root-0", "root-1", "root-2", "claude-a", "claude-b",
+        "root-0",
+        "root-1",
+        "root-2",
+        "claude-a",
+        "claude-b",
     ]
 
 
 def test_fork_chain_three_levels(tmp_path: Path):
     """codex(0..10) → claude(0..3) → codex(0..2)."""
     store = _store(tmp_path)
-    store.create(_session(id="A", tool="codex"),
-                 [_msg(f"A-{i}") for i in range(10)])
+    store.create(_session(id="A", tool="codex"), [_msg(f"A-{i}") for i in range(10)])
     store.create(
         _session(id="B", tool="claude", forked_from="A", fork_point=4),
         [_msg(f"B-{i}") for i in range(3)],
@@ -235,7 +239,9 @@ def test_list_sorts_most_recent_first(tmp_path: Path):
 def test_list_limit(tmp_path: Path):
     store = _store(tmp_path)
     for i in range(5):
-        store.create(_session(id=f"s{i}", last_active=f"2026-04-3{i}T00:00:00Z"), [_msg("x")])
+        store.create(
+            _session(id=f"s{i}", last_active=f"2026-04-3{i}T00:00:00Z"), [_msg("x")]
+        )
     out = list(store.list(limit=3))
     assert len(out) == 3
 
@@ -309,12 +315,17 @@ def test_index_ignores_unknown_fields(tmp_path: Path):
     """An older store reading a session written by a newer schema
     must not crash."""
     import json as j
+
     store = _store(tmp_path)
     store.create(_session(id="s1"), [_msg("a")])
     # Manually append a row with extra fields.
     paths = TrackPaths.under(tmp_path)
-    extra = {"id": "s2", "tool": "claude", "future_field": "surprise",
-             "started_at": "2026-04-30T00:00:00Z"}
+    extra = {
+        "id": "s2",
+        "tool": "claude",
+        "future_field": "surprise",
+        "started_at": "2026-04-30T00:00:00Z",
+    }
     with open(paths.track_dir / "local-store" / "index.jsonl", "a") as f:
         f.write(j.dumps(extra) + "\n")
     # Should still read both sessions.
@@ -371,6 +382,7 @@ def test_cursor_decode_rejects_missing_keys():
 
 def test_cursor_decode_empty_returns_none():
     from fleet.track.store import _decode_cursor
+
     assert _decode_cursor(None) is None
     assert _decode_cursor("") is None
 
@@ -527,13 +539,19 @@ def test_page_query_filter_substring_match(tmp_path: Path):
     """`query` is case-insensitive substring across id/tool/cwd/title."""
     store = _store(tmp_path)
     store.create(
-        _session(id="abc-fleet", cwd="/tmp/fleet-sdk",
-                 metadata={"title": "fleet-track sidecar"}),
+        _session(
+            id="abc-fleet",
+            cwd="/tmp/fleet-sdk",
+            metadata={"title": "fleet-track sidecar"},
+        ),
         [_msg("x")],
     )
     store.create(
-        _session(id="def-other", cwd="/tmp/theseus",
-                 metadata={"title": "session metadata index"}),
+        _session(
+            id="def-other",
+            cwd="/tmp/theseus",
+            metadata={"title": "session metadata index"},
+        ),
         [_msg("x")],
     )
 
@@ -565,16 +583,22 @@ def test_page_query_paginates_within_filtered_set(tmp_path: Path):
     store = _store(tmp_path)
     for i in range(4):
         store.create(
-            _session(id=f"keep-{i}", tool="claude",
-                     last_active=f"2026-04-3{i}T00:00:00Z",
-                     metadata={"title": "keep-me"}),
+            _session(
+                id=f"keep-{i}",
+                tool="claude",
+                last_active=f"2026-04-3{i}T00:00:00Z",
+                metadata={"title": "keep-me"},
+            ),
             [_msg("x")],
         )
     for i in range(3):
         store.create(
-            _session(id=f"drop-{i}", tool="claude",
-                     last_active=f"2026-04-3{i}T00:00:00Z",
-                     metadata={"title": "drop-me"}),
+            _session(
+                id=f"drop-{i}",
+                tool="claude",
+                last_active=f"2026-04-3{i}T00:00:00Z",
+                metadata={"title": "drop-me"},
+            ),
             [_msg("x")],
         )
 
@@ -595,8 +619,9 @@ def test_chained_page_eager_merge_paginates(tmp_path: Path):
     local = _store(tmp_path)
     for i in range(3):
         local.create(
-            _session(id=f"local-{i}", tool="claude",
-                     last_active=f"2026-04-3{i}T00:00:00Z"),
+            _session(
+                id=f"local-{i}", tool="claude", last_active=f"2026-04-3{i}T00:00:00Z"
+            ),
             [_msg("x")],
         )
 
@@ -622,8 +647,7 @@ def test_chained_page_dedupes_by_id(tmp_path: Path):
     local_b = LocalSessionStore(TrackPaths.under(tmp_path), name="other-store")
     for store in (local_a, local_b):
         store.create(
-            _session(id="shared", tool="claude",
-                     last_active="2026-04-30T00:00:00Z"),
+            _session(id="shared", tool="claude", last_active="2026-04-30T00:00:00Z"),
             [_msg("x")],
         )
 
@@ -651,3 +675,144 @@ def test_chained_page_query_filter(tmp_path: Path):
 
     items, _ = chained.page(query="match-me", limit=10)
     assert [s.id for s in items] == ["keep"]
+
+
+# ------------------------------------------------------------------ #
+# ChainedSessionStore — authoritative-paging delegation                #
+# ------------------------------------------------------------------ #
+
+
+class _FakeAuthorityStore:
+    """Minimum SessionStore that opts into authoritative paging.
+
+    Returns hard-coded pages so we can verify that ChainedSessionStore
+    delegates paging to it (cursors, limit, ordering all come from
+    here) and merges other stores' rows ONLY into the returned page's
+    window — not into pages outside it.
+    """
+
+    prefers_authoritative_paging: bool = True
+
+    def __init__(self, sessions: list[Session]) -> None:
+        # Pre-sorted (last_active DESC, id DESC), like a real impl.
+        from fleet.track.store import _sort_key
+
+        self._sessions = sorted(sessions, key=_sort_key, reverse=True)
+
+    def list(self, **kwargs) -> list[Session]:
+        return list(self._sessions)
+
+    def page(self, *, limit: int, cursor=None, **_) -> tuple[list[Session], str | None]:
+        # Cursor here is just an integer index encoded as string.
+        idx = int(cursor) if cursor else 0
+        page = self._sessions[idx : idx + limit]
+        next_idx = idx + limit
+        next_cursor = str(next_idx) if next_idx < len(self._sessions) else None
+        return page, next_cursor
+
+    def get(self, id: str):
+        for s in self._sessions:
+            if s.id == id:
+                return s
+        return None
+
+    def events(self, id: str):
+        return iter(())
+
+    def own_events(self, id: str):
+        return iter(())
+
+    def create(self, *a, **kw):
+        raise NotImplementedError
+
+    def append(self, *a, **kw):
+        raise NotImplementedError
+
+    def delete(self, *a, **kw):
+        raise NotImplementedError
+
+
+def test_chained_delegates_paging_when_authority_present(tmp_path: Path):
+    """When a backing store advertises `prefers_authoritative_paging`,
+    ChainedSessionStore must hand paging to it and pass the cursor
+    straight through. Local rows that fall in the page's window
+    overlay; rows OUTSIDE the window must NOT show up (they belong to
+    other authority pages)."""
+    from fleet.track.store import ChainedSessionStore
+
+    # Authority owns 4 rows. We'll page in chunks of 2.
+    auth = _FakeAuthorityStore(
+        [
+            _session(id="auth-newest", last_active="2026-05-04T00:00:00Z"),
+            _session(id="auth-2", last_active="2026-05-03T00:00:00Z"),
+            _session(id="auth-3", last_active="2026-05-02T00:00:00Z"),
+            _session(id="auth-oldest", last_active="2026-05-01T00:00:00Z"),
+        ]
+    )
+    # Local stub has two rows: one inside page 0's window, one inside
+    # page 1's window. Each must show up only on the appropriate page.
+    local = _store(tmp_path)
+    local.create(
+        _session(id="local-in-page0", last_active="2026-05-03T12:00:00Z"), [_msg("x")]
+    )
+    local.create(
+        _session(id="local-in-page1", last_active="2026-05-01T12:00:00Z"), [_msg("x")]
+    )
+
+    chained = ChainedSessionStore(auth, local)
+
+    page0, cursor = chained.page(limit=2)
+    page0_ids = [s.id for s in page0]
+    # `local-in-page0` (la=05-03T12) sits between auth-newest (05-04) and
+    # auth-2 (05-03T00) — so it lands in page 0.
+    assert "local-in-page0" in page0_ids
+    assert "local-in-page1" not in page0_ids
+    assert cursor is not None  # authority emits a cursor; we pass it through
+
+    page1, cursor = chained.page(limit=2, cursor=cursor)
+    page1_ids = [s.id for s in page1]
+    # `local-in-page1` (la=05-01T12) sits between auth-3 (05-02) and
+    # auth-oldest (05-01T00) — page 1's window.
+    assert "local-in-page1" in page1_ids
+    assert "local-in-page0" not in page1_ids
+
+
+def test_chained_authority_cursor_is_passthrough(tmp_path: Path):
+    """The authority's cursors are returned verbatim — they're not
+    rewrapped or merged with local cursors. Round-trip a cursor and
+    confirm it walks the authority's pages unchanged."""
+    from fleet.track.store import ChainedSessionStore
+
+    auth = _FakeAuthorityStore(
+        [
+            _session(id=f"r{i}", last_active=f"2026-05-{i:02d}T00:00:00Z")
+            for i in range(1, 6)
+        ]
+    )
+    chained = ChainedSessionStore(auth, _store(tmp_path))
+
+    seen_ids: list[str] = []
+    cursor = None
+    for _ in range(10):  # safety bound
+        page, cursor = chained.page(limit=2, cursor=cursor)
+        seen_ids.extend(s.id for s in page)
+        if cursor is None:
+            break
+    # Walked all 5 rows in some order — but each appeared exactly once.
+    assert sorted(seen_ids) == ["r1", "r2", "r3", "r4", "r5"]
+
+
+def test_chained_local_only_uses_eager_merge(tmp_path: Path):
+    """Sanity: when no backing store opts into authoritative paging,
+    the legacy eager-merge path is used (existing tests already
+    cover correctness; here we just confirm the dispatch picks it)."""
+    from fleet.track.store import ChainedSessionStore
+
+    local_a = _store(tmp_path)
+    local_b = LocalSessionStore(TrackPaths.under(tmp_path), name="b")
+    local_a.create(_session(id="a"), [_msg("x")])
+    local_b.create(_session(id="b"), [_msg("x")])
+    chained = ChainedSessionStore(local_a, local_b)
+    page, _ = chained.page(limit=10)
+    # Both rows present; ordering by last_active DESC.
+    assert {s.id for s in page} == {"a", "b"}

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -320,3 +320,218 @@ def test_index_ignores_unknown_fields(tmp_path: Path):
     # Should still read both sessions.
     ids = {s.id for s in store.list()}
     assert ids == {"s1", "s2"}
+
+
+# ------------------------------------------------------------------ #
+# Cursor format — must stay byte-compatible with the orchestrator      #
+# ------------------------------------------------------------------ #
+
+
+def test_cursor_format_pinned():
+    """Golden test: a cursor for a known (last_active, id) pair must
+    encode to a fixed string. If this test ever has to change, you've
+    broken wire compat with the server's `_encode_cursor` (see
+    theseus:orchestrator/public_api/track.py). Update both sides
+    together or paged scripts will paginate against the wrong rows."""
+    from fleet.track.store import _encode_cursor, _decode_cursor
+
+    cursor = _encode_cursor("2026-04-30T00:00:00Z", "abc12345")
+    # base64url(json({"la":"2026-04-30T00:00:00Z","id":"abc12345"})), no padding.
+    assert cursor == "eyJsYSI6IjIwMjYtMDQtMzBUMDA6MDA6MDBaIiwiaWQiOiJhYmMxMjM0NSJ9"
+    decoded = _decode_cursor(cursor)
+    assert decoded == {"la": "2026-04-30T00:00:00Z", "id": "abc12345"}
+
+
+def test_cursor_with_null_last_active_round_trips():
+    from fleet.track.store import _encode_cursor, _decode_cursor
+
+    cursor = _encode_cursor(None, "deadbeef")
+    decoded = _decode_cursor(cursor)
+    assert decoded == {"la": None, "id": "deadbeef"}
+
+
+def test_cursor_decode_rejects_garbage():
+    from fleet.track.store import _decode_cursor
+
+    with pytest.raises(ValueError):
+        _decode_cursor("not-base64!!")
+
+
+def test_cursor_decode_rejects_missing_keys():
+    """A cursor that decodes to JSON but lacks `la`/`id` is wire garbage."""
+    import base64
+    import json as j
+    from fleet.track.store import _decode_cursor
+
+    raw = j.dumps({"foo": "bar"}, separators=(",", ":"))
+    cursor = base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
+    with pytest.raises(ValueError, match="missing keys"):
+        _decode_cursor(cursor)
+
+
+def test_cursor_decode_empty_returns_none():
+    from fleet.track.store import _decode_cursor
+    assert _decode_cursor(None) is None
+    assert _decode_cursor("") is None
+
+
+# ------------------------------------------------------------------ #
+# page() — must mirror the orchestrator's predicate exactly            #
+# ------------------------------------------------------------------ #
+
+
+def test_page_returns_recency_first(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="old", last_active="2025-01-01T00:00:00Z"), [_msg("a")])
+    store.create(_session(id="new", last_active="2026-04-30T00:00:00Z"), [_msg("b")])
+    items, _cursor = store.page(limit=10)
+    assert [s.id for s in items] == ["new", "old"]
+
+
+def test_page_returns_no_cursor_when_under_limit(tmp_path: Path):
+    store = _store(tmp_path)
+    store.create(_session(id="a"), [_msg("x")])
+    items, cursor = store.page(limit=10)
+    assert len(items) == 1
+    assert cursor is None
+
+
+def test_page_returns_cursor_when_more_pages_exist(tmp_path: Path):
+    store = _store(tmp_path)
+    for i in range(5):
+        store.create(
+            _session(id=f"s{i}", last_active=f"2026-04-3{i}T00:00:00Z"),
+            [_msg("x")],
+        )
+    items, cursor = store.page(limit=2)
+    assert len(items) == 2
+    assert cursor is not None
+
+
+def test_page_walks_full_set_via_cursor(tmp_path: Path):
+    """Walking pages with `--cursor` must visit every session exactly once
+    in recency-DESC order."""
+    store = _store(tmp_path)
+    for i in range(7):
+        store.create(
+            _session(id=f"s{i}", last_active=f"2026-04-3{i}T00:00:00Z"),
+            [_msg("x")],
+        )
+
+    seen: list[str] = []
+    cursor = None
+    while True:
+        items, cursor = store.page(limit=2, cursor=cursor)
+        seen.extend(s.id for s in items)
+        if cursor is None:
+            break
+
+    assert seen == ["s6", "s5", "s4", "s3", "s2", "s1", "s0"]
+    # No duplicates.
+    assert len(set(seen)) == len(seen)
+
+
+def test_page_tiebreak_by_id_desc_when_last_active_equal(tmp_path: Path):
+    """Two sessions with identical last_active must sort by id DESC,
+    matching the server's ORDER BY clause."""
+    store = _store(tmp_path)
+    same = "2026-04-30T00:00:00Z"
+    store.create(_session(id="aaa", last_active=same), [_msg("x")])
+    store.create(_session(id="bbb", last_active=same), [_msg("x")])
+    store.create(_session(id="ccc", last_active=same), [_msg("x")])
+    items, _ = store.page(limit=10)
+    assert [s.id for s in items] == ["ccc", "bbb", "aaa"]
+
+
+def test_page_null_last_active_sweeps_to_tail(tmp_path: Path):
+    """Sessions with NULL last_active sort AFTER any with a value.
+    Must hold across the cursor walk too."""
+    store = _store(tmp_path)
+    store.create(_session(id="dated", last_active="2026-04-30T00:00:00Z"), [_msg("x")])
+    store.create(_session(id="nullA", last_active=None), [_msg("x")])
+    store.create(_session(id="nullB", last_active=None), [_msg("x")])
+
+    page1, cursor = store.page(limit=2)
+    assert [s.id for s in page1] == ["dated", "nullB"]
+    assert cursor is not None
+
+    page2, cursor = store.page(limit=2, cursor=cursor)
+    assert [s.id for s in page2] == ["nullA"]
+    assert cursor is None
+
+
+def test_page_filters_apply_before_cursor(tmp_path: Path):
+    """Filter (--tool=claude) must restrict the row set BEFORE the
+    cursor predicate. Otherwise a cursor minted with one filter would
+    leak rows when walked under a different filter."""
+    store = _store(tmp_path)
+    for i in range(4):
+        store.create(
+            _session(id=f"c{i}", tool="claude", last_active=f"2026-04-3{i}T00:00:00Z"),
+            [_msg("x")],
+        )
+    for i in range(2):
+        store.create(
+            _session(id=f"x{i}", tool="codex", last_active=f"2026-04-3{i}T00:00:00Z"),
+            [_msg("x")],
+        )
+
+    page1, cursor = store.page(tool="claude", limit=2)
+    assert [s.id for s in page1] == ["c3", "c2"]
+
+    page2, cursor = store.page(tool="claude", limit=2, cursor=cursor)
+    assert [s.id for s in page2] == ["c1", "c0"]
+    assert cursor is None
+
+
+def test_page_clamps_limit_to_max(tmp_path: Path):
+    """`limit` over MAX_PAGE_LIMIT must be clamped, not used as-is —
+    matches the server's `Query(le=200)` constraint."""
+    from fleet.track.store import MAX_PAGE_LIMIT
+
+    store = _store(tmp_path)
+    # Seed MAX+1 sessions; ask for MAX*10 — should still get exactly MAX
+    # in the page.
+    for i in range(MAX_PAGE_LIMIT + 1):
+        store.create(
+            _session(id=f"s{i:04d}", last_active=f"2026-04-30T00:00:{i % 60:02d}Z"),
+            [_msg("x")],
+        )
+    items, cursor = store.page(limit=MAX_PAGE_LIMIT * 10)
+    assert len(items) == MAX_PAGE_LIMIT
+    assert cursor is not None  # one row remains
+
+
+def test_page_invalid_cursor_raises_value_error(tmp_path: Path):
+    store = _store(tmp_path)
+    with pytest.raises(ValueError):
+        store.page(limit=10, cursor="not-a-real-cursor!!!")
+
+
+def test_list_uses_default_page_limit(tmp_path: Path):
+    """`list()` without an explicit limit must return up to DEFAULT_PAGE_LIMIT
+    rows — verifying the delegation to page() didn't regress."""
+    from fleet.track.store import DEFAULT_PAGE_LIMIT
+
+    store = _store(tmp_path)
+    for i in range(DEFAULT_PAGE_LIMIT + 5):
+        store.create(
+            _session(id=f"s{i:03d}", last_active=f"2026-04-30T{i % 24:02d}:00:00Z"),
+            [_msg("x")],
+        )
+    out = store.list()
+    assert len(out) == DEFAULT_PAGE_LIMIT
+
+
+def test_chained_page_raises(tmp_path: Path):
+    """Cursor pagination across stores requires a k-way merge we
+    haven't built; chained must raise loudly so callers fall back to
+    a single backend."""
+    from fleet.track.store import ChainedSessionStore, NativeFilesSessionStore
+
+    paths = TrackPaths.under(tmp_path)
+    chained = ChainedSessionStore(
+        _store(tmp_path), NativeFilesSessionStore(home=tmp_path)
+    )
+    with pytest.raises(NotImplementedError, match="--source"):
+        chained.page(limit=10)

--- a/tests/track/test_store_native.py
+++ b/tests/track/test_store_native.py
@@ -287,6 +287,33 @@ def test_chained_fork_chain_resolves_across_stores(tmp_path: Path):
     assert len(events) == 3
 
 
+def test_chained_fork_chain_in_same_local_store_does_not_duplicate(tmp_path: Path):
+    """Regression: when parent and child both live in the same
+    LocalSessionStore, ChainedSessionStore.events() must not double-emit
+    parent events. (Bugbot #5871e98c.)
+
+    The chained store walks the fork chain itself; if it then asked the
+    underlying store for the leaf via `events()` (which also walks the
+    chain), parent events would be yielded twice.
+    """
+    paths = TrackPaths.under(tmp_path)
+    local = LocalSessionStore(paths)
+    local.create(
+        Session(id="root", tool="claude"),
+        [UserMessage(source="claude", text=f"r{i}") for i in range(4)],
+    )
+    local.create(
+        Session(id="child", tool="claude", forked_from="root", fork_point=2),
+        [UserMessage(source="claude", text="c0"),
+         UserMessage(source="claude", text="c1")],
+    )
+    chained = ChainedSessionStore(local)
+
+    events = list(chained.events("child"))
+    # Expected: r0, r1 (parent up to fork_point=2), then c0, c1.
+    assert [e.text for e in events] == ["r0", "r1", "c0", "c1"]
+
+
 def test_chained_requires_at_least_one_store():
     with pytest.raises(ValueError):
         ChainedSessionStore()

--- a/tests/track/test_store_native.py
+++ b/tests/track/test_store_native.py
@@ -1,0 +1,303 @@
+"""Tests for NativeFilesSessionStore + ChainedSessionStore.
+
+Both stores are read-only views; we exercise list / get / events and
+the chained-lookup behavior including cross-store fork resolution.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fleet.track.paths import TrackPaths
+from fleet.track.store import (
+    ChainedSessionStore,
+    LocalSessionStore,
+    NativeFilesSessionStore,
+    Session,
+)
+from fleet.track.unified import UserMessage
+
+
+# ------------------------------------------------------------------ #
+# Fixture helpers                                                      #
+# ------------------------------------------------------------------ #
+
+
+def _seed_native_claude(home: Path, *, sid: str, encoded_cwd: str = "-tmp-x") -> Path:
+    base = home / ".claude" / "projects" / encoded_cwd
+    base.mkdir(parents=True, exist_ok=True)
+    f = base / f"{sid}.jsonl"
+    rows = [
+        # First row carries claude metadata so the parser synthesizes SessionStart.
+        {"type": "user", "uuid": "u1", "sessionId": sid, "cwd": "/tmp/x",
+         "gitBranch": "main", "version": "0.5",
+         "timestamp": "2026-04-30T00:00:00Z",
+         "message": {"role": "user", "content": "hi"}},
+        {"type": "assistant", "uuid": "a1", "parentUuid": "u1",
+         "timestamp": "2026-04-30T00:00:01Z",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "yo"}]}},
+    ]
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+def _seed_native_codex(home: Path, *, sid: str, cwd: str = "/tmp/y") -> Path:
+    base = home / ".codex" / "sessions" / "2026" / "05" / "01"
+    base.mkdir(parents=True, exist_ok=True)
+    f = base / f"rollout-2026-05-01T00-00-00-{sid}.jsonl"
+    rows = [
+        {"timestamp": "2026-05-01T00:00:00Z", "type": "session_meta",
+         "payload": {"id": sid, "cwd": cwd, "cli_version": "0.5",
+                     "base_instructions": {"text": "you are codex"}}},
+        {"timestamp": "2026-05-01T00:00:01Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user",
+                     "content": [{"type": "input_text", "text": "first"}]}},
+    ]
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+# ------------------------------------------------------------------ #
+# NativeFilesSessionStore                                              #
+# ------------------------------------------------------------------ #
+
+
+def test_native_store_lists_claude_session_by_filename(tmp_path: Path):
+    sid = "11111111-2222-3333-4444-555555555555"
+    _seed_native_claude(tmp_path, sid=sid)
+    store = NativeFilesSessionStore(home=tmp_path)
+    sessions = store.list()
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s.id == sid
+    assert s.tool == "claude"
+    assert s.event_count == 2  # 2 lines
+
+
+def test_native_store_lists_codex_session_by_uuid_in_filename(tmp_path: Path):
+    sid = "abcdef01-2345-6789-abcd-ef0123456789"
+    _seed_native_codex(tmp_path, sid=sid, cwd="/tmp/cdx")
+    store = NativeFilesSessionStore(home=tmp_path)
+    sessions = store.list()
+    s = next(x for x in sessions if x.tool == "codex")
+    assert s.id == sid
+    assert s.cwd == "/tmp/cdx"
+
+
+def test_native_store_filters_by_tool(tmp_path: Path):
+    _seed_native_claude(tmp_path, sid="11111111-1111-1111-1111-111111111111")
+    _seed_native_codex(tmp_path, sid="22222222-2222-2222-2222-222222222222")
+    store = NativeFilesSessionStore(home=tmp_path)
+    assert {s.tool for s in store.list(tool="claude")} == {"claude"}
+    assert {s.tool for s in store.list(tool="codex")} == {"codex"}
+
+
+def test_native_store_skips_fleet_checkouts(tmp_path: Path):
+    """Files marked with `_fleet_meta` are checkouts, not native sessions —
+    the picker should skip them."""
+    base = tmp_path / ".claude" / "projects" / "-tmp-x"
+    base.mkdir(parents=True)
+    sid = "11111111-1111-1111-1111-111111111111"
+    f = base / f"{sid}.jsonl"
+    rows = [
+        {"_fleet_meta": {"forked_from": "src", "fork_point": 0,
+                         "ephemeral_id": sid, "target_tool": "claude"},
+         "type": "system", "content": "fleet checkout"},
+        {"type": "user", "uuid": "u1",
+         "message": {"role": "user", "content": "hi"}},
+    ]
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    store = NativeFilesSessionStore(home=tmp_path)
+    assert store.list() == []
+
+
+def test_native_store_skips_non_uuid_filenames(tmp_path: Path):
+    """Claude can have files like `agent-abc.jsonl` (sub-agent traces) which
+    don't follow the canonical session-id naming. Skip them."""
+    base = tmp_path / ".claude" / "projects" / "-tmp-x"
+    base.mkdir(parents=True)
+    f = base / "agent-not-a-uuid.jsonl"
+    f.write_text(json.dumps({"type": "user", "uuid": "u1",
+                             "message": {"role": "user", "content": "hi"}}) + "\n")
+    store = NativeFilesSessionStore(home=tmp_path)
+    assert store.list() == []
+
+
+def test_native_store_get_by_prefix(tmp_path: Path):
+    _seed_native_claude(tmp_path, sid="abcdef01-2345-6789-abcd-ef0123456789")
+    store = NativeFilesSessionStore(home=tmp_path)
+    s = store.get("abcdef01")
+    assert s is not None
+    assert s.id == "abcdef01-2345-6789-abcd-ef0123456789"
+
+
+def test_native_store_get_missing_returns_none(tmp_path: Path):
+    store = NativeFilesSessionStore(home=tmp_path)
+    assert store.get("nope") is None
+
+
+def test_native_store_events_re_parses_file(tmp_path: Path):
+    sid = "11111111-2222-3333-4444-555555555555"
+    _seed_native_claude(tmp_path, sid=sid)
+    store = NativeFilesSessionStore(home=tmp_path)
+    events = list(store.events(sid))
+    # Synthesized SessionStart + UserMessage + AssistantMessage = 3
+    assert len(events) >= 2
+    assert any(e.type == "user_message" for e in events)
+    assert any(e.type == "assistant_message" for e in events)
+
+
+def test_native_store_is_read_only(tmp_path: Path):
+    store = NativeFilesSessionStore(home=tmp_path)
+    s = Session(id="s", tool="claude")
+    with pytest.raises(NotImplementedError):
+        store.create(s, [])
+    with pytest.raises(NotImplementedError):
+        store.append("s", [])
+    with pytest.raises(NotImplementedError):
+        store.delete("s")
+
+
+def test_native_store_list_recency_sorted(tmp_path: Path):
+    """Most-recent-first sort is what the picker shows."""
+    import time
+    a = _seed_native_claude(tmp_path, sid="11111111-1111-1111-1111-111111111111",
+                            encoded_cwd="-tmp-a")
+    b = _seed_native_claude(tmp_path, sid="22222222-2222-2222-2222-222222222222",
+                            encoded_cwd="-tmp-b")
+    # Bump b's mtime forward.
+    import os
+    fresh = time.time()
+    os.utime(b, (fresh, fresh))
+    os.utime(a, (fresh - 3600, fresh - 3600))
+    store = NativeFilesSessionStore(home=tmp_path)
+    ids = [s.id for s in store.list()]
+    assert ids == [
+        "22222222-2222-2222-2222-222222222222",
+        "11111111-1111-1111-1111-111111111111",
+    ]
+
+
+# ------------------------------------------------------------------ #
+# ChainedSessionStore                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_chained_lists_union_deduped_by_id(tmp_path: Path):
+    """Sessions present in both stores show up once; first store wins."""
+    paths = TrackPaths.under(tmp_path)
+    local = LocalSessionStore(paths)
+    sid_overlap = "11111111-1111-1111-1111-111111111111"
+    sid_native_only = "22222222-2222-2222-2222-222222222222"
+
+    # Native: two sessions
+    _seed_native_claude(tmp_path, sid=sid_overlap)
+    _seed_native_claude(tmp_path, sid=sid_native_only,
+                        encoded_cwd="-tmp-other")
+    # Local: one of those (overlapping id; first-store-wins).
+    # The store recomputes event_count from the events list, so just
+    # use cwd as the discriminator.
+    local.create(
+        Session(id=sid_overlap, tool="claude", cwd="/from/local"),
+        [UserMessage(source="claude", text="from local")],
+    )
+
+    chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
+    sessions = chained.list()
+    ids = [s.id for s in sessions]
+    assert ids.count(sid_overlap) == 1
+    assert sid_native_only in ids
+    # First-store-wins: the overlapping id should reflect the LOCAL row
+    # (cwd /from/local), not the native one.
+    overlap = next(s for s in sessions if s.id == sid_overlap)
+    assert overlap.cwd == "/from/local"
+
+
+def test_chained_get_finds_in_either_store(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    local = LocalSessionStore(paths)
+    local.create(
+        Session(id="local-only", tool="claude"),
+        [UserMessage(source="claude", text="x")],
+    )
+    sid = "33333333-3333-3333-3333-333333333333"
+    _seed_native_claude(tmp_path, sid=sid)
+    chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
+
+    assert chained.get("local-only") is not None
+    assert chained.get(sid) is not None
+    assert chained.get("nope") is None
+
+
+def test_chained_events_pulls_from_correct_store(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    local = LocalSessionStore(paths)
+    local.create(
+        Session(id="local-1", tool="claude"),
+        [UserMessage(source="claude", text="local-event")],
+    )
+    sid = "44444444-4444-4444-4444-444444444444"
+    _seed_native_claude(tmp_path, sid=sid)
+    chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
+
+    local_events = list(chained.events("local-1"))
+    assert any(getattr(e, "text", "") == "local-event" for e in local_events)
+
+    native_events = list(chained.events(sid))
+    assert any(e.type == "user_message" for e in native_events)
+
+
+def test_chained_create_uses_first_writable_store(tmp_path: Path):
+    """When the first store is read-only and the second is writable,
+    create falls through to the writable one."""
+    paths = TrackPaths.under(tmp_path)
+    local = LocalSessionStore(paths)
+    chained = ChainedSessionStore(NativeFilesSessionStore(home=tmp_path), local)
+
+    s = chained.create(
+        Session(id="written", tool="claude"),
+        [UserMessage(source="claude", text="hi")],
+    )
+    assert s.id == "written"
+    assert local.get("written") is not None
+
+
+def test_chained_fork_chain_resolves_across_stores(tmp_path: Path):
+    """Parent in native, child in local: events() walks the chain
+    correctly across both stores."""
+    paths = TrackPaths.under(tmp_path)
+    local = LocalSessionStore(paths)
+    parent_id = "55555555-5555-5555-5555-555555555555"
+    _seed_native_claude(tmp_path, sid=parent_id)
+    # Child stored in local, fork-pointing at parent in native.
+    local.create(
+        Session(id="child-of-native", tool="codex",
+                forked_from=parent_id, fork_point=2),
+        [UserMessage(source="codex", text="child-1")],
+    )
+    chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
+
+    events = list(chained.events("child-of-native"))
+    # Native parent contributes 2 events (its full history pre-fork);
+    # child contributes 1.
+    assert len(events) == 3
+
+
+def test_chained_requires_at_least_one_store():
+    with pytest.raises(ValueError):
+        ChainedSessionStore()
+
+
+def test_chained_remote_source_value_error():
+    """`--source remote` should not silently accept; the CLI raises
+    typer.BadParameter via _resolve_session_store. Here we just verify
+    that ChainedSessionStore is constructible and other source modes
+    work — the CLI test belongs in a different file."""
+    paths_obj = TrackPaths.under(Path("/tmp"))  # only used for path construction
+    chained = ChainedSessionStore(LocalSessionStore(paths_obj))
+    # `list` returns empty for a fresh store.
+    assert chained.list() == []

--- a/tests/track/test_uploader.py
+++ b/tests/track/test_uploader.py
@@ -1,0 +1,205 @@
+"""Unit tests for uploader.py."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from fleet.track.uploader import (
+    HttpxTransport,
+    Transport,
+    UploadPool,
+    _read_safe,
+    upload_one,
+)
+
+
+# ------------------------------------------------------------------ #
+# Helpers                                                              #
+# ------------------------------------------------------------------ #
+
+
+class RecordingTransport:
+    """Records every put() call. Test analog to HttpxTransport."""
+
+    def __init__(self, status_for_url: Optional[dict] = None, raise_on_url: Optional[str] = None) -> None:
+        self.calls: list[tuple[str, bytes]] = []
+        self._statuses = status_for_url or {}
+        self._raise_on = raise_on_url
+
+    def put(self, url: str, content: bytes) -> int:
+        self.calls.append((url, content))
+        if self._raise_on and url == self._raise_on:
+            raise httpx.RequestError("simulated network failure")
+        return self._statuses.get(url, 200)
+
+
+# ------------------------------------------------------------------ #
+# _read_safe                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_read_safe_returns_full_content_for_complete_file(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"a": 1}\n{"b": 2}\n')
+    assert _read_safe(f) == b'{"a": 1}\n{"b": 2}\n'
+
+
+def test_read_safe_trims_partial_trailing_jsonl_line(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"a": 1}\n{"b":')  # partial second line — no trailing newline
+    assert _read_safe(f) == b'{"a": 1}\n'
+
+
+def test_read_safe_does_not_trim_non_jsonl(tmp_path: Path):
+    f = tmp_path / "x.txt"
+    f.write_text("hello world without newline")
+    assert _read_safe(f) == b"hello world without newline"
+
+
+def test_read_safe_missing_file_returns_none(tmp_path: Path):
+    assert _read_safe(tmp_path / "does-not-exist.jsonl") is None
+
+
+# ------------------------------------------------------------------ #
+# upload_one                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_upload_one_success(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"hello": "world"}\n')
+    transport = RecordingTransport()
+    ok = upload_one(f, "https://s3/x", transport)
+    assert ok is True
+    assert len(transport.calls) == 1
+    url, body = transport.calls[0]
+    assert url == "https://s3/x"
+    # Scrubber is applied: identity content here, no rules fire, body matches input.
+    assert body == b'{"hello": "world"}\n'
+
+
+def test_upload_one_scrubs_secrets(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"key": "AKIAIOSFODNN7EXAMPLE"}\n')
+    transport = RecordingTransport()
+    upload_one(f, "https://s3/x", transport)
+    _, body = transport.calls[0]
+    assert b"AKIAIOSFODNN7EXAMPLE" not in body
+    assert b"REDACTED" in body
+
+
+def test_upload_one_returns_false_on_4xx(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text("hi")
+    transport = RecordingTransport(status_for_url={"https://s3/x": 403})
+    assert upload_one(f, "https://s3/x", transport) is False
+
+
+def test_upload_one_returns_false_on_network_error(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text("hi")
+    transport = RecordingTransport(raise_on_url="https://s3/x")
+    assert upload_one(f, "https://s3/x", transport) is False
+
+
+def test_upload_one_returns_false_when_file_unreadable(tmp_path: Path):
+    transport = RecordingTransport()
+    assert upload_one(tmp_path / "ghost.jsonl", "https://s3/x", transport) is False
+    assert transport.calls == []
+
+
+# ------------------------------------------------------------------ #
+# UploadPool                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_pool_calls_on_done_for_success(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text("ok")
+
+    done: list[tuple[str, str]] = []
+    failed: list[tuple[str, str, str]] = []
+    pool = UploadPool(
+        on_done=lambda p, s: done.append((p, s)),
+        on_failed=lambda p, s, e: failed.append((p, s, e)),
+        transport=RecordingTransport(),
+    )
+
+    pool.submit("rel/x.jsonl", "h1", f, "https://s3/x")
+    pool.drain(timeout=5)
+    pool.shutdown()
+
+    assert done == [("rel/x.jsonl", "h1")]
+    assert failed == []
+
+
+def test_pool_calls_on_failed_for_4xx(tmp_path: Path):
+    f = tmp_path / "x.jsonl"
+    f.write_text("ok")
+
+    done: list = []
+    failed: list = []
+    pool = UploadPool(
+        on_done=lambda p, s: done.append((p, s)),
+        on_failed=lambda p, s, e: failed.append((p, s, e)),
+        transport=RecordingTransport(status_for_url={"https://s3/x": 403}),
+    )
+
+    pool.submit("rel/x.jsonl", "h1", f, "https://s3/x")
+    pool.drain(timeout=5)
+    pool.shutdown()
+
+    assert done == []
+    assert len(failed) == 1
+    assert failed[0][0] == "rel/x.jsonl"
+
+
+def test_pool_in_flight_count_drops_after_completion(tmp_path: Path):
+    """A barrier transport ensures we can observe in_flight > 0 before draining."""
+    f = tmp_path / "x.jsonl"
+    f.write_text("ok")
+
+    release = threading.Event()
+
+    class BlockingTransport:
+        def put(self, url: str, content: bytes) -> int:
+            release.wait(timeout=5)
+            return 200
+
+    pool = UploadPool(
+        on_done=lambda *_: None,
+        on_failed=lambda *_: None,
+        transport=BlockingTransport(),
+    )
+    pool.submit("rel/x.jsonl", "h1", f, "https://s3/x")
+
+    # Spin briefly waiting for the worker to claim the future.
+    deadline = time.monotonic() + 1.0
+    while pool.in_flight_count() == 0 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert pool.in_flight_count() >= 1
+    release.set()
+    pool.drain(timeout=5)
+    assert pool.in_flight_count() == 0
+    pool.shutdown()
+
+
+def test_httpx_transport_uses_injected_client():
+    """HttpxTransport with a MockTransport-backed client routes correctly."""
+    captured = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured.append((str(req.url), req.content))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    transport: Transport = HttpxTransport(client=client)
+    assert transport.put("https://s3.example/path?sig=x", b"payload") == 200
+    assert captured == [("https://s3.example/path?sig=x", b"payload")]
+    client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,7 @@ dependencies = [
 [package.optional-dependencies]
 cli = [
     { name = "rich" },
+    { name = "textual" },
     { name = "typer" },
     { name = "watchdog" },
 ]
@@ -690,9 +691,11 @@ dev = [
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-mock" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "ruff" },
+    { name = "textual" },
     { name = "typer" },
     { name = "unasync" },
 ]
@@ -723,10 +726,13 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=10.0.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=10.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "textual", marker = "extra == 'cli'", specifier = ">=0.50.0" },
+    { name = "textual", marker = "extra == 'dev'", specifier = ">=0.50.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9.0" },
     { name = "typer", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
@@ -1312,6 +1318,36 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "uc-micro-py", version = "1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "uc-micro-py", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1324,6 +1360,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py", version = "2.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -1339,6 +1380,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -1364,6 +1410,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/db9ae5ab1fcdd9cd2bcc7ca3b7361b712e30590b64d5151a31563af8f82d/mcp-1.24.0.tar.gz", hash = "sha256:aeaad134664ce56f2721d1abf300666a1e8348563f4d3baff361c3b652448efc", size = 604375, upload-time = "2025-12-12T14:19:38.205Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/0d/5cf14e177c8ae655a2fd9324a6ef657ca4cafd3fc2201c87716055e29641/mcp-1.24.0-py3-none-any.whl", hash = "sha256:db130e103cc50ddc3dffc928382f33ba3eaef0b711f7a87c05e7ded65b1ca062", size = 232896, upload-time = "2025-12-12T14:19:36.14Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316, upload-time = "2024-09-09T20:27:48.397Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -2156,6 +2232,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2473,6 +2562,26 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify"], marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify"], marker = "python_full_version >= '3.10'" },
+    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mdit-py-plugins", version = "0.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/1e/1eedc5bac184d00aaa5f9a99095f7e266af3ec46fa926c1051be5d358da1/textual-8.2.5.tar.gz", hash = "sha256:6c894e65a879dadb4f6cf46ddcfedb0173ff7e0cb1fe605ff7b357a597bdbc90", size = 1851596, upload-time = "2026-04-30T08:02:58.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/01/c4555f9c8a692ff83d84930150540f743ce94c89234f9e9a15ff4baba3a8/textual-8.2.5-py3-none-any.whl", hash = "sha256:247d2aa2faf222749c321f88a736247f37ee2c023604079c7490bfacddfcd4b2", size = 727050, upload-time = "2026-04-30T08:03:01.421Z" },
+]
+
+[[package]]
 name = "tokenize-rt"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2565,6 +2674,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -678,6 +678,7 @@ dependencies = [
 cli = [
     { name = "rich" },
     { name = "typer" },
+    { name = "watchdog" },
 ]
 dev = [
     { name = "black", version = "25.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -730,6 +731,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "unasync", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+    { name = "watchdog", marker = "extra == 'cli'", specifier = ">=4.0.0" },
 ]
 provides-extras = ["cli", "dev", "playwright", "eval"]
 
@@ -2599,6 +2601,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/7223011bb760fce8ddc53416beb65b83a3ea6d7d13738dde75eeb2c89679/watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8", size = 96390, upload-time = "2024-11-01T14:06:49.325Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/d2b21bc4e706d3a9d467561f487c2938cbd881c69f3808c43ac1ec242391/watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a", size = 88386, upload-time = "2024-11-01T14:06:50.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1c90b20eda9f4132e4603a26296108728a8bfe9584b006bd05dd94548853/watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c", size = 89017, upload-time = "2024-11-01T14:06:51.717Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/79/69f2b0e8d3f2afd462029031baafb1b75d11bb62703f0e1022b2e54d49ee/watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa", size = 87903, upload-time = "2024-11-01T14:06:57.052Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/2b/dc048dd71c2e5f0f7ebc04dd7912981ec45793a03c0dc462438e0591ba5d/watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e", size = 88381, upload-time = "2024-11-01T14:06:58.193Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `fleet/track/` package: passive sidecar for AI coding sessions with a unified Event format and cross-tool resume
- 288 unit tests, all passing; verified end-to-end on real claude/codex sessions
- Architecture designed for future server-canonical storage; `SessionStore`, `Source`, and `Compactor` are protocols with one or more local implementations and clearly-marked future slots
- Auth path is provisional (JWT + Supabase placeholder substitution) — replaced by PATs in a follow-up PR

## Architecture

```
fleet/track/
├── unified.py         pydantic discriminated Event union (15 types) + raw escape hatch
├── sources/
│   ├── base.py        Source ABC: parse + serialize per tool
│   ├── claude.py      ClaudeSource (full)
│   ├── codex.py       CodexSource (full)
│   └── cursor.py      CursorSource (stub)
├── store.py           Session, SessionStore Protocol
│                      LocalSessionStore (writable), NativeFilesSessionStore (read-only),
│                      ChainedSessionStore (composes; first-store-wins)
├── compactor.py       Compactor Protocol; TruncationCompactor with token-budget targeting
│                      KNOWN_MODELS registry (gpt-5, claude-opus-4-7, etc.)
├── resumer.py         Cross-tool resume; checkout creation; GC by `_fleet_meta` marker
├── converter.py       Cross-format conversion glue
├── picker.py          fzf-based interactive picker
├── cli.py             `flt track ls/resume/gc/...`
└── (daemon, queue, merkle, status, watcher, etc.)
```

### Key abstractions

| Layer | Status | Future slot |
|---|---|---|
| `Source` ABC + per-tool impls | Solid | Cursor / OpenCode = one new file each |
| `SessionStore` Protocol | Solid | `RemoteSessionStore` (theseus) |
| `Compactor` Protocol | Solid | `LLMSummarizingCompactor`, `RecallToolCompactor` |
| `Event` discriminated union | Solid | `raw` escape hatch + `synthesized` flag |
| `TrackPaths` injection | Solid | Tests use `TrackPaths.under(tmp_path)` |
| `httpx.Client` injection | Solid | Tests use `httpx.MockTransport` |

## What works today

```bash
flt track ls                                    # native files + dev stub, deduped
flt track ls --tool codex --limit 10            # filtered
flt track ls --json                             # for scripting
flt track resume <id>                           # same-tool: native CLI passthrough
flt track resume <id> --in claude               # cross-tool: convert + checkout + dispatch
flt track resume                                # interactive fzf picker
flt track resume <id> --in codex --target-model gpt-5  # model-aware budget
flt track gc                                    # clean up checkouts
```

Empirically verified in both directions:
- claude → codex: codex resumes converted history, quotes user's first message verbatim
- codex → claude: claude resumes converted history, quotes user's first content block
- Token budgets honored across model targets (verified on 21K-event codex sessions)

## What's deferred (not in this PR)

- **PAT migration**: `flt login`/`logout`/`whoami` + `auth.py` + `_supabase.py` will be replaced with PAT-based auth (orchestrator + fleet.so + SDK changes; tracked separately)
- **`RemoteSessionStore`**: server-side endpoints for cross-machine resume; `--source remote` raises `BadParameter` until they exist
- **Track daemon ↔ SessionStore wiring**: the daemon's S3 upload path runs alongside the new SessionStore layer rather than feeding it
- **`LLMSummarizingCompactor` / `RecallToolCompactor`**: protocol slots, no implementations yet

## Test plan

- [x] `uv run pytest tests/track/` — 288 tests pass
- [x] Manual: `flt track ls --source native` shows local sessions
- [x] Manual: `flt track resume <id> --in <other-tool>` runs end-to-end on real sessions
- [x] Manual: `flt track gc` removes checkout files (identified by `_fleet_meta`)
- [x] Empirical: 230K real session lines round-trip byte-identical through self-format
- [x] Empirical: cross-format conversion + resume verified content-attached for both directions

## See also

- Design docs in `docs/fleet-track/` (goals, current-state assessment, v2 architecture, unified format spec, local resume test plan)