### PR TITLE
Fix track daemon manifest stalling under continuous load

### DIFF
--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from .reconciler import ReconcileResult
 
 RECONCILE_INTERVAL = 600  # full Merkle diff every 10 minutes
+MANIFEST_FLUSH_INTERVAL = 60  # at minimum, persist manifest this often when dirty
 
 
 def _setup_logging(paths: TrackPaths) -> None:
@@ -134,6 +135,7 @@ class Daemon:
         self._confirmed_map: dict[str, str] = {}
         self._confirmed_lock = threading.Lock()
         self._manifest_dirty = False  # set when confirmed_map gains new entries
+        self._last_manifest_flush: float = 0.0
         # path -> sha256 for rows this process has successfully registered
         # in the orchestrator metadata index.
         self._metadata_indexed: dict[str, str] = {}
@@ -244,12 +246,19 @@ class Daemon:
                 last_queue_reset = now
 
             self._drain_queue()
-            # Write manifest once all pending uploads have drained.
+            # Persist manifest opportunistically when the queue is idle, but
+            # also at least every MANIFEST_FLUSH_INTERVAL seconds so a daemon
+            # that stays continuously busy still publishes progress. The
+            # manifest only ever contains files in _confirmed_map (successful
+            # S3 PUTs), so an interim flush is always safe.
             if self._manifest_dirty:
                 stats = self._queue.stats()
-                if stats.get("pending", 0) == 0 and stats.get("in_flight", 0) == 0:
+                idle = stats.get("pending", 0) == 0 and stats.get("in_flight", 0) == 0
+                stale = (now - self._last_manifest_flush) >= MANIFEST_FLUSH_INTERVAL
+                if idle or stale:
                     self._upload_manifest()
                     self._manifest_dirty = False
+                    self._last_manifest_flush = now
             self._write_status()
             self._stop.wait(timeout=10)
 

--- a/fleet/track/queue.py
+++ b/fleet/track/queue.py
@@ -105,12 +105,23 @@ class UploadQueue:
             self._conn.commit()
 
     def enqueue_batch(self, items: list[tuple[str, str]]) -> None:
+        # Reset any existing row for the same (path, sha256) back to pending.
+        # The reconciler only calls this for files the remote manifest is
+        # missing, so any prior `done`/`failed`/`in_flight` state is a lie we
+        # need to overrule — otherwise INSERT OR IGNORE would let stale `done`
+        # rows block re-upload indefinitely.
         now = int(time.time())
         with self._lock:
             self._conn.executemany(
                 """
-                INSERT OR IGNORE INTO queue (path, sha256, status, next_attempt_at, enqueued_at, updated_at)
+                INSERT INTO queue (path, sha256, status, next_attempt_at, enqueued_at, updated_at)
                 VALUES (?, ?, 'pending', 0, ?, ?)
+                ON CONFLICT(path, sha256) DO UPDATE SET
+                    status = 'pending',
+                    next_attempt_at = 0,
+                    attempts = 0,
+                    last_error = NULL,
+                    updated_at = excluded.updated_at
                 """,
                 [(path, sha256, now, now) for path, sha256 in items],
             )


### PR DESCRIPTION
## Summary

`flt track` daemon was wedged in a loop where uploaded files were never reflected in the server-side manifest, so metadata upserts never fired. Symptom: `flt track status` showed hundreds of files `done` locally, but the orchestrator's `track_sessions` table only had a few rows from the *current* daemon process.

Two bugs, fixed together:

- **`daemon.py`** — manifest was only flushed when both `pending == 0 AND in_flight == 0`. Under continuous load that condition is never met, so `manifest.json` on S3 stays stale forever. Every reconcile diffs against that stale manifest, re-flags the same files, the daemon re-PUTs them, and the cycle repeats. Metadata rows in `track_sessions` are only written via `_upsert_metadata_for_paths(confirmed_existing)` — gated on the remote manifest — so most files never get registered.
- **`queue.py`** — `enqueue_batch` used `INSERT OR IGNORE` keyed on `UNIQUE(path, sha256)`. Once the original bug left rows marked `done` locally while the remote manifest didn't have them, the reconciler couldn't re-queue them: its intent was silently dropped. The drainer saw zero `pending`, so no uploads happened despite the reconciler reporting hundreds of files needing upload.

## Fix

- `daemon.py`: flush manifest when dirty AND (queue idle OR `MANIFEST_FLUSH_INTERVAL=60` seconds elapsed since last flush). The manifest only ever contains files in `_confirmed_map` (successful S3 PUTs), so an interim flush is always safe — at worst it's a snapshot that the next flush will extend.
- `queue.py`: `enqueue_batch` now `UPSERT`s, resetting matching rows back to `pending` (clearing `attempts`/`last_error`). The reconciler is the only caller, and it only enqueues files the remote manifest is missing — so any prior `done`/`failed`/`in_flight` state is by definition stale.

## Test plan

- [ ] Verified locally: with the daemon running with 800+ files needing upload, manifest writes resumed every ~60s (instead of never), the reconciler stopped re-flagging the same files, and `track_sessions` rows climbed steadily as uploads completed.
- [ ] Add a unit test for `Daemon._upload_manifest` firing under continuous load (mock `Queue.stats()` to always report `in_flight > 0`, advance a fake clock past `MANIFEST_FLUSH_INTERVAL`, assert flush called).
- [ ] Add a unit test for `UploadQueue.enqueue_batch` resetting an existing `done` row back to `pending`.