### PR TITLE
Add raw Turbopuffer track search CLI

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -63,10 +63,19 @@ flt track resume
 flt track gc
 ```
 
-### Agent Search
+### Search
 
-`flt track search <query>` emits JSON by default for agent workflows. For
-structured search, agents can pass a Turbopuffer-shaped JSON body through
+`flt track ls` lists deterministic session metadata from the orchestrator's
+Postgres store. `flt track search` is Turbopuffer-only and emits JSON by default
+for agent workflows.
+
+Simple query mode sends the query to the orchestrator-managed hybrid index:
+
+```bash
+flt track search "bugbot local index"
+```
+
+For structured search, agents can pass a Turbopuffer-shaped JSON body through
 orchestrator:
 
 ```bash

--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -58,9 +58,26 @@ flt track status
 flt track daemon --once
 flt track logs
 flt track ls
+flt track search
 flt track resume
 flt track gc
 ```
+
+### Agent Search
+
+`flt track search <query>` emits JSON by default for agent workflows. For
+structured search, agents can pass a Turbopuffer-shaped JSON body through
+orchestrator:
+
+```bash
+flt track search --tpuf '{"query":"bugbot local index","top_k":20}'
+flt track search --tpuf @search.json
+flt track search --tpuf -
+```
+
+The raw body supports `query`, `rank_by`, `filters`, and `top_k`, matching
+`POST /v1/track/sessions/search`. Orchestrator injects the team boundary and
+hydrates the ranked results back to Fleet session metadata.
 
 ## Design Notes
 

--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -79,6 +79,31 @@ The raw body supports `query`, `rank_by`, `filters`, and `top_k`, matching
 `POST /v1/track/sessions/search`. Orchestrator injects the team boundary and
 hydrates the ranked results back to Fleet session metadata.
 
+Filterable attributes are:
+
+```text
+session_id, user_id, device_id, tool, cwd, repo_url, git_branch, model,
+forked_from, event_count, started_at, last_active
+```
+
+`team_id` is always injected by orchestrator. Filters use Turbopuffer filter
+arrays, for example:
+
+```json
+{
+  "query": "deployment debugging",
+  "filters": [
+    "And",
+    [
+      ["repo_url", "Eq", "git@github.com:fleet-ai/theseus.git"],
+      ["tool", "Eq", "codex"],
+      ["last_active", "Gte", "2026-05-01T00:00:00Z"]
+    ]
+  ],
+  "top_k": 25
+}
+```
+
 ## Design Notes
 
 - Raw native session files remain the restore source of truth.

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -8,6 +8,7 @@ Upload endpoints:
 Metadata endpoints:
   POST /v1/track/sessions/{id}         → upsert one session metadata row
   GET  /v1/track/sessions              → list/search remote sessions
+  POST /v1/track/sessions/search       → raw Turbopuffer-shaped search
   GET  /v1/track/sessions/{id}         → fetch one session metadata row
   GET  /v1/track/sessions/{id}/content → get a presigned S3 GET URL
 
@@ -187,6 +188,22 @@ class TrackAPIClient:
         resp = self._client.get(
             "/v1/track/sessions",
             params=params,
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
+    def search_sessions_raw(self, body: Mapping[str, Any]) -> dict:
+        """Run agent-facing raw Turbopuffer-shaped session search.
+
+        The body is forwarded to orchestrator's
+        `POST /v1/track/sessions/search`. Orchestrator owns auth, team-scope
+        wrapping, server-side embeddings for `query`, and hydration back to
+        Fleet session metadata.
+        """
+        resp = self._client.post(
+            "/v1/track/sessions/search",
+            json=dict(body),
             headers=self._headers(),
         )
         _raise(resp)

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -479,6 +479,16 @@ def search_sessions(
     and returns hydrated Fleet session metadata.
 
     \b
+    Filterable attributes:
+
+      session_id, user_id, device_id, tool, cwd, repo_url, git_branch,
+      model, forked_from, event_count, started_at, last_active
+
+    `team_id` is always injected by orchestrator. Use Turbopuffer filter arrays,
+    for example ["tool","Eq","codex"], ["last_active","Gte","2026-05-01T00:00:00Z"],
+    or ["And",[[...],[...]]].
+
+    \b
     Example raw filter body:
 
       {"query":"deployment debugging",

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sys
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -288,17 +290,39 @@ def _print_sessions_json(
     source: str,
     sessions,
     next_cursor: str | None,
+    mode: str | None = None,
 ) -> None:
-    console.print_json(
-        json.dumps(
-            {
-                "query": query,
-                "source": _normalize_source(source),
-                "items": _session_dicts(sessions),
-                "next_cursor": next_cursor,
-            }
-        )
-    )
+    payload = {
+        "query": query,
+        "source": _normalize_source(source),
+        "items": _session_dicts(sessions),
+        "next_cursor": next_cursor,
+    }
+    if mode is not None:
+        payload["mode"] = mode
+    console.print_json(json.dumps(payload))
+
+
+def _read_json_argument(value: str) -> dict:
+    """Read an inline JSON object, @file JSON object, or stdin JSON object."""
+    raw = value
+    if value == "-":
+        raw = sys.stdin.read()
+    elif value.startswith("@"):
+        raw = Path(value[1:]).read_text()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise typer.BadParameter(f"invalid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter("--tpuf must be a JSON object")
+    return parsed
+
+
+def _sessions_from_api_items(items: list[dict]):
+    from .store import _session_from_api
+
+    return [_session_from_api(item) for item in items]
 
 
 def _render_sessions_table(sessions, next_cursor: str | None) -> None:
@@ -396,7 +420,10 @@ def list_sessions(
 
 @app.command(name="search")
 def search_sessions(
-    query: str = typer.Argument(..., help="Search query to send to the session index"),
+    query: str | None = typer.Argument(
+        None,
+        help="Natural-language query to send to the session index. Omit when using --tpuf.",
+    ),
     tool: str = typer.Option(
         None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"
     ),
@@ -409,6 +436,16 @@ def search_sessions(
         None,
         "--cursor",
         help="Opaque cursor from a prior search response.",
+    ),
+    tpuf: str = typer.Option(
+        None,
+        "--tpuf",
+        "--raw-tpuf",
+        help=(
+            "Agent mode: POST Turbopuffer-shaped JSON to orchestrator. "
+            "Pass inline JSON, @file, or - for stdin. Supports query, rank_by, "
+            "filters, top_k."
+        ),
     ),
     json_out: bool = typer.Option(
         True,
@@ -426,8 +463,64 @@ def search_sessions(
     With the default remote source, the query is forwarded to the orchestrator
     search endpoint, which uses Turbopuffer. Use `--source local` only after
     manually building the dev/test local index.
+
+    \b
+    Agent raw mode:
+
+      flt track search --tpuf '{"query":"bugbot local index","top_k":20}'
+      flt track search --tpuf @search.json
+      flt track search --tpuf -
+
+    Raw mode sends a JSON object to `POST /v1/track/sessions/search`.
+    Supported fields are `query`, `rank_by`, `filters`, and `top_k`.
+    `query` runs orchestrator-managed hybrid search: BM25 over `search_text`
+    plus ANN over `vector`. `rank_by` and `filters` are forwarded in
+    Turbopuffer shape. The server always injects the caller's team boundary
+    and returns hydrated Fleet session metadata.
+
+    \b
+    Example raw filter body:
+
+      {"query":"deployment debugging",
+       "filters":["And",[["repo_url","Eq","git@github.com:fleet-ai/theseus.git"],
+                         ["tool","Eq","codex"]]],
+       "top_k":25}
     """
-    if not query.strip():
+    if tpuf is not None:
+        if _normalize_source(source) != "remote":
+            raise typer.BadParameter("--tpuf requires --source remote")
+        if cursor:
+            raise typer.BadParameter("--cursor is not supported with --tpuf")
+        if any(value is not None for value in (tool, cwd, since)):
+            raise typer.BadParameter(
+                "--tool, --cwd, and --since are not applied with --tpuf; "
+                "put structured filters in the JSON body"
+            )
+
+        body = _read_json_argument(tpuf)
+        body.setdefault("top_k", limit)
+        if query is not None and "query" not in body and "rank_by" not in body:
+            body["query"] = query
+
+        data = TrackAPIClient().search_sessions_raw(body)
+        sessions = _sessions_from_api_items(data.get("items", []))
+        next_cursor = data.get("next_cursor")
+        if json_out:
+            _print_sessions_json(
+                query=body.get("query") if isinstance(body.get("query"), str) else None,
+                source=source,
+                sessions=sessions,
+                next_cursor=next_cursor,
+                mode="tpuf",
+            )
+            return
+        if not sessions:
+            console.print("[dim]No sessions found.[/dim]")
+            return
+        _render_sessions_table(sessions, next_cursor)
+        return
+
+    if query is None or not query.strip():
         raise typer.BadParameter("query must not be empty")
 
     store = _resolve_session_store(source)

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -370,7 +370,7 @@ def list_sessions(
         None,
         "--query",
         "-q",
-        help="Search remote sessions. With --source remote, forwards the query to the server search index.",
+        help="Substring filter over session metadata (id/tool/cwd/title).",
     ),
     json_out: bool = typer.Option(False, "--json", help="Emit JSON for scripting"),
     source: str = typer.Option(
@@ -422,29 +422,21 @@ def list_sessions(
 def search_sessions(
     query: str | None = typer.Argument(
         None,
-        help="Natural-language query to send to the session index. Omit when using --tpuf.",
+        help="Natural-language query to send to Turbopuffer. Omit when using --tpuf.",
     ),
-    tool: str = typer.Option(
-        None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"
-    ),
-    cwd: str = typer.Option(None, "--cwd", help="Filter by working directory"),
-    since: str = typer.Option(
-        None, "--since", help="Only sessions active since (ISO-8601)"
-    ),
-    limit: int = typer.Option(50, "--limit", "-n", help="Max rows per page (1..200)"),
-    cursor: str = typer.Option(
-        None,
-        "--cursor",
-        help="Opaque cursor from a prior search response.",
+    limit: int = typer.Option(
+        50,
+        "--limit",
+        "-n",
+        help="Default top_k for the Turbopuffer request when --tpuf omits top_k.",
     ),
     tpuf: str = typer.Option(
         None,
         "--tpuf",
         "--raw-tpuf",
         help=(
-            "Agent mode: POST Turbopuffer-shaped JSON to orchestrator. "
-            "Pass inline JSON, @file, or - for stdin. Supports query, rank_by, "
-            "filters, top_k."
+            "POST a Turbopuffer-shaped JSON search body to orchestrator. "
+            "Pass inline JSON, @file, or - for stdin."
         ),
     ),
     json_out: bool = typer.Option(
@@ -452,26 +444,25 @@ def search_sessions(
         "--json/--table",
         help="Emit agent-friendly JSON by default; use --table for a human table.",
     ),
-    source: str = typer.Option(
-        DEFAULT_SESSION_SOURCE,
-        "--source",
-        help=SOURCE_HELP,
-    ),
 ) -> None:
     """Search tracked sessions.
 
-    With the default remote source, the query is forwarded to the orchestrator
-    search endpoint, which uses Turbopuffer. Use `--source local` only after
-    manually building the dev/test local index.
+    Search is Turbopuffer-only. `flt track ls` lists deterministic session
+    metadata from Postgres; `flt track search` asks the search index for ranked
+    results and returns hydrated Fleet session metadata.
 
     \b
-    Agent raw mode:
+    Simple query mode:
+
+      flt track search "bugbot local index"
+
+    Structured agent mode:
 
       flt track search --tpuf '{"query":"bugbot local index","top_k":20}'
       flt track search --tpuf @search.json
       flt track search --tpuf -
 
-    Raw mode sends a JSON object to `POST /v1/track/sessions/search`.
+    Both modes send a JSON object to `POST /v1/track/sessions/search`.
     Supported fields are `query`, `rank_by`, `filters`, and `top_k`.
     `query` runs orchestrator-managed hybrid search: BM25 over `search_text`
     plus ANN over `vector`. `rank_by` and `filters` are forwarded in
@@ -496,61 +487,29 @@ def search_sessions(
                          ["tool","Eq","codex"]]],
        "top_k":25}
     """
-    if tpuf is not None:
-        if _normalize_source(source) != "remote":
-            raise typer.BadParameter("--tpuf requires --source remote")
-        if cursor:
-            raise typer.BadParameter("--cursor is not supported with --tpuf")
-        if any(value is not None for value in (tool, cwd, since)):
+    if tpuf is None:
+        if query is None or not query.strip():
             raise typer.BadParameter(
-                "--tool, --cwd, and --since are not applied with --tpuf; "
-                "put structured filters in the JSON body"
+                "query must not be empty unless --tpuf is provided"
             )
-
+        body = {"query": query}
+    else:
         body = _read_json_argument(tpuf)
-        body.setdefault("top_k", limit)
         if query is not None and "query" not in body and "rank_by" not in body:
             body["query"] = query
 
-        data = TrackAPIClient().search_sessions_raw(body)
-        sessions = _sessions_from_api_items(data.get("items", []))
-        next_cursor = data.get("next_cursor")
-        if json_out:
-            _print_sessions_json(
-                query=body.get("query") if isinstance(body.get("query"), str) else None,
-                source=source,
-                sessions=sessions,
-                next_cursor=next_cursor,
-                mode="tpuf",
-            )
-            return
-        if not sessions:
-            console.print("[dim]No sessions found.[/dim]")
-            return
-        _render_sessions_table(sessions, next_cursor)
-        return
-
-    if query is None or not query.strip():
-        raise typer.BadParameter("query must not be empty")
-
-    store = _resolve_session_store(source)
-    _validate_cursor_for_source(source, cursor)
-
-    sessions, next_cursor = store.page(
-        tool=tool,
-        cwd=cwd,
-        since=since,
-        query=query,
-        limit=limit,
-        cursor=cursor,
-    )
+    body.setdefault("top_k", limit)
+    data = TrackAPIClient().search_sessions_raw(body)
+    sessions = _sessions_from_api_items(data.get("items", []))
+    next_cursor = data.get("next_cursor")
 
     if json_out:
         _print_sessions_json(
-            query=query,
-            source=source,
+            query=body.get("query") if isinstance(body.get("query"), str) else None,
+            source="remote",
             sessions=sessions,
             next_cursor=next_cursor,
+            mode="tpuf",
         )
         return
 

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -187,6 +187,48 @@ def test_list_sessions_sends_filters_and_returns_json():
     assert out["next_cursor"] == "next"
 
 
+def test_search_sessions_raw_posts_turbopuffer_body_and_returns_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": "s1",
+                        "tool": "codex",
+                        "last_active": "2026-05-05T00:00:00Z",
+                    }
+                ],
+                "next_cursor": None,
+            },
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.search_sessions_raw(
+        {
+            "query": "bugbot local index",
+            "filters": [
+                "And",
+                [["repo_url", "Eq", "git@github.com:fleet-ai/fleet-sdk.git"]],
+            ],
+            "top_k": 10,
+        }
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://test/v1/track/sessions/search"
+    assert captured["headers"]["authorization"] == "Bearer test-api-key"
+    assert captured["body"]["query"] == "bugbot local index"
+    assert captured["body"]["top_k"] == 10
+    assert out["items"][0]["id"] == "s1"
+
+
 def test_download_session_content_uses_presigned_url_without_auth_headers():
     seen: list[tuple[str, str | None]] = []
 

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -142,56 +142,100 @@ def test_track_ls_honors_explicit_local_source(monkeypatch):
     assert json.loads(result.stdout)["source"] == "local"
 
 
-def test_track_search_emits_agent_friendly_json_and_passes_cursor(monkeypatch):
+def test_track_search_posts_simple_query_to_raw_remote_search(monkeypatch):
     calls: list[dict] = []
 
-    class FakeStore:
-        def page(self, **kwargs):
-            calls.append(kwargs)
-            return (
-                [
-                    Session(
-                        id="session-2",
-                        tool="claude",
-                        cwd="/theseus",
-                        last_active="2026-05-06T00:00:00Z",
-                        metadata={"title": "Turbopuffer indexing"},
-                    )
+    class FakeAPI:
+        def search_sessions_raw(self, body):
+            calls.append(body)
+            return {
+                "items": [
+                    {
+                        "id": "session-2",
+                        "tool": "claude",
+                        "cwd": "/theseus",
+                        "last_active": "2026-05-06T00:00:00Z",
+                        "metadata": {"title": "Turbopuffer indexing"},
+                    }
                 ],
-                None,
-            )
+                "next_cursor": None,
+            }
 
-    monkeypatch.setattr(cli, "_resolve_session_store", lambda source: FakeStore())
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
 
     result = runner.invoke(
         cli.app,
         [
             "search",
             "who worked on turbopuffer indexing",
-            "--tool",
-            "claude",
             "--limit",
             "5",
-            "--cursor",
-            "opaque-tpuf-cursor",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == [{"query": "who worked on turbopuffer indexing", "top_k": 5}]
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "tpuf"
+    assert payload["source"] == "remote"
+    assert payload["query"] == "who worked on turbopuffer indexing"
+    assert payload["items"][0]["metadata"]["title"] == "Turbopuffer indexing"
+
+
+def test_track_search_requires_query_without_tpuf(monkeypatch):
+    class FakeAPI:
+        def search_sessions_raw(self, body):  # pragma: no cover - must not call
+            raise AssertionError("unexpected API call")
+
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
+
+    result = runner.invoke(cli.app, ["search"])
+
+    assert result.exit_code != 0
+    assert "query must not be empty unless --tpuf is provided" in (
+        result.stdout + result.stderr
+    )
+
+
+def test_track_search_tpuf_still_accepts_positional_query(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeAPI:
+        def search_sessions_raw(self, body):
+            calls.append(body)
+            return {
+                "items": [
+                    {
+                        "id": "session-2",
+                        "tool": "claude",
+                        "cwd": "/theseus",
+                        "last_active": "2026-05-06T00:00:00Z",
+                        "metadata": {"title": "Turbopuffer indexing"},
+                    }
+                ],
+                "next_cursor": None,
+            }
+
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "search",
+            "who worked on turbopuffer indexing",
+            "--tpuf",
+            json.dumps({"filters": ["tool", "Eq", "claude"]}),
         ],
     )
 
     assert result.exit_code == 0, result.stdout
     assert calls == [
         {
-            "tool": "claude",
-            "cwd": None,
-            "since": None,
             "query": "who worked on turbopuffer indexing",
-            "limit": 5,
-            "cursor": "opaque-tpuf-cursor",
+            "filters": ["tool", "Eq", "claude"],
+            "top_k": 50,
         }
     ]
-    payload = json.loads(result.stdout)
-    assert payload["source"] == "remote"
-    assert payload["query"] == "who worked on turbopuffer indexing"
-    assert payload["items"][0]["metadata"]["title"] == "Turbopuffer indexing"
 
 
 def test_track_search_tpuf_posts_json_file_to_remote_api(tmp_path, monkeypatch):
@@ -264,32 +308,6 @@ def test_track_search_tpuf_applies_limit_as_default_top_k(monkeypatch):
     assert calls == [{"rank_by": ["last_active", "desc"], "top_k": 25}]
 
 
-def test_track_search_tpuf_rejects_local_source_and_legacy_filters(monkeypatch):
-    class FakeAPI:
-        def search_sessions_raw(self, body):  # pragma: no cover - must not call
-            raise AssertionError("unexpected API call")
-
-    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
-
-    local_result = runner.invoke(
-        cli.app,
-        ["search", "--source", "local", "--tpuf", json.dumps({"query": "x"})],
-    )
-    assert local_result.exit_code != 0
-    assert "--tpuf requires --source remote" in (
-        local_result.stdout + local_result.stderr
-    )
-
-    flag_result = runner.invoke(
-        cli.app,
-        ["search", "--tool", "codex", "--tpuf", json.dumps({"query": "x"})],
-    )
-    assert flag_result.exit_code != 0
-    assert "structured filters in the JSON body" in (
-        flag_result.stdout + flag_result.stderr
-    )
-
-
 def test_track_search_help_documents_agent_tpuf_mode():
     result = runner.invoke(cli.app, ["search", "--help"])
 
@@ -303,6 +321,11 @@ def test_track_search_help_documents_agent_tpuf_mode():
     assert "last_active" in result.stdout
     assert "event_count" in result.stdout
     assert "team_id" in result.stdout
+    assert "--tool" not in result.stdout
+    assert "--cwd" not in result.stdout
+    assert "--since" not in result.stdout
+    assert "--cursor" not in result.stdout
+    assert "--source" not in result.stdout
 
 
 def test_build_local_index_scans_native_files_into_local_store(tmp_path, monkeypatch):

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -298,6 +298,11 @@ def test_track_search_help_documents_agent_tpuf_mode():
     assert "Turbopuffer-shaped JSON" in result.stdout
     assert "rank_by" in result.stdout
     assert "filters" in result.stdout
+    assert "Filterable attributes" in result.stdout
+    assert "repo_url" in result.stdout
+    assert "last_active" in result.stdout
+    assert "event_count" in result.stdout
+    assert "team_id" in result.stdout
 
 
 def test_build_local_index_scans_native_files_into_local_store(tmp_path, monkeypatch):

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -194,6 +194,112 @@ def test_track_search_emits_agent_friendly_json_and_passes_cursor(monkeypatch):
     assert payload["items"][0]["metadata"]["title"] == "Turbopuffer indexing"
 
 
+def test_track_search_tpuf_posts_json_file_to_remote_api(tmp_path, monkeypatch):
+    calls: list[dict] = []
+    spec = {
+        "query": "bugbot local index",
+        "filters": [
+            "And",
+            [
+                ["repo_url", "Eq", "git@github.com:fleet-ai/fleet-sdk.git"],
+                ["tool", "Eq", "codex"],
+            ],
+        ],
+        "top_k": 10,
+    }
+    spec_path = tmp_path / "search.json"
+    spec_path.write_text(json.dumps(spec))
+
+    class FakeAPI:
+        def search_sessions_raw(self, body):
+            calls.append(body)
+            return {
+                "items": [
+                    {
+                        "id": "session-raw",
+                        "tool": "codex",
+                        "cwd": "/repo",
+                        "last_active": "2026-05-06T00:00:00Z",
+                        "metadata": {"title": "Raw search"},
+                    }
+                ],
+                "next_cursor": None,
+            }
+
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
+
+    result = runner.invoke(cli.app, ["search", "--tpuf", f"@{spec_path}"])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == [spec]
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "tpuf"
+    assert payload["source"] == "remote"
+    assert payload["query"] == "bugbot local index"
+    assert payload["items"][0]["id"] == "session-raw"
+
+
+def test_track_search_tpuf_applies_limit_as_default_top_k(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeAPI:
+        def search_sessions_raw(self, body):
+            calls.append(body)
+            return {"items": [], "next_cursor": None}
+
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "search",
+            "--tpuf",
+            json.dumps({"rank_by": ["last_active", "desc"]}),
+            "--limit",
+            "25",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == [{"rank_by": ["last_active", "desc"], "top_k": 25}]
+
+
+def test_track_search_tpuf_rejects_local_source_and_legacy_filters(monkeypatch):
+    class FakeAPI:
+        def search_sessions_raw(self, body):  # pragma: no cover - must not call
+            raise AssertionError("unexpected API call")
+
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
+
+    local_result = runner.invoke(
+        cli.app,
+        ["search", "--source", "local", "--tpuf", json.dumps({"query": "x"})],
+    )
+    assert local_result.exit_code != 0
+    assert "--tpuf requires --source remote" in (
+        local_result.stdout + local_result.stderr
+    )
+
+    flag_result = runner.invoke(
+        cli.app,
+        ["search", "--tool", "codex", "--tpuf", json.dumps({"query": "x"})],
+    )
+    assert flag_result.exit_code != 0
+    assert "structured filters in the JSON body" in (
+        flag_result.stdout + flag_result.stderr
+    )
+
+
+def test_track_search_help_documents_agent_tpuf_mode():
+    result = runner.invoke(cli.app, ["search", "--help"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "--tpuf" in result.stdout
+    assert "Turbopuffer-shaped JSON" in result.stdout
+    assert "rank_by" in result.stdout
+    assert "filters" in result.stdout
+
+
 def test_build_local_index_scans_native_files_into_local_store(tmp_path, monkeypatch):
     paths = TrackPaths.under(tmp_path)
     monkeypatch.setattr(cli.TrackPaths, "default", lambda: paths)


### PR DESCRIPTION
## Summary
- add TrackAPIClient.search_sessions_raw for POST /v1/track/sessions/search
- add `flt track search --tpuf/--raw-tpuf` for agent-facing Turbopuffer-shaped JSON search bodies
- document inline JSON, @file, and stdin usage in CLI help and FleetTrack docs

Depends on the orchestrator raw search endpoint in fleet-ai/theseus branch `track-raw-filter-search`.

## Tests
- `uv run --extra dev ruff check fleet/track/api.py fleet/track/cli.py tests/track/test_api.py tests/track/test_cli.py`
- `uv run --extra dev ruff format --check fleet/track/api.py fleet/track/cli.py tests/track/test_api.py tests/track/test_cli.py`
- `uv run --extra dev pytest tests/track/test_api.py tests/track/test_cli.py`
- `uv run --extra dev flt track search --help`
- `uv run --extra dev pytest tests/track`