### PR TITLE
Limit track CLI sources to remote and local

### DIFF
--- a/fleet/track/_picker_page.py
+++ b/fleet/track/_picker_page.py
@@ -14,7 +14,7 @@ Invoked by `pick_session` via fzf's `--bind` reload triggers:
 State file (JSON):
 
     {
-      "source":         "remote" | "local" | "stub" | "native" | "auto",
+      "source":         "remote" | "local",
       "tool":           Optional[str],
       "cwd":            Optional[str],
       "since":          Optional[str],
@@ -50,7 +50,7 @@ def _save_state(path: Path, state: dict[str, Any]) -> None:
 def _resolve_store(source: str):
     # Lazy-import so this script stays fast to start. Reuses the CLI's
     # store-resolution so behavior is consistent with the rest of `flt
-    # track` (remote default, local chains, native filters, etc.).
+    # track` (remote default, manually built local index, etc.).
     from .cli import _resolve_session_store
 
     return _resolve_session_store(source)

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 
 import typer
 from rich.console import Console
@@ -25,9 +26,8 @@ console = Console()
 DEFAULT_SESSION_SOURCE = "remote"
 LOCAL_SESSION_SOURCE = "local"
 SOURCE_HELP = (
-    "Where to read sessions from: remote (default, orchestrator/Turbopuffer), "
-    "local (native+stub; auto alias), native (~/.claude, ~/.codex), "
-    "stub (LocalSessionStore)."
+    "Where to read sessions from: remote (default, orchestrator/Turbopuffer) "
+    "or local (manually built Fleet local index)."
 )
 
 
@@ -240,39 +240,29 @@ def _resolve_session_store(source: str):
 
     Modes:
       - `remote` (default): orchestrator-backed metadata/search index.
-      - `local`: chained Native + Stub. Shows native session files on disk
-        AND anything explicitly ingested into the stub.
-      - `auto`: backwards-compatible alias for `local`.
-      - `native`: only the read-only view of `~/.claude` / `~/.codex`.
-      - `stub`: only the LocalSessionStore (the dev stub).
+      - `local`: Fleet's prebuilt local index under ~/.fleet/track/local-store.
     """
     from .store import (
-        ChainedSessionStore,
         LocalSessionStore,
-        NativeFilesSessionStore,
         RemoteSessionStore,
     )
 
     source = _normalize_source(source)
     paths = TrackPaths.default()
-    if source == "stub":
-        return LocalSessionStore(paths)
-    if source == "native":
-        return NativeFilesSessionStore()
     if source == "remote":
         return RemoteSessionStore()
-    if source in {LOCAL_SESSION_SOURCE, "auto"}:
-        # LocalSessionStore first so explicitly-ingested rows shadow native
-        # ones with the same id (e.g. forks re-stored after resume).
-        return ChainedSessionStore(
-            LocalSessionStore(paths),
-            NativeFilesSessionStore(),
-        )
+    if source == LOCAL_SESSION_SOURCE:
+        return LocalSessionStore(paths)
     raise typer.BadParameter(f"Unknown --source value: {source!r}")
 
 
 def _normalize_source(source: str) -> str:
-    return (source or DEFAULT_SESSION_SOURCE).strip().lower()
+    normalized = (source or DEFAULT_SESSION_SOURCE).strip().lower()
+    if normalized not in {DEFAULT_SESSION_SOURCE, LOCAL_SESSION_SOURCE}:
+        raise typer.BadParameter(
+            "Unknown --source value. Expected 'remote' or 'local'."
+        )
+    return normalized
 
 
 def _validate_cursor_for_source(source: str, cursor: str | None) -> None:
@@ -375,17 +365,7 @@ def list_sessions(
     byte-compatible with the orchestrator's `/v1/track/sessions` endpoint
     so scripting against either side uses the same opaque tokens.
     """
-    from .store import ChainedSessionStore
-
     store = _resolve_session_store(source)
-
-    # `--cursor` requires a single backing store; chained stores don't
-    # support pagination (see ChainedSessionStore.page).
-    if cursor and isinstance(store, ChainedSessionStore):
-        raise typer.BadParameter(
-            "--cursor requires --source native | stub | remote; `local` chains "
-            "multiple backends and can't paginate across them."
-        )
     _validate_cursor_for_source(source, cursor)
 
     sessions, next_cursor = store.page(
@@ -444,20 +424,13 @@ def search_sessions(
     """Search tracked sessions.
 
     With the default remote source, the query is forwarded to the orchestrator
-    search endpoint, which uses Turbopuffer. Use `--source local` for the old
-    on-disk substring search.
+    search endpoint, which uses Turbopuffer. Use `--source local` only after
+    manually building the dev/test local index.
     """
     if not query.strip():
         raise typer.BadParameter("query must not be empty")
 
-    from .store import ChainedSessionStore
-
     store = _resolve_session_store(source)
-    if cursor and isinstance(store, ChainedSessionStore):
-        raise typer.BadParameter(
-            "--cursor requires --source native | stub | remote; `local` chains "
-            "multiple backends and can't paginate across them."
-        )
     _validate_cursor_for_source(source, cursor)
 
     sessions, next_cursor = store.page(
@@ -483,6 +456,64 @@ def search_sessions(
         return
 
     _render_sessions_table(sessions, next_cursor)
+
+
+@app.command()
+def build_local_index(
+    replace: bool = typer.Option(
+        True,
+        "--replace/--append",
+        help="Replace the existing Fleet local index before scanning native files.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit JSON for scripting"),
+) -> None:
+    """Build the dev/test local index from native session files.
+
+    This is intentionally manual: normal Track commands use the remote source.
+    Local mode reads only this Fleet index and does not live-scan native files.
+    """
+    from .store import LocalSessionStore, NativeFilesSessionStore
+
+    paths = TrackPaths.default()
+    local_root = paths.track_dir / "local-store"
+    if replace and local_root.exists():
+        shutil.rmtree(local_root)
+
+    local = LocalSessionStore(paths)
+    native = NativeFilesSessionStore(home=paths.home)
+
+    indexed = 0
+    skipped = 0
+    cursor = None
+    while True:
+        sessions, next_cursor = native.page(limit=200, cursor=cursor)
+        for session in sessions:
+            try:
+                local.create(session, list(native.own_events(session.id)))
+            except Exception:
+                skipped += 1
+                continue
+            indexed += 1
+        if next_cursor is None:
+            break
+        cursor = next_cursor
+
+    payload = {
+        "source": LOCAL_SESSION_SOURCE,
+        "indexed": indexed,
+        "skipped": skipped,
+        "path": str(local_root),
+        "replace": replace,
+    }
+    if json_out:
+        console.print_json(json.dumps(payload))
+        return
+
+    console.print(
+        f"[green]Indexed[/green] {indexed} sessions into {local_root}"
+        + (f" [yellow]({skipped} skipped)[/yellow]" if skipped else "")
+    )
+    console.print("  Use [bold]--source local[/bold] to read this index.")
 
 
 @app.command()

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -922,30 +922,7 @@ class NativeFilesSessionStore:
         limit = _clamp_limit(limit)
         cur = _decode_cursor(cursor)
 
-        rows: list[Session] = []
-        for source, build_session in self._sources_with_session_builders():
-            if tool is not None and source.name != tool:
-                continue
-            if not source.is_present():
-                continue
-            for path in source.iter_files():
-                # Skip fleet checkouts; they're transient views, not
-                # native sessions, and would clutter the picker.
-                if _looks_like_fleet_checkout(path):
-                    continue
-                try:
-                    s = build_session(path)
-                except OSError:
-                    continue
-                if s is None:
-                    continue
-                if cwd is not None and s.cwd != cwd:
-                    continue
-                if since is not None and (s.last_active or "") < since:
-                    continue
-                if not _matches_query(s, query):
-                    continue
-                rows.append(s)
+        rows = list(self._iter_sessions(tool=tool, cwd=cwd, since=since, query=query))
 
         rows.sort(key=_sort_key, reverse=True)
         rows = [s for s in rows if _passes_cursor(s, cur)]
@@ -961,12 +938,15 @@ class NativeFilesSessionStore:
         return page, next_cursor
 
     def get(self, id: str) -> Optional[Session]:
-        # Two-pass: exact match, then unique prefix.
-        all_sessions = self.list()
-        for s in all_sessions:
+        # Exact match first, then unique prefix. This must scan all native
+        # sessions, not just the first list() page, because callers like
+        # build-local-index replay events for every paginated row.
+        matches: list[Session] = []
+        for s in self._iter_sessions():
             if s.id == id:
                 return s
-        matches = [s for s in all_sessions if s.id.startswith(id)]
+            if s.id.startswith(id):
+                matches.append(s)
         if len(matches) == 1:
             return matches[0]
         if len(matches) > 1:
@@ -1008,6 +988,38 @@ class NativeFilesSessionStore:
     # ------------------------------------------------------------------ #
     # Internals                                                            #
     # ------------------------------------------------------------------ #
+
+    def _iter_sessions(
+        self,
+        *,
+        tool: Optional[str] = None,
+        cwd: Optional[str] = None,
+        since: Optional[str] = None,
+        query: Optional[str] = None,
+    ) -> Iterator[Session]:
+        for source, build_session in self._sources_with_session_builders():
+            if tool is not None and source.name != tool:
+                continue
+            if not source.is_present():
+                continue
+            for path in source.iter_files():
+                # Skip fleet checkouts; they're transient views, not
+                # native sessions, and would clutter the picker.
+                if _looks_like_fleet_checkout(path):
+                    continue
+                try:
+                    s = build_session(path)
+                except OSError:
+                    continue
+                if s is None:
+                    continue
+                if cwd is not None and s.cwd != cwd:
+                    continue
+                if since is not None and (s.last_active or "") < since:
+                    continue
+                if not _matches_query(s, query):
+                    continue
+                yield s
 
     def _sources_with_session_builders(self):
         """Each tuple is (source_instance, fn(path)→Session|None)."""

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -237,3 +237,49 @@ def test_build_local_index_scans_native_files_into_local_store(tmp_path, monkeyp
     assert session is not None
     assert session.tool == "claude"
     assert list(local.own_events(sid))
+
+
+def test_build_local_index_indexes_native_sessions_past_first_page(
+    tmp_path, monkeypatch
+):
+    import os
+    import time
+
+    paths = TrackPaths.under(tmp_path)
+    monkeypatch.setattr(cli.TrackPaths, "default", lambda: paths)
+
+    native_dir = tmp_path / ".claude" / "projects" / "-tmp-project"
+    native_dir.mkdir(parents=True)
+    native_files = []
+    for i in range(60):
+        sid = f"00000000-0000-0000-0000-{i:012d}"
+        native_file = native_dir / f"{sid}.jsonl"
+        rows = [
+            {
+                "type": "user",
+                "uuid": f"u{i}",
+                "sessionId": sid,
+                "cwd": "/tmp/project",
+                "timestamp": "2026-05-01T00:00:00Z",
+                "message": {"role": "user", "content": f"hello {i}"},
+            }
+        ]
+        native_file.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+        native_files.append(native_file)
+
+    now = time.time()
+    for i, native_file in enumerate(native_files):
+        timestamp = now - i
+        os.utime(native_file, (timestamp, timestamp))
+
+    result = runner.invoke(cli.app, ["build-local-index", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["indexed"] == 60
+    assert payload["skipped"] == 0
+
+    target = "00000000-0000-0000-0000-000000000059"
+    local = LocalSessionStore(paths)
+    assert local.get(target) is not None
+    assert list(local.own_events(target))

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 from fleet.track import cli
 from fleet.track.api import TrackAPIError
 from fleet.track.paths import TrackPaths
-from fleet.track.store import ChainedSessionStore, RemoteSessionStore, Session
+from fleet.track.store import LocalSessionStore, RemoteSessionStore, Session
 
 
 runner = CliRunner()
@@ -63,14 +63,16 @@ def test_enable_persists_generated_device_id_before_provision_retry(
     )
 
 
-def test_resolve_session_store_defaults_remote_and_local_alias(tmp_path, monkeypatch):
+def test_resolve_session_store_only_accepts_remote_or_local(tmp_path, monkeypatch):
     paths = TrackPaths.under(tmp_path)
     monkeypatch.setattr(cli.TrackPaths, "default", lambda: paths)
 
     assert isinstance(cli._resolve_session_store("remote"), RemoteSessionStore)
     assert isinstance(cli._resolve_session_store(""), RemoteSessionStore)
-    assert isinstance(cli._resolve_session_store("local"), ChainedSessionStore)
-    assert isinstance(cli._resolve_session_store("auto"), ChainedSessionStore)
+    assert isinstance(cli._resolve_session_store("local"), LocalSessionStore)
+    for source in ("auto", "stub", "native"):
+        with pytest.raises(typer.BadParameter):
+            cli._resolve_session_store(source)
 
 
 def test_track_ls_defaults_remote_and_forwards_query(monkeypatch):
@@ -190,3 +192,48 @@ def test_track_search_emits_agent_friendly_json_and_passes_cursor(monkeypatch):
     assert payload["source"] == "remote"
     assert payload["query"] == "who worked on turbopuffer indexing"
     assert payload["items"][0]["metadata"]["title"] == "Turbopuffer indexing"
+
+
+def test_build_local_index_scans_native_files_into_local_store(tmp_path, monkeypatch):
+    paths = TrackPaths.under(tmp_path)
+    monkeypatch.setattr(cli.TrackPaths, "default", lambda: paths)
+
+    sid = "11111111-2222-3333-4444-555555555555"
+    native_dir = tmp_path / ".claude" / "projects" / "-tmp-project"
+    native_dir.mkdir(parents=True)
+    native_file = native_dir / f"{sid}.jsonl"
+    rows = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": sid,
+            "cwd": "/tmp/project",
+            "timestamp": "2026-05-01T00:00:00Z",
+            "message": {"role": "user", "content": "hello"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "parentUuid": "u1",
+            "timestamp": "2026-05-01T00:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}],
+            },
+        },
+    ]
+    native_file.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+    result = runner.invoke(cli.app, ["build-local-index", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["source"] == "local"
+    assert payload["indexed"] == 1
+    assert payload["skipped"] == 0
+
+    local = LocalSessionStore(paths)
+    session = local.get(sid)
+    assert session is not None
+    assert session.tool == "claude"
+    assert list(local.own_events(sid))

--- a/tests/track/test_picker_page.py
+++ b/tests/track/test_picker_page.py
@@ -50,7 +50,7 @@ def _state_for(
     query: str = "",
 ) -> dict:
     return {
-        "source": "stub",
+        "source": "local",
         "tool": None,
         "cwd": None,
         "since": None,

--- a/tests/track/test_store_native.py
+++ b/tests/track/test_store_native.py
@@ -32,14 +32,26 @@ def _seed_native_claude(home: Path, *, sid: str, encoded_cwd: str = "-tmp-x") ->
     f = base / f"{sid}.jsonl"
     rows = [
         # First row carries claude metadata so the parser synthesizes SessionStart.
-        {"type": "user", "uuid": "u1", "sessionId": sid, "cwd": "/tmp/x",
-         "gitBranch": "main", "version": "0.5",
-         "timestamp": "2026-04-30T00:00:00Z",
-         "message": {"role": "user", "content": "hi"}},
-        {"type": "assistant", "uuid": "a1", "parentUuid": "u1",
-         "timestamp": "2026-04-30T00:00:01Z",
-         "message": {"role": "assistant",
-                     "content": [{"type": "text", "text": "yo"}]}},
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": sid,
+            "cwd": "/tmp/x",
+            "gitBranch": "main",
+            "version": "0.5",
+            "timestamp": "2026-04-30T00:00:00Z",
+            "message": {"role": "user", "content": "hi"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "parentUuid": "u1",
+            "timestamp": "2026-04-30T00:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "yo"}],
+            },
+        },
     ]
     f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
     return f
@@ -50,12 +62,25 @@ def _seed_native_codex(home: Path, *, sid: str, cwd: str = "/tmp/y") -> Path:
     base.mkdir(parents=True, exist_ok=True)
     f = base / f"rollout-2026-05-01T00-00-00-{sid}.jsonl"
     rows = [
-        {"timestamp": "2026-05-01T00:00:00Z", "type": "session_meta",
-         "payload": {"id": sid, "cwd": cwd, "cli_version": "0.5",
-                     "base_instructions": {"text": "you are codex"}}},
-        {"timestamp": "2026-05-01T00:00:01Z", "type": "response_item",
-         "payload": {"type": "message", "role": "user",
-                     "content": [{"type": "input_text", "text": "first"}]}},
+        {
+            "timestamp": "2026-05-01T00:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": sid,
+                "cwd": cwd,
+                "cli_version": "0.5",
+                "base_instructions": {"text": "you are codex"},
+            },
+        },
+        {
+            "timestamp": "2026-05-01T00:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "first"}],
+            },
+        },
     ]
     f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
     return f
@@ -104,11 +129,17 @@ def test_native_store_skips_fleet_checkouts(tmp_path: Path):
     sid = "11111111-1111-1111-1111-111111111111"
     f = base / f"{sid}.jsonl"
     rows = [
-        {"_fleet_meta": {"forked_from": "src", "fork_point": 0,
-                         "ephemeral_id": sid, "target_tool": "claude"},
-         "type": "system", "content": "fleet checkout"},
-        {"type": "user", "uuid": "u1",
-         "message": {"role": "user", "content": "hi"}},
+        {
+            "_fleet_meta": {
+                "forked_from": "src",
+                "fork_point": 0,
+                "ephemeral_id": sid,
+                "target_tool": "claude",
+            },
+            "type": "system",
+            "content": "fleet checkout",
+        },
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hi"}},
     ]
     f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
     store = NativeFilesSessionStore(home=tmp_path)
@@ -121,8 +152,12 @@ def test_native_store_skips_non_uuid_filenames(tmp_path: Path):
     base = tmp_path / ".claude" / "projects" / "-tmp-x"
     base.mkdir(parents=True)
     f = base / "agent-not-a-uuid.jsonl"
-    f.write_text(json.dumps({"type": "user", "uuid": "u1",
-                             "message": {"role": "user", "content": "hi"}}) + "\n")
+    f.write_text(
+        json.dumps(
+            {"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hi"}}
+        )
+        + "\n"
+    )
     store = NativeFilesSessionStore(home=tmp_path)
     assert store.list() == []
 
@@ -133,6 +168,30 @@ def test_native_store_get_by_prefix(tmp_path: Path):
     s = store.get("abcdef01")
     assert s is not None
     assert s.id == "abcdef01-2345-6789-abcd-ef0123456789"
+
+
+def test_native_store_get_and_events_scan_past_default_first_page(tmp_path: Path):
+    import os
+    import time
+
+    paths: list[Path] = []
+    for i in range(60):
+        sid = f"00000000-0000-0000-0000-{i:012d}"
+        paths.append(_seed_native_claude(tmp_path, sid=sid, encoded_cwd=f"-tmp-{i}"))
+
+    now = time.time()
+    for i, path in enumerate(paths):
+        timestamp = now - i
+        os.utime(path, (timestamp, timestamp))
+
+    target = "00000000-0000-0000-0000-000000000059"
+    store = NativeFilesSessionStore(home=tmp_path)
+
+    assert target not in {session.id for session in store.list()}
+    session = store.get(target)
+    assert session is not None
+    assert session.id == target
+    assert any(event.type == "user_message" for event in store.events(target))
 
 
 def test_native_store_get_missing_returns_none(tmp_path: Path):
@@ -165,12 +224,16 @@ def test_native_store_is_read_only(tmp_path: Path):
 def test_native_store_list_recency_sorted(tmp_path: Path):
     """Most-recent-first sort is what the picker shows."""
     import time
-    a = _seed_native_claude(tmp_path, sid="11111111-1111-1111-1111-111111111111",
-                            encoded_cwd="-tmp-a")
-    b = _seed_native_claude(tmp_path, sid="22222222-2222-2222-2222-222222222222",
-                            encoded_cwd="-tmp-b")
+
+    a = _seed_native_claude(
+        tmp_path, sid="11111111-1111-1111-1111-111111111111", encoded_cwd="-tmp-a"
+    )
+    b = _seed_native_claude(
+        tmp_path, sid="22222222-2222-2222-2222-222222222222", encoded_cwd="-tmp-b"
+    )
     # Bump b's mtime forward.
     import os
+
     fresh = time.time()
     os.utime(b, (fresh, fresh))
     os.utime(a, (fresh - 3600, fresh - 3600))
@@ -196,8 +259,7 @@ def test_chained_lists_union_deduped_by_id(tmp_path: Path):
 
     # Native: two sessions
     _seed_native_claude(tmp_path, sid=sid_overlap)
-    _seed_native_claude(tmp_path, sid=sid_native_only,
-                        encoded_cwd="-tmp-other")
+    _seed_native_claude(tmp_path, sid=sid_native_only, encoded_cwd="-tmp-other")
     # Local: one of those (overlapping id; first-store-wins).
     # The store recomputes event_count from the events list, so just
     # use cwd as the discriminator.
@@ -275,8 +337,9 @@ def test_chained_fork_chain_resolves_across_stores(tmp_path: Path):
     _seed_native_claude(tmp_path, sid=parent_id)
     # Child stored in local, fork-pointing at parent in native.
     local.create(
-        Session(id="child-of-native", tool="codex",
-                forked_from=parent_id, fork_point=2),
+        Session(
+            id="child-of-native", tool="codex", forked_from=parent_id, fork_point=2
+        ),
         [UserMessage(source="codex", text="child-1")],
     )
     chained = ChainedSessionStore(local, NativeFilesSessionStore(home=tmp_path))
@@ -304,8 +367,10 @@ def test_chained_fork_chain_in_same_local_store_does_not_duplicate(tmp_path: Pat
     )
     local.create(
         Session(id="child", tool="claude", forked_from="root", fork_point=2),
-        [UserMessage(source="claude", text="c0"),
-         UserMessage(source="claude", text="c1")],
+        [
+            UserMessage(source="claude", text="c0"),
+            UserMessage(source="claude", text="c1"),
+        ],
     )
     chained = ChainedSessionStore(local)
 


### PR DESCRIPTION
## Summary
- reduce public Track CLI sources to `remote` and `local` only
- make `local` read only the Fleet local index under `~/.fleet/track/local-store` instead of live-scanning native files
- add manual `flt track build-local-index` for dev/test local indexing from native session files

Stacked on #106.

## Tests
- `uv run --extra dev ruff check fleet/track/cli.py fleet/track/_picker_page.py tests/track/test_cli.py tests/track/test_picker_page.py`
- `uv run --extra dev ruff format --check fleet/track/cli.py fleet/track/_picker_page.py tests/track/test_cli.py tests/track/test_picker_page.py`
- `uv run --extra dev pytest tests/track`
- `uv run --extra dev flt track ls --help`
- `uv run --extra dev flt track search --help`
- `uv run --extra dev flt track build-local-index --help`