### PR TITLE
Pass API key to track daemon service

### DIFF
--- a/fleet/track/install.py
+++ b/fleet/track/install.py
@@ -24,6 +24,7 @@ from .paths import TrackPaths
 PLIST_LABEL = "io.fleet.track"
 SYSTEMD_SERVICE = "fleet-track"
 DAEMON_ENV_KEYS = ("FLEET_API_KEY", "FLEET_TRACK_BASE_URL")
+PRIVATE_FILE_MODE = 0o600
 
 
 def flt_executable() -> str:
@@ -122,7 +123,7 @@ def render_launchd_plist(paths: TrackPaths, flt_path: str, env_path: str = "/usr
 def render_systemd_unit(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
     """Return the systemd service unit body. Pure: no filesystem side-effects."""
     extra_env = "\n".join(
-        f"Environment={key}={value}"
+        f'Environment="{key}={_escape_systemd_env_value(value)}"'
         for key in DAEMON_ENV_KEYS
         if (value := os.environ.get(key))
     )
@@ -145,6 +146,28 @@ WantedBy=default.target
 """
 
 
+def _escape_systemd_env_value(value: str) -> str:
+    """Escape a value for a quoted systemd Environment= assignment."""
+    if "\n" in value or "\r" in value:
+        raise ValueError("Daemon environment values cannot contain newlines")
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+
+
+def _write_private_text(path: Path, body: str) -> None:
+    """Write a service file without leaving secrets world-readable."""
+    if path.exists():
+        path.chmod(PRIVATE_FILE_MODE)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, PRIVATE_FILE_MODE)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write(body)
+    finally:
+        if fd != -1:
+            os.close(fd)
+    path.chmod(PRIVATE_FILE_MODE)
+
+
 # ------------------------------------------------------------------ #
 # macOS launchd                                                        #
 # ------------------------------------------------------------------ #
@@ -163,7 +186,7 @@ def _install_launchd(paths: TrackPaths) -> None:
     )
     plist_path = _launchd_plist_path()
     plist_path.parent.mkdir(parents=True, exist_ok=True)
-    plist_path.write_text(body)
+    _write_private_text(plist_path, body)
 
     subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
     subprocess.run(["launchctl", "load", str(plist_path)], check=True)
@@ -194,7 +217,7 @@ def _install_systemd(paths: TrackPaths) -> None:
     )
     service_path = _systemd_service_path()
     service_path.parent.mkdir(parents=True, exist_ok=True)
-    service_path.write_text(body)
+    _write_private_text(service_path, body)
 
     subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
     subprocess.run(["systemctl", "--user", "enable", "--now", SYSTEMD_SERVICE], check=True)

--- a/fleet/track/install.py
+++ b/fleet/track/install.py
@@ -15,6 +15,7 @@ import platform
 import shutil
 import subprocess
 import sys
+from html import escape
 from pathlib import Path
 from typing import Optional
 
@@ -22,6 +23,7 @@ from .paths import TrackPaths
 
 PLIST_LABEL = "io.fleet.track"
 SYSTEMD_SERVICE = "fleet-track"
+DAEMON_ENV_KEYS = ("FLEET_API_KEY", "FLEET_TRACK_BASE_URL")
 
 
 def flt_executable() -> str:
@@ -79,12 +81,11 @@ def is_installed() -> bool:
 
 def render_launchd_plist(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
     """Return the plist XML body. Pure: no filesystem side-effects."""
-    extra_env = ""
-    if os.environ.get("FLEET_TRACK_BASE_URL"):
-        extra_env = (
-            f"<key>FLEET_TRACK_BASE_URL</key>"
-            f"<string>{os.environ['FLEET_TRACK_BASE_URL']}</string>"
-        )
+    extra_env = "\n".join(
+        f"        <key>{key}</key>\n        <string>{escape(value)}</string>"
+        for key in DAEMON_ENV_KEYS
+        if (value := os.environ.get(key))
+    )
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -120,9 +121,11 @@ def render_launchd_plist(paths: TrackPaths, flt_path: str, env_path: str = "/usr
 
 def render_systemd_unit(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
     """Return the systemd service unit body. Pure: no filesystem side-effects."""
-    extra_env = ""
-    if os.environ.get("FLEET_TRACK_BASE_URL"):
-        extra_env = f"Environment=FLEET_TRACK_BASE_URL={os.environ['FLEET_TRACK_BASE_URL']}"
+    extra_env = "\n".join(
+        f"Environment={key}={value}"
+        for key in DAEMON_ENV_KEYS
+        if (value := os.environ.get(key))
+    )
     return f"""[Unit]
 Description=Fleet track daemon — AI session sync
 After=network-online.target

--- a/tests/track/test_install.py
+++ b/tests/track/test_install.py
@@ -32,16 +32,27 @@ def test_render_launchd_plist_has_required_keys(tmp_path: Path):
 
 
 def test_render_launchd_plist_excludes_track_base_url_when_unset(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
     body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
     assert "FLEET_TRACK_BASE_URL" not in body
+    assert "FLEET_API_KEY" not in body
 
 
 def test_render_launchd_plist_includes_track_base_url_when_set(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://example.fleetai.com")
     body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
     assert "FLEET_TRACK_BASE_URL" in body
     assert "https://example.fleetai.com" in body
+
+
+def test_render_launchd_plist_includes_api_key_when_set(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_API_KEY", "sk_test")
+    monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
+    body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert "FLEET_API_KEY" in body
+    assert "sk_test" in body
 
 
 def test_render_systemd_unit_has_required_directives(tmp_path: Path):
@@ -57,15 +68,25 @@ def test_render_systemd_unit_has_required_directives(tmp_path: Path):
 
 
 def test_render_systemd_unit_excludes_track_base_url_when_unset(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
     body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
     assert "FLEET_TRACK_BASE_URL" not in body
+    assert "FLEET_API_KEY" not in body
 
 
 def test_render_systemd_unit_includes_track_base_url_when_set(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://dev.example.com")
     body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
     assert "Environment=FLEET_TRACK_BASE_URL=https://dev.example.com" in body
+
+
+def test_render_systemd_unit_includes_api_key_when_set(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_API_KEY", "sk_test")
+    monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
+    body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert "Environment=FLEET_API_KEY=sk_test" in body
 
 
 def test_flt_executable_returns_a_string():

--- a/tests/track/test_install.py
+++ b/tests/track/test_install.py
@@ -1,12 +1,15 @@
-"""Unit tests for install.py — pure rendering only, no shelling out."""
+"""Unit tests for install.py — rendering and file writes only, no shelling out."""
 
 from __future__ import annotations
 
+import stat
 from pathlib import Path
 
 from fleet.track.install import (
+    PRIVATE_FILE_MODE,
     PLIST_LABEL,
     SYSTEMD_SERVICE,
+    _write_private_text,
     flt_executable,
     render_launchd_plist,
     render_systemd_unit,
@@ -79,14 +82,47 @@ def test_render_systemd_unit_includes_track_base_url_when_set(tmp_path: Path, mo
     monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://dev.example.com")
     body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
-    assert "Environment=FLEET_TRACK_BASE_URL=https://dev.example.com" in body
+    assert 'Environment="FLEET_TRACK_BASE_URL=https://dev.example.com"' in body
 
 
 def test_render_systemd_unit_includes_api_key_when_set(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("FLEET_API_KEY", "sk_test")
     monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
     body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
-    assert "Environment=FLEET_API_KEY=sk_test" in body
+    assert 'Environment="FLEET_API_KEY=sk_test"' in body
+
+
+def test_render_systemd_unit_escapes_percent_specifiers(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_API_KEY", "sk_%team%")
+    monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
+    body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert 'Environment="FLEET_API_KEY=sk_%%team%%"' in body
+
+
+def test_render_systemd_unit_escapes_quoted_value(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_API_KEY", 'sk_"quoted"\\path')
+    monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
+    body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
+    assert 'Environment="FLEET_API_KEY=sk_\\"quoted\\"\\\\path"' in body
+
+
+def test_write_private_text_uses_user_only_permissions(tmp_path: Path):
+    target = tmp_path / "fleet-track.service"
+    _write_private_text(target, "secret")
+
+    assert target.read_text() == "secret"
+    assert stat.S_IMODE(target.stat().st_mode) == PRIVATE_FILE_MODE
+
+
+def test_write_private_text_tightens_existing_permissions(tmp_path: Path):
+    target = tmp_path / "fleet-track.service"
+    target.write_text("old")
+    target.chmod(0o644)
+
+    _write_private_text(target, "new")
+
+    assert target.read_text() == "new"
+    assert stat.S_IMODE(target.stat().st_mode) == PRIVATE_FILE_MODE
 
 
 def test_flt_executable_returns_a_string():


### PR DESCRIPTION
## Summary
- include `FLEET_API_KEY` in the launchd/systemd service environment generated by `flt track enable`
- keep forwarding `FLEET_TRACK_BASE_URL` for local/staging testing
- cover both launchd plist and systemd unit rendering

## Tests
- `uv run pytest tests/track/test_install.py tests/track/test_cli.py tests/track/test_api.py tests/track/test_daemon.py tests/track/test_drainer.py tests/track/test_reconciler.py tests/track/test_paths.py tests/test_cli_auth.py`

## Local verification
- manually reloaded the launchd service with dev `FLEET_API_KEY` and `FLEET_TRACK_BASE_URL=http://localhost:8000`
- `flt track status` is idle/uploading rather than auth-erroring
- `flt track ls --source remote --limit 5` returns sessions from the local orchestrator backed by dev Supabase