### PR TITLE
Fix remote track resume behavior

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -8,8 +8,6 @@ resuming them locally or across tools.
 The SDK scans:
 
 - `~/.claude/projects/**/*.jsonl`
-- `~/.cursor/projects/**/agent-transcripts/**/*.jsonl`
-- `~/.cursor/projects/**/agent-transcripts/**/*.txt`
 - `~/.codex/sessions/**/*.jsonl`
 - `~/.codex/archived_sessions/**/*.jsonl`
 
@@ -40,9 +38,12 @@ fleet-track-sessions/
   {team_id}/{user_id}/{device_id}/
     manifest.json
     raw/.claude/projects/...
-    raw/.cursor/projects/...
     raw/.codex/sessions/...
 ```
+
+Cursor transcript syncing is intentionally disabled for now. `CursorSource`
+still exists for future parser work, but Cursor files are not included in the
+default daemon scan until the SDK can extract stable metadata and replay events.
 
 Authentication uses `FLEET_API_KEY`. Track requires an API key that resolves to
 a concrete Fleet profile so orchestrator can isolate uploaded sessions by

--- a/docs/fleet-track/goals.md
+++ b/docs/fleet-track/goals.md
@@ -6,7 +6,9 @@ FleetTrack now has a usable v1 product path:
 
 - API-key authentication through `FLEET_API_KEY`.
 - `flt track enable/status/daemon/logs/ls/resume/gc`.
-- Local source discovery for Claude, Codex, and Cursor.
+- Local source discovery for Claude and Codex. Cursor discovery code exists, but
+  default syncing is disabled until metadata extraction and event replay are
+  implemented.
 - Periodic full reconciliation into a SQLite upload queue.
 - Scrubbed whole-file uploads to S3 through orchestrator-issued presigned URLs.
 - Remote session metadata indexing for listing/search/resume.

--- a/fleet/track/__init__.py
+++ b/fleet/track/__init__.py
@@ -2,14 +2,13 @@
 
 This package handles three things:
 
-  1. **Sync** local AI session files (claude, codex, cursor, opencode)
+  1. **Sync** local AI session files (claude, codex)
      to a backing store (LocalSessionStore locally; RemoteSessionStore
      against orchestrator).
   2. **Convert** between session formats via a unified Event model so
      a session written by one CLI can be resumed in another.
-  3. **Resume** sessions — same-tool (passes through to the native CLI)
-     or cross-tool (converts via unified, drops a checkout file the
-     target CLI's resume scan finds).
+  3. **Resume** sessions — same-tool native when the file exists locally,
+     or via a Fleet checkout when conversion/materialization is needed.
 
 The public surface below is what consumers should import. Internals
 (parsers, daemon plumbing, CLI commands) live in submodules and aren't

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -48,7 +48,7 @@ SEARCH_FILTER_FIELDS = (
     {
         "name": "tool",
         "type": "string",
-        "description": "AI tool name, for example codex, claude, cursor, or opencode.",
+        "description": "AI tool name, for example codex or claude.",
     },
     {
         "name": "cwd",
@@ -183,7 +183,7 @@ def enable() -> None:
     found = [s for s in sources if s.is_present()]
     if not found:
         console.print(
-            "[yellow]No AI tool sessions found[/yellow] (~/.claude, ~/.cursor, ~/.codex)"
+            "[yellow]No AI tool sessions found[/yellow] (~/.claude, ~/.codex)"
         )
     else:
         for s in found:
@@ -486,7 +486,7 @@ def _render_sessions_table(sessions, next_cursor: str | None) -> None:
 @app.command(name="ls")
 def list_sessions(
     tool: str = typer.Option(
-        None, "--tool", "-t", help="Filter by tool (claude/codex/cursor/opencode)"
+        None, "--tool", "-t", help="Filter by tool (claude/codex)"
     ),
     cwd: str = typer.Option(None, "--cwd", help="Filter by working directory"),
     since: str = typer.Option(
@@ -815,7 +815,7 @@ def resume(
             if not available:
                 console.print(
                     "[red]No supported AI CLIs found on PATH.[/red] "
-                    "Install one of: claude, codex, cursor, opencode."
+                    "Install one of: claude, codex."
                 )
                 raise typer.Exit(1)
             if len(available) == 1:

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -175,6 +175,7 @@ class Daemon:
 
         self._device_id = device_id
         result: ReconcileResult = self._reconciler.reconcile(device_id)
+        self._apply_reconcile_result(result)
 
         # Drain until queue empty (or one drain returns claimed=0).
         assert self._drainer is not None
@@ -292,9 +293,26 @@ class Daemon:
             self._status.errors = [str(e)]
             return
 
+        self._apply_reconcile_result(result)
+
+        if not result.in_sync:
+            self._drain_queue()
+
+        log.info(
+            "reconcile done run_id=%s changed=%d", run_id, len(result.changed_paths)
+        )
+
+    def _apply_reconcile_result(self, result: "ReconcileResult") -> None:
         # Seed confirmed_map from S3 — these are files we know are safely stored.
+        # Pruned paths are legacy manifest entries that are no longer part of
+        # default sync (currently Cursor); mark the manifest dirty so the next
+        # upload stops advertising them.
         confirmed_existing: dict[str, str] = {}
         with self._confirmed_lock:
+            if result.pruned_paths:
+                for path in result.pruned_paths:
+                    self._confirmed_map.pop(path, None)
+                self._manifest_dirty = True
             for path, digest in result.remote_map.items():
                 self._confirmed_map.setdefault(path, digest)
                 if result.local_map.get(path) == digest:
@@ -305,13 +323,6 @@ class Daemon:
         self._status.files_total = len(result.local_map)
         self._status.last_sync = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         self._status.state = "idle"
-
-        if not result.in_sync:
-            self._drain_queue()
-
-        log.info(
-            "reconcile done run_id=%s changed=%d", run_id, len(result.changed_paths)
-        )
 
     def _upload_manifest(self) -> None:
         """PUT manifest.json reflecting only files confirmed uploaded to S3.

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -30,7 +30,7 @@ from .drainer import QueueDrainer
 from .merkle import HashCache, MerkleTree
 from .paths import TrackPaths
 from .queue import UploadQueue
-from .reconciler import Reconciler
+from .reconciler import Reconciler, _is_unsupported_manifest_path
 from .sources import source_summary
 from .status import (
     TrackStatus,
@@ -310,6 +310,7 @@ class Daemon:
         confirmed_existing: dict[str, str] = {}
         with self._confirmed_lock:
             if result.pruned_paths:
+                self._queue.delete_paths(result.pruned_paths)
                 for path in result.pruned_paths:
                     self._confirmed_map.pop(path, None)
                 self._manifest_dirty = True
@@ -383,6 +384,14 @@ class Daemon:
     # ------------------------------------------------------------------ #
 
     def _on_upload_done(self, rel_path: str, sha256: str) -> None:
+        if _is_unsupported_manifest_path(rel_path):
+            self._queue.delete_paths([rel_path])
+            with self._confirmed_lock:
+                if self._confirmed_map.pop(rel_path, None) is not None:
+                    self._manifest_dirty = True
+            log.info("ignored unsupported upload result %s", rel_path)
+            return
+
         self._queue.mark_done(rel_path, sha256)
         self._status.files_synced += 1
         # Record this file as confirmed on S3 using the hash we originally computed.

--- a/fleet/track/picker.py
+++ b/fleet/track/picker.py
@@ -56,8 +56,6 @@ def fzf_available() -> bool:
 _TOOL_BINARIES: list[tuple[str, str]] = [
     ("claude", "claude"),
     ("codex", "codex"),
-    ("cursor", "cursor"),
-    ("opencode", "opencode"),
 ]
 
 
@@ -65,8 +63,8 @@ def installed_tools() -> list[str]:
     """Return the names of supported AI CLIs whose binary is on `PATH`.
 
     Used by the second-stage picker to hide tools the user couldn't actually
-    launch into. Order matches `_TOOL_BINARIES` (claude, codex, cursor,
-    opencode) so the picker is deterministic regardless of $PATH ordering.
+    launch into. Order matches `_TOOL_BINARIES` so the picker is deterministic
+    regardless of $PATH ordering.
     """
     return [name for name, binary in _TOOL_BINARIES if shutil.which(binary)]
 
@@ -136,15 +134,16 @@ class PageState:
     `fleet.track._picker_page` — keep field names aligned.
     """
 
-    source: str        # `--source` value the parent picker was opened with
+    source: str  # `--source` value the parent picker was opened with
     tool: Optional[str] = None
     cwd: Optional[str] = None
     since: Optional[str] = None
     query: str = ""
     limit: int = 20
 
-    def to_state(self, *, current_index: int = 0,
-                 cursors: Optional[list] = None) -> dict:
+    def to_state(
+        self, *, current_index: int = 0, cursors: Optional[list] = None
+    ) -> dict:
         return {
             "source": self.source,
             "tool": self.tool,
@@ -211,16 +210,22 @@ def pick_session(
         # terminal so the user never has to scroll within a page.
         state_path = _make_state_file(page_state)
         helper = (
-            f'{_shell_quote(sys.executable)} -m fleet.track._picker_page '
-            f'--state-file {_shell_quote(str(state_path))}'
+            f"{_shell_quote(sys.executable)} -m fleet.track._picker_page "
+            f"--state-file {_shell_quote(str(state_path))}"
         )
-        args.extend([
-            "--disabled",
-            "--bind", f"change:reload({helper} --direction query --query {{q}})",
-            "--bind", f"right:reload({helper} --direction next)",
-            "--bind", f"left:reload({helper} --direction prev)",
-            "--bind", f"alt-h:reload({helper} --direction first)",
-        ])
+        args.extend(
+            [
+                "--disabled",
+                "--bind",
+                f"change:reload({helper} --direction query --query {{q}})",
+                "--bind",
+                f"right:reload({helper} --direction next)",
+                "--bind",
+                f"left:reload({helper} --direction prev)",
+                "--bind",
+                f"alt-h:reload({helper} --direction first)",
+            ]
+        )
 
     try:
         result = subprocess.run(
@@ -303,7 +308,9 @@ def _format_line(s: Session) -> str:
     when = _human_when(s.last_active or s.started_at)
     cwd_short = _short_cwd(s.cwd)
     fork_marker = " ↳" if s.forked_from else "  "
-    title = _short_title(s.metadata.get("title") if isinstance(s.metadata, dict) else None)
+    title = _short_title(
+        s.metadata.get("title") if isinstance(s.metadata, dict) else None
+    )
     line = f"{short_id}  {tool}  {when:>14}  {cwd_short:<30}{fork_marker} {s.event_count:>4}e  {title}"
     return line.rstrip()  # no trailing whitespace; keeps stream-compare tests honest
 

--- a/fleet/track/queue.py
+++ b/fleet/track/queue.py
@@ -14,7 +14,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 from .paths import TrackPaths
 
@@ -26,12 +26,12 @@ MAX_BACKOFF_SECS = 1800  # 30 min
 
 
 def _backoff(attempts: int) -> float:
-    return min(BASE_BACKOFF_SECS * (2 ** attempts), MAX_BACKOFF_SECS)
+    return min(BASE_BACKOFF_SECS * (2**attempts), MAX_BACKOFF_SECS)
 
 
 @dataclass
 class QueueItem:
-    path: str        # relative to $HOME
+    path: str  # relative to $HOME
     sha256: str
     attempts: int
     last_error: Optional[str]
@@ -46,7 +46,9 @@ class UploadQueue:
 
     def _open_conn(self, _retry: bool = False) -> sqlite3.Connection:
         try:
-            conn = sqlite3.connect(self._paths.state_db, timeout=10, check_same_thread=False)
+            conn = sqlite3.connect(
+                self._paths.state_db, timeout=10, check_same_thread=False
+            )
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA synchronous=NORMAL")
             conn.execute("""
@@ -62,7 +64,9 @@ class UploadQueue:
                     UNIQUE(path, sha256)
                 )
             """)
-            conn.execute("CREATE INDEX IF NOT EXISTS queue_status ON queue(status, next_attempt_at)")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS queue_status ON queue(status, next_attempt_at)"
+            )
             conn.commit()
 
             result = conn.execute("PRAGMA integrity_check").fetchone()
@@ -85,7 +89,9 @@ class UploadQueue:
     def _wipe_and_reinit(self) -> None:
         """Delete corrupt database files and start fresh. Queue items are lost but
         the next reconcile will re-enqueue anything not yet on S3."""
-        log.warning("queue database is corrupt — wiping and reinitialising (next reconcile will re-upload missing files)")
+        log.warning(
+            "queue database is corrupt — wiping and reinitialising (next reconcile will re-upload missing files)"
+        )
         for suffix in ("", "-shm", "-wal"):
             p = Path(str(self._paths.state_db) + suffix)
             if p.exists():
@@ -187,7 +193,8 @@ class UploadQueue:
         now = int(time.time())
         with self._lock:
             row = self._conn.execute(
-                "SELECT attempts FROM queue WHERE path = ? AND sha256 = ?", (path, sha256)
+                "SELECT attempts FROM queue WHERE path = ? AND sha256 = ?",
+                (path, sha256),
             ).fetchone()
             attempts = (row[0] if row else 0) + 1
             status = "failed" if attempts >= MAX_ATTEMPTS else "pending"
@@ -217,8 +224,24 @@ class UploadQueue:
         """Purge successfully uploaded items older than 24h."""
         cutoff = int(time.time()) - 86400
         with self._lock:
-            self._conn.execute("DELETE FROM queue WHERE status = 'done' AND updated_at < ?", (cutoff,))
+            self._conn.execute(
+                "DELETE FROM queue WHERE status = 'done' AND updated_at < ?", (cutoff,)
+            )
             self._conn.commit()
+
+    def delete_paths(self, paths: Iterable[str]) -> int:
+        """Delete every queued row for the given relative paths."""
+        unique_paths = tuple(dict.fromkeys(paths))
+        if not unique_paths:
+            return 0
+        placeholders = ",".join("?" for _ in unique_paths)
+        with self._lock:
+            cur = self._conn.execute(
+                f"DELETE FROM queue WHERE path IN ({placeholders})",
+                unique_paths,
+            )
+            self._conn.commit()
+        return cur.rowcount
 
     def stats(self) -> dict[str, int]:
         with self._lock:

--- a/fleet/track/reconciler.py
+++ b/fleet/track/reconciler.py
@@ -22,6 +22,7 @@ log = logging.getLogger("fleet.track.reconciler")
 class ReconcileResult:
     in_sync: bool
     changed_paths: tuple[str, ...]
+    pruned_paths: tuple[str, ...]
     local_map: dict[str, str]
     remote_map: dict[str, str]
     local_root: str
@@ -50,8 +51,12 @@ class Reconciler:
         Idempotent: calling twice in a row when nothing has changed is a no-op
         (returns `in_sync=True` and enqueues nothing).
         """
-        remote_map = self._api.get_manifest(device_id)
-        local_map, local_root = self._tree.build()
+        remote_map_raw = self._api.get_manifest(device_id)
+        local_map_raw, _local_root_raw = self._tree.build()
+        local_map, pruned_local = _prune_unsupported_manifest_paths(local_map_raw)
+        remote_map, pruned_remote = _prune_unsupported_manifest_paths(remote_map_raw)
+        pruned_paths = tuple(sorted(set(pruned_local) | set(pruned_remote)))
+        local_root = MerkleTree.compute_root(local_map)
         remote_root = MerkleTree.compute_root(remote_map)
 
         if local_root == remote_root:
@@ -59,6 +64,7 @@ class Reconciler:
             return ReconcileResult(
                 in_sync=True,
                 changed_paths=(),
+                pruned_paths=pruned_paths,
                 local_map=local_map,
                 remote_map=remote_map,
                 local_root=local_root,
@@ -73,6 +79,7 @@ class Reconciler:
         return ReconcileResult(
             in_sync=False,
             changed_paths=tuple(changed),
+            pruned_paths=pruned_paths,
             local_map=local_map,
             remote_map=remote_map,
             local_root=local_root,
@@ -83,3 +90,22 @@ class Reconciler:
         """Initial seed for the Daemon's `confirmed_map`: every file the
         remote manifest already has is treated as confirmed-on-S3."""
         return dict(remote_map)
+
+
+def _prune_unsupported_manifest_paths(
+    file_map: dict[str, str],
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Drop legacy paths that are no longer part of default remote sync."""
+    kept: dict[str, str] = {}
+    pruned: list[str] = []
+    for path, digest in file_map.items():
+        if _is_unsupported_manifest_path(path):
+            pruned.append(path)
+        else:
+            kept[path] = digest
+    return kept, tuple(sorted(pruned))
+
+
+def _is_unsupported_manifest_path(path: str) -> bool:
+    normalized = path.lstrip("/")
+    return normalized == ".cursor" or normalized.startswith(".cursor/")

--- a/fleet/track/resumer.py
+++ b/fleet/track/resumer.py
@@ -90,9 +90,10 @@ def resume_session(
     still materialize a checkout because the native CLI cannot resume a
     session id whose file is absent locally.
 
-    Cross-tool: creates a checkout via the supplied `compactor` (default:
-    a `TruncationCompactor` sized to the target tool/model's typical
-    context window). Dispatches on the new ephemeral id.
+    Same-tool remote/cross-machine restores materialize the full source
+    history into a checkout. Cross-tool creates a checkout via the supplied
+    `compactor` (default: a `TruncationCompactor` sized to the target
+    tool/model's typical context window). Dispatches on the new ephemeral id.
 
     Future strategies (LLM summarization, recall-tool injection) plug
     in by passing a different `compactor`. The interface is the seam.
@@ -136,11 +137,18 @@ def resume_session(
             cwd=target_cwd_local,
         )
 
+    same_tool_materialized = session.tool == target_tool
+
     # Cross-tool: pick a default compactor sized to the target. Pass an
     # `emission_estimator` so the compactor can verify post-serialization
     # size against the budget — per-event estimation is imprecise because
     # the cross-source synthesizer's wrapper overhead varies by target.
-    if compactor is None:
+    #
+    # Same-tool materialized restores intentionally skip compaction even if
+    # the CLI default supplied one: native same-tool resume preserves the whole
+    # file, so the remote/cross-machine path must do the same.
+    checkout_compactor = None if same_tool_materialized else compactor
+    if checkout_compactor is None and not same_tool_materialized:
         from .compactor import estimate_tokens
 
         target_source = _source_for(target_tool, home=paths.home)
@@ -155,7 +163,7 @@ def resume_session(
                 # over-budget so the compactor keeps trimming.
                 return 10_000_000
 
-        compactor = TruncationCompactor(
+        checkout_compactor = TruncationCompactor(
             budget=budget_for(target_tool, target_model),
             emission_estimator=_emission_tokens,
         )
@@ -165,7 +173,7 @@ def resume_session(
         session=session,
         target_tool=target_tool,
         paths=paths,
-        compactor=compactor,
+        compactor=checkout_compactor,
     )
     # The checkout file lives under the resolved-target-cwd's project dir
     # (see `_checkout_path`); launch the CLI from there so its project

--- a/fleet/track/resumer.py
+++ b/fleet/track/resumer.py
@@ -3,11 +3,10 @@
 The flow:
 
   1. Materialize the session's full event chain (walks `forked_from`).
-  2. If the target tool matches the source, just dispatch native
-     resume directly against the source's own native session — no
-     conversion, no checkout. Cleanest path; no pollution.
-  3. Otherwise: synthesize a fresh ephemeral session id, convert
-     events to the target's native format, write to
+  2. If the target tool matches the source and that native session file
+     exists on this machine, dispatch native resume directly.
+  3. Otherwise: synthesize a fresh ephemeral session id, convert or
+     re-materialize events to the target's native format, write to
      `~/.<target>/.../.fleet-checkouts/<ephemeral-id>.jsonl`, and
      `exec` the target's native resume command.
 
@@ -32,7 +31,7 @@ from .converter import _encode_claude_cwd
 from .paths import TrackPaths
 from .sources import ClaudeSource, CodexSource
 from .sources.base import with_synth_meta
-from .store import Session, SessionStore
+from .store import NativeFilesSessionStore, Session, SessionStore
 from .unified import Event, SessionStart
 
 log = logging.getLogger("fleet.track.resumer")
@@ -85,9 +84,11 @@ def resume_session(
 ) -> int:
     """Resume `session` in `target_tool`. Returns the target CLI's exit code.
 
-    If the target_tool matches the session's tool, dispatches the
-    native resume command against the original session (no conversion,
-    no checkout, no compaction — would be destructive of user history).
+    If the target_tool matches the session's tool and the source native
+    session file exists on this machine, dispatches the native resume
+    command against the original session. Remote/cross-machine sessions
+    still materialize a checkout because the native CLI cannot resume a
+    session id whose file is absent locally.
 
     Cross-tool: creates a checkout via the supplied `compactor` (default:
     a `TruncationCompactor` sized to the target tool/model's typical
@@ -125,7 +126,9 @@ def resume_session(
         # No repo metadata; honor the original cwd if we can.
         target_cwd_local = _resolve_cwd(session.cwd) if session.cwd else None
 
-    if session.tool == target_tool:
+    if session.tool == target_tool and _native_session_available(
+        session, home=paths.home
+    ):
         return _exec_native_resume(
             target_tool,
             session.id,
@@ -256,6 +259,12 @@ def _create_checkout(
 
     target_source = _source_for(target_tool, home=paths.home)
     target_bytes = target_source.serialize(annotated)
+    target_bytes = _rewrite_checkout_session_identity(
+        target_bytes,
+        target_tool=target_tool,
+        session_id=ephemeral_id,
+        cwd=target_cwd,
+    )
 
     # Where does it go?
     out_path = _checkout_path(target_tool, target_cwd, ephemeral_id, paths.home)
@@ -340,6 +349,15 @@ def _checkout_path(target_tool: str, cwd: str, ephemeral_id: str, home: Path) ->
     raise ValueError(f"Unknown target tool: {target_tool}")
 
 
+def _native_session_available(session: Session, *, home: Path) -> bool:
+    """True when the target tool can resume the original id from local files."""
+    try:
+        native = NativeFilesSessionStore(home=home).get(session.id)
+    except KeyError:
+        return False
+    return native is not None and native.tool == session.tool
+
+
 def _source_for(tool: str, *, home: Path):
     if tool == "claude":
         return ClaudeSource(home=home)
@@ -388,6 +406,65 @@ def _resolve_local_cwd(session: Session) -> Optional[str]:
     if resolved is None:
         return None
     return _resolve_cwd(resolved)
+
+
+def _rewrite_checkout_session_identity(
+    body: bytes,
+    *,
+    target_tool: str,
+    session_id: str,
+    cwd: str,
+) -> bytes:
+    if target_tool == "claude":
+        return _rewrite_claude_checkout_identity(body, session_id=session_id, cwd=cwd)
+    if target_tool == "codex":
+        return _rewrite_codex_checkout_identity(body, session_id=session_id, cwd=cwd)
+    return body
+
+
+def _rewrite_claude_checkout_identity(
+    body: bytes, *, session_id: str, cwd: str
+) -> bytes:
+    """Make same-source Claude checkout rows resumable under the ephemeral id."""
+    out: list[str] = []
+    for line in body.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            out.append(line)
+            continue
+        if isinstance(row, dict):
+            row["sessionId"] = session_id
+            row["cwd"] = cwd
+            line = json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+        out.append(line)
+    return ("\n".join(out) + ("\n" if out else "")).encode("utf-8")
+
+
+def _rewrite_codex_checkout_identity(
+    body: bytes, *, session_id: str, cwd: str
+) -> bytes:
+    """Make same-source Codex checkout metadata point at the ephemeral id."""
+    out: list[str] = []
+    for line in body.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            out.append(line)
+            continue
+        if isinstance(row, dict) and row.get("type") == "session_meta":
+            payload = row.get("payload")
+            if isinstance(payload, dict):
+                payload["id"] = session_id
+                payload["cwd"] = cwd
+                row["payload"] = payload
+                line = json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+        out.append(line)
+    return ("\n".join(out) + ("\n" if out else "")).encode("utf-8")
 
 
 def _inject_codex_checkout_meta(body: bytes, meta: dict) -> bytes:

--- a/fleet/track/resumer.py
+++ b/fleet/track/resumer.py
@@ -464,11 +464,15 @@ def _rewrite_codex_checkout_identity(
         except json.JSONDecodeError:
             out.append(line)
             continue
-        if isinstance(row, dict) and row.get("type") == "session_meta":
+        if isinstance(row, dict) and row.get("type") in {
+            "session_meta",
+            "turn_context",
+        }:
             payload = row.get("payload")
             if isinstance(payload, dict):
-                payload["id"] = session_id
                 payload["cwd"] = cwd
+                if row.get("type") == "session_meta":
+                    payload["id"] = session_id
                 row["payload"] = payload
                 line = json.dumps(row, ensure_ascii=False, separators=(",", ":"))
         out.append(line)

--- a/fleet/track/sources/__init__.py
+++ b/fleet/track/sources/__init__.py
@@ -48,9 +48,10 @@ __all__ = [
 
 def default_sources(home: Optional[Path] = None) -> list[Source]:
     """The standard set of sources we sync from. Tests pass a tmp home."""
+    # CursorSource remains importable, but it is not in the default sync set
+    # until we have stable metadata extraction and event parsing for resume.
     return [
         ClaudeSource(home=home),
-        CursorSource(home=home),
         CodexSource(home=home),
     ]
 
@@ -65,7 +66,6 @@ EXCLUDE_PATTERNS = DEFAULT_EXCLUDE_PATTERNS
 # Path.home(); but exposed as a module attribute for legacy callers.
 WATCH_ROOTS = [
     Path.home() / ".claude" / "projects",
-    Path.home() / ".cursor" / "projects",
     Path.home() / ".codex",
 ]
 

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -809,8 +809,30 @@ class RemoteSessionStore:
             return _session_from_api(self._api.get_session(id))
         except Exception as e:
             if getattr(e, "status_code", None) == 404:
-                return None
-            raise
+                pass
+            else:
+                raise
+
+        if not id:
+            return None
+
+        matches: list[Session] = []
+        cursor = None
+        while True:
+            items, cursor = self.page(limit=MAX_PAGE_LIMIT, cursor=cursor)
+            for session in items:
+                if session.id.startswith(id):
+                    matches.append(session)
+                    if len(matches) > 1:
+                        raise KeyError(
+                            f"Ambiguous prefix {id!r}: matches {[m.id for m in matches]}"
+                        )
+            if cursor is None:
+                break
+
+        if matches:
+            return matches[0]
+        return None
 
     def events(self, id: str) -> Iterator[Event]:
         leaf = self.get(id)

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -114,6 +114,87 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
     cache.close()
 
 
+def test_run_once_rewrites_manifest_without_legacy_cursor_paths(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    rel_path = (
+        ".codex/sessions/"
+        "rollout-2026-05-05T00-00-00-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl"
+    )
+    session_file = tmp_path / rel_path
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        '{"type":"session_meta","payload":{"id":"s2","cwd":"/tmp"}}\n'
+    )
+
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[session_file])
+    local_map, _ = tree.build()
+    cursor_rel = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
+    remote_files = {**local_map, cursor_rel: "legacy-cursor-digest"}
+
+    api_requests: list[tuple[str, dict]] = []
+    metadata_upserts: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path.endswith("/v1/track/manifest"):
+            return httpx.Response(
+                200,
+                json={
+                    "root_hash": MerkleTree.compute_root(remote_files),
+                    "files": remote_files,
+                },
+            )
+        if req.method == "POST" and req.url.path.endswith("/v1/track/upload-urls"):
+            body = json.loads(req.content)
+            api_requests.append((req.url.path, body))
+            return httpx.Response(
+                200,
+                json={"urls": {p: f"https://s3.test/{p}" for p in body["paths"]}},
+            )
+        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
+            metadata_upserts.append(json.loads(req.content))
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+    transport = RecordingTransport()
+
+    daemon = Daemon(
+        paths,
+        queue=queue,
+        cache=cache,
+        tree=tree,
+        api=api,
+        upload_transport=transport,
+    )
+
+    result = daemon.run_once(device_id="dev1")
+
+    assert result.in_sync is True
+    assert result.changed_paths == ()
+    assert result.pruned_paths == (cursor_rel,)
+
+    assert [url for url, _ in transport.calls] == ["https://s3.test/manifest.json"]
+    manifest = json.loads(transport.calls[-1][1])
+    assert manifest["files"] == local_map
+    assert cursor_rel not in daemon._confirmed_map
+
+    upload_url_paths = [body["paths"] for _, body in api_requests]
+    assert upload_url_paths == [["manifest.json"]]
+    assert len(metadata_upserts) == 1
+
+    queue.close()
+    cache.close()
+
+
 def test_upload_done_uses_callback_digest_instead_of_stale_cache(tmp_path: Path):
     paths = TrackPaths.under(tmp_path)
     paths.ensure_track_dir()

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -133,6 +133,7 @@ def test_run_once_rewrites_manifest_without_legacy_cursor_paths(tmp_path: Path):
     tree = MerkleTree(cache, file_iter=[session_file])
     local_map, _ = tree.build()
     cursor_rel = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
+    queue.enqueue(cursor_rel, "legacy-cursor-digest")
     remote_files = {**local_map, cursor_rel: "legacy-cursor-digest"}
 
     api_requests: list[tuple[str, dict]] = []
@@ -181,6 +182,7 @@ def test_run_once_rewrites_manifest_without_legacy_cursor_paths(tmp_path: Path):
     assert result.in_sync is True
     assert result.changed_paths == ()
     assert result.pruned_paths == (cursor_rel,)
+    assert queue.stats() == {}
 
     assert [url for url, _ in transport.calls] == ["https://s3.test/manifest.json"]
     manifest = json.loads(transport.calls[-1][1])
@@ -190,6 +192,35 @@ def test_run_once_rewrites_manifest_without_legacy_cursor_paths(tmp_path: Path):
     upload_url_paths = [body["paths"] for _, body in api_requests]
     assert upload_url_paths == [["manifest.json"]]
     assert len(metadata_upserts) == 1
+
+    queue.close()
+    cache.close()
+
+
+def test_upload_done_ignores_legacy_cursor_paths(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree)
+
+    rel_path = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
+    queue.enqueue(rel_path, "cursor-digest")
+    daemon._confirmed_map[rel_path] = "old-digest"
+    metadata_calls: list[tuple[str, str]] = []
+
+    def record_metadata(path: str, digest: str) -> None:
+        metadata_calls.append((path, digest))
+
+    daemon._upsert_session_metadata = record_metadata  # type: ignore[method-assign]
+
+    daemon._on_upload_done(rel_path, "cursor-digest")
+
+    assert queue.stats() == {}
+    assert rel_path not in daemon._confirmed_map
+    assert daemon._manifest_dirty is True
+    assert metadata_calls == []
 
     queue.close()
     cache.close()

--- a/tests/track/test_picker.py
+++ b/tests/track/test_picker.py
@@ -55,6 +55,7 @@ def test_short_cwd_truncates_long_basenames():
 
 def test_human_when_seconds():
     from datetime import datetime, timezone, timedelta
+
     ts = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
     out = _human_when(ts)
     assert "s ago" in out
@@ -62,6 +63,7 @@ def test_human_when_seconds():
 
 def test_human_when_minutes():
     from datetime import datetime, timezone, timedelta
+
     ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     out = _human_when(ts)
     assert "m ago" in out
@@ -69,6 +71,7 @@ def test_human_when_minutes():
 
 def test_human_when_hours():
     from datetime import datetime, timezone, timedelta
+
     ts = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
     out = _human_when(ts)
     assert "h ago" in out
@@ -76,7 +79,12 @@ def test_human_when_hours():
 
 def test_human_when_handles_z_suffix():
     from datetime import datetime, timezone, timedelta
-    ts = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+
+    ts = (
+        (datetime.now(timezone.utc) - timedelta(minutes=1))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
     out = _human_when(ts)
     assert "ago" in out
 
@@ -124,14 +132,17 @@ def test_format_line_includes_event_count():
 
 
 def test_format_line_includes_metadata_title():
-    s = Session(id="x", tool="claude", metadata={"title": "Implementing fleet-track sidecar"})
+    s = Session(
+        id="x", tool="claude", metadata={"title": "Implementing fleet-track sidecar"}
+    )
     line = _format_line(s)
     assert "Implementing fleet-track sidecar" in line
 
 
 def test_format_line_truncates_long_titles():
     s = Session(
-        id="x", tool="claude",
+        id="x",
+        tool="claude",
         metadata={"title": "x" * 200},
     )
     line = _format_line(s)
@@ -142,7 +153,8 @@ def test_format_line_truncates_long_titles():
 def test_format_line_collapses_newlines_in_title():
     """Titles never break the fzf row — newlines and tabs collapse to spaces."""
     s = Session(
-        id="x", tool="claude",
+        id="x",
+        tool="claude",
         metadata={"title": "first line\nsecond line\twith tab"},
     )
     line = _format_line(s)
@@ -191,13 +203,13 @@ def test_installed_tools_returns_only_binaries_on_path():
 
 def test_installed_tools_canonical_order_independent_of_shutil():
     """Even if shutil reports them in a different order, the function
-    returns the canonical [claude, codex, cursor, opencode] subset."""
+    returns the canonical [claude, codex] subset."""
     found = {"opencode", "claude"}
     with mock.patch(
         "fleet.track.picker.shutil.which",
         side_effect=lambda n: "/x" if n in found else None,
     ):
-        assert installed_tools() == ["claude", "opencode"]
+        assert installed_tools() == ["claude"]
 
 
 def test_installed_tools_empty_when_nothing_on_path():
@@ -268,12 +280,10 @@ def test_pick_tool_returns_none_on_cancel():
 def test_pick_tool_lists_source_tool_first():
     """Source tool must be on the first row so it's the default highlight."""
     runner = _runner_returning("codex      cross-tool: lossy\n")
-    pick_tool("codex", available=["claude", "codex", "cursor"], runner=runner)
+    pick_tool("codex", available=["claude", "codex"], runner=runner)
     lines = runner.captured["input"].splitlines()
     assert lines[0].startswith("codex")
-    # Remaining are claude/cursor in canonical order.
     assert lines[1].startswith("claude")
-    assert lines[2].startswith("cursor")
 
 
 def test_pick_tool_falls_back_to_canonical_when_source_not_installed():

--- a/tests/track/test_queue.py
+++ b/tests/track/test_queue.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import sqlite3
 import time
 from pathlib import Path
 
 from fleet.track.paths import TrackPaths
-from fleet.track.queue import MAX_ATTEMPTS, QueueItem, UploadQueue
+from fleet.track.queue import MAX_ATTEMPTS, UploadQueue
 
 
 def _q(tmp_path: Path) -> UploadQueue:
@@ -186,3 +185,17 @@ def test_separate_paths_separate_queues(tmp_path: Path):
 
     q1.close()
     q2.close()
+
+
+def test_delete_paths_removes_all_versions(tmp_path: Path):
+    q = _q(tmp_path)
+    q.enqueue(".cursor/projects/p/session.jsonl", "h1")
+    q.enqueue(".cursor/projects/p/session.jsonl", "h2")
+    q.enqueue(".codex/sessions/s.jsonl", "h3")
+
+    removed = q.delete_paths([".cursor/projects/p/session.jsonl"])
+
+    assert removed == 2
+    items = q.claim_batch(n=10)
+    assert [item.path for item in items] == [".codex/sessions/s.jsonl"]
+    q.close()

--- a/tests/track/test_reconciler.py
+++ b/tests/track/test_reconciler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import httpx
@@ -89,6 +88,47 @@ def test_reconcile_when_in_sync_enqueues_nothing(tmp_path: Path):
 
     assert result.in_sync is True
     assert result.changed_paths == ()
+    assert queue.stats() == {}
+    queue.close()
+
+
+def test_reconcile_prunes_legacy_cursor_manifest_paths(tmp_path: Path):
+    """Old Cursor entries should not keep the manifest out of sync."""
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+
+    f1 = _seed_file(tmp_path, ".codex/sessions/2026/05/05/rollout-s1.jsonl", "AAA")
+    tree = MerkleTree(cache, file_iter=[f1])
+    local_map, _ = tree.build()
+    cursor_rel = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
+    remote_files = {**local_map, cursor_rel: "legacy-cursor-digest"}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "root_hash": MerkleTree.compute_root(remote_files),
+                "files": remote_files,
+            },
+        )
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+
+    reconciler = Reconciler(queue=queue, cache=cache, tree=tree, api=api)
+    result = reconciler.reconcile("dev1")
+
+    assert result.in_sync is True
+    assert result.changed_paths == ()
+    assert result.pruned_paths == (cursor_rel,)
+    assert result.local_map == local_map
+    assert result.remote_map == local_map
     assert queue.stats() == {}
     queue.close()
 

--- a/tests/track/test_resumer.py
+++ b/tests/track/test_resumer.py
@@ -297,6 +297,35 @@ def test_resume_same_tool_without_native_file_materializes_checkout(
     assert checkout.exists()
 
 
+def test_resume_same_tool_materialized_checkout_ignores_compactor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class FailingCompactor:
+        def compact(self, _events):
+            raise AssertionError("same-tool restore must preserve full history")
+
+    store = _store(tmp_path)
+    s = _seed(store, tool="claude", id="src-full", cwd="/private/tmp/work")
+    calls: list[str] = []
+
+    def fake_exec(_tool, session_id, *, prompt, cwd=None):
+        calls.append(session_id)
+        return 0
+
+    monkeypatch.setattr("fleet.track.resumer._exec_native_resume", fake_exec)
+
+    rc = resume_session(
+        store=store,
+        session=s,
+        target_tool="claude",
+        paths=TrackPaths.under(tmp_path),
+        compactor=FailingCompactor(),
+    )
+
+    assert rc == 0
+    assert calls and calls[0] != "src-full"
+
+
 def test_resume_same_tool_uses_native_session_when_present(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/track/test_resumer.py
+++ b/tests/track/test_resumer.py
@@ -19,20 +19,31 @@ from fleet.track.resumer import (
     _checkout_path,
     _create_checkout,
     gc_checkouts,
+    resume_session,
 )
 from fleet.track.store import LocalSessionStore, Session
-from fleet.track.unified import AssistantMessage, UserMessage
+from fleet.track.unified import UserMessage
 
 
 def _store(tmp_path: Path) -> LocalSessionStore:
     return LocalSessionStore(TrackPaths.under(tmp_path))
 
 
-def _seed(store: LocalSessionStore, *, tool: str, id: str, n_events: int = 3,
-          forked_from=None, fork_point=None, cwd="/private/tmp/r") -> Session:
+def _seed(
+    store: LocalSessionStore,
+    *,
+    tool: str,
+    id: str,
+    n_events: int = 3,
+    forked_from=None,
+    fork_point=None,
+    cwd="/private/tmp/r",
+) -> Session:
     events = [UserMessage(source=tool, text=f"u{i}") for i in range(n_events)]
     s = Session(
-        id=id, tool=tool, cwd=cwd,
+        id=id,
+        tool=tool,
+        cwd=cwd,
         started_at="2026-04-30T00:00:00Z",
         last_active="2026-04-30T01:00:00Z",
         forked_from=forked_from,
@@ -50,7 +61,9 @@ def test_checkout_path_for_claude(tmp_path: Path):
     """Flat layout: claude requires checkouts directly under <encoded-cwd>/
     (its scanner doesn't recurse into subdirs)."""
     p = _checkout_path("claude", "/private/tmp/work", "abc-123", tmp_path)
-    assert p == tmp_path / ".claude" / "projects" / "-private-tmp-work" / "abc-123.jsonl"
+    assert (
+        p == tmp_path / ".claude" / "projects" / "-private-tmp-work" / "abc-123.jsonl"
+    )
 
 
 def test_checkout_path_for_codex(tmp_path: Path):
@@ -114,13 +127,45 @@ def test_create_checkout_claude_rows_carry_ephemeral_session_id(tmp_path: Path):
     paths = TrackPaths.under(tmp_path)
 
     info = _create_checkout(store=store, session=s, target_tool="claude", paths=paths)
-    rows = [json.loads(l) for l in info.path.read_text().splitlines() if l.strip()]
+    rows = [
+        json.loads(line) for line in info.path.read_text().splitlines() if line.strip()
+    ]
     # Skip the header row (has _fleet_meta)
     body_rows = [r for r in rows if "_fleet_meta" not in r]
     msg_rows = [r for r in body_rows if r.get("type") in ("user", "assistant")]
     assert msg_rows, "expected at least one converted message row"
     for r in msg_rows:
         assert r.get("sessionId") == info.ephemeral_id
+
+
+def test_create_checkout_claude_rewrites_same_source_raw_session_id(tmp_path: Path):
+    class Store:
+        def events(self, _id):
+            yield UserMessage(
+                source="claude",
+                id="u1",
+                text="hi",
+                raw={
+                    "type": "user",
+                    "uuid": "u1",
+                    "sessionId": "src-raw",
+                    "cwd": "/remote/repo",
+                    "timestamp": "2026-04-30T00:00:00Z",
+                    "message": {"role": "user", "content": "hi"},
+                },
+            )
+
+    s = Session(id="src-raw", tool="claude", cwd="/private/tmp/work")
+    paths = TrackPaths.under(tmp_path)
+
+    info = _create_checkout(store=Store(), session=s, target_tool="claude", paths=paths)
+    rows = [
+        json.loads(line) for line in info.path.read_text().splitlines() if line.strip()
+    ]
+    body_rows = [r for r in rows if "_fleet_meta" not in r]
+
+    assert body_rows
+    assert {r.get("sessionId") for r in body_rows} == {info.ephemeral_id}
 
 
 # ------------------------------------------------------------------ #
@@ -155,8 +200,16 @@ def test_create_checkout_codex_payload_has_required_fields(tmp_path: Path):
     first = json.loads(info.path.read_text().splitlines()[0])
     payload = first["payload"]
 
-    required = {"id", "timestamp", "cwd", "originator", "cli_version",
-                "source", "model_provider", "base_instructions"}
+    required = {
+        "id",
+        "timestamp",
+        "cwd",
+        "originator",
+        "cli_version",
+        "source",
+        "model_provider",
+        "base_instructions",
+    }
     assert set(payload.keys()) >= required
     assert isinstance(payload["base_instructions"], dict)
 
@@ -180,9 +233,15 @@ def test_checkout_includes_full_ancestor_chain(tmp_path: Path):
 
     # Full chain: 3 from A + 2 from B = 5 input events.
     # In codex output: 1 session_meta + 5 message rows = 6 rows total.
-    rows = [json.loads(l) for l in info.path.read_text().splitlines() if l.strip()]
-    msg_rows = [r for r in rows if r.get("type") == "response_item"
-                and r.get("payload", {}).get("type") == "message"]
+    rows = [
+        json.loads(line) for line in info.path.read_text().splitlines() if line.strip()
+    ]
+    msg_rows = [
+        r
+        for r in rows
+        if r.get("type") == "response_item"
+        and r.get("payload", {}).get("type") == "message"
+    ]
     assert len(msg_rows) == 5
     # Texts come from A then B in chain order.
     texts = [r["payload"]["content"][0]["text"] for r in msg_rows]
@@ -207,23 +266,106 @@ def test_checkout_resolves_symlinked_cwd(tmp_path: Path):
     assert "private" in str(info.path)
 
 
+def test_resume_same_tool_without_native_file_materializes_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = _store(tmp_path)
+    s = _seed(store, tool="claude", id="src-same", cwd="/private/tmp/work")
+    paths = TrackPaths.under(tmp_path)
+    calls: list[tuple[str, str, str | None]] = []
+
+    def fake_exec(tool, session_id, *, prompt, cwd=None):
+        calls.append((tool, session_id, cwd))
+        return 0
+
+    monkeypatch.setattr("fleet.track.resumer._exec_native_resume", fake_exec)
+
+    rc = resume_session(
+        store=store,
+        session=s,
+        target_tool="claude",
+        paths=paths,
+        compactor=None,
+    )
+
+    assert rc == 0
+    assert calls
+    tool, resumed_id, _cwd = calls[0]
+    assert tool == "claude"
+    assert resumed_id != "src-same"
+    checkout = next((tmp_path / ".claude" / "projects").glob(f"**/{resumed_id}.jsonl"))
+    assert checkout.exists()
+
+
+def test_resume_same_tool_uses_native_session_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    sid = "11111111-2222-3333-4444-555555555555"
+    native_dir = tmp_path / ".claude" / "projects" / "-private-tmp-work"
+    native_dir.mkdir(parents=True)
+    (native_dir / f"{sid}.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": "u1",
+                "sessionId": sid,
+                "cwd": "/private/tmp/work",
+                "timestamp": "2026-04-30T00:00:00Z",
+                "message": {"role": "user", "content": "hi"},
+            }
+        )
+        + "\n"
+    )
+    store = _store(tmp_path)
+    s = _seed(store, tool="claude", id=sid, cwd="/private/tmp/work")
+    calls: list[str] = []
+
+    def fake_exec(_tool, session_id, *, prompt, cwd=None):
+        calls.append(session_id)
+        return 0
+
+    def fail_checkout(**_kwargs):
+        raise AssertionError("same-tool native resume should not create a checkout")
+
+    monkeypatch.setattr("fleet.track.resumer._exec_native_resume", fake_exec)
+    monkeypatch.setattr("fleet.track.resumer._create_checkout", fail_checkout)
+
+    rc = resume_session(
+        store=store,
+        session=s,
+        target_tool="claude",
+        paths=TrackPaths.under(tmp_path),
+        compactor=None,
+    )
+
+    assert rc == 0
+    assert calls == [sid]
+
+
 # ------------------------------------------------------------------ #
 # GC                                                                   #
 # ------------------------------------------------------------------ #
 
 
 def _fleet_meta_row() -> str:
-    return json.dumps({
-        "_fleet_meta": {"forked_from": "x", "fork_point": 0,
-                        "ephemeral_id": "e", "target_tool": "claude"},
-        "type": "system",
-        "content": "fleet-track checkout",
-    })
+    return json.dumps(
+        {
+            "_fleet_meta": {
+                "forked_from": "x",
+                "fork_point": 0,
+                "ephemeral_id": "e",
+                "target_tool": "claude",
+            },
+            "type": "system",
+            "content": "fleet-track checkout",
+        }
+    )
 
 
 def _native_row() -> str:
-    return json.dumps({"type": "user", "uuid": "u1",
-                       "message": {"role": "user", "content": "hi"}})
+    return json.dumps(
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hi"}}
+    )
 
 
 def test_gc_removes_old_marked_checkouts(tmp_path: Path):
@@ -236,6 +378,7 @@ def test_gc_removes_old_marked_checkouts(tmp_path: Path):
     new.write_text(_fleet_meta_row() + "\n")
     # Backdate `old`'s mtime by 30 hours.
     import os
+
     old_mtime = time.time() - 30 * 3600
     os.utime(old, (old_mtime, old_mtime))
 
@@ -257,6 +400,7 @@ def test_gc_does_not_touch_native_sessions(tmp_path: Path):
     native = cdir / "native.jsonl"
     native.write_text(_native_row() + "\n")
     import os
+
     old = time.time() - 100 * 3600  # 100 hours old
     os.utime(native, (old, old))
 
@@ -271,16 +415,26 @@ def test_gc_recognizes_codex_session_meta_inner_marker(tmp_path: Path):
     cdir = tmp_path / ".codex" / "sessions" / "2026" / "05" / "01"
     cdir.mkdir(parents=True)
     f = cdir / "rollout-old-abc.jsonl"
-    f.write_text(json.dumps({
-        "timestamp": "x",
-        "type": "session_meta",
-        "payload": {
-            "id": "abc",
-            "_fleet_meta": {"forked_from": "src", "fork_point": 0,
-                            "ephemeral_id": "abc", "target_tool": "codex"},
-        },
-    }) + "\n")
+    f.write_text(
+        json.dumps(
+            {
+                "timestamp": "x",
+                "type": "session_meta",
+                "payload": {
+                    "id": "abc",
+                    "_fleet_meta": {
+                        "forked_from": "src",
+                        "fork_point": 0,
+                        "ephemeral_id": "abc",
+                        "target_tool": "codex",
+                    },
+                },
+            }
+        )
+        + "\n"
+    )
     import os
+
     old = time.time() - 30 * 3600
     os.utime(f, (old, old))
 
@@ -297,4 +451,3 @@ def test_gc_recognizes_codex_session_meta_inner_marker(tmp_path: Path):
 def test_supported_tools_set():
     assert "claude" in SUPPORTED_TOOLS
     assert "codex" in SUPPORTED_TOOLS
-

--- a/tests/track/test_resumer.py
+++ b/tests/track/test_resumer.py
@@ -22,7 +22,7 @@ from fleet.track.resumer import (
     resume_session,
 )
 from fleet.track.store import LocalSessionStore, Session
-from fleet.track.unified import UserMessage
+from fleet.track.unified import SessionStart, TurnStart, UserMessage
 
 
 def _store(tmp_path: Path) -> LocalSessionStore:
@@ -212,6 +212,65 @@ def test_create_checkout_codex_payload_has_required_fields(tmp_path: Path):
     }
     assert set(payload.keys()) >= required
     assert isinstance(payload["base_instructions"], dict)
+
+
+def test_create_checkout_codex_rewrites_same_source_turn_context_cwd(
+    tmp_path: Path,
+):
+    local_cwd = str((tmp_path / "work").resolve(strict=False))
+
+    class Store:
+        def events(self, _id):
+            yield SessionStart(
+                source="codex",
+                id="meta-row",
+                cwd="/remote/repo",
+                raw={
+                    "timestamp": "2026-04-30T00:00:00Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "src-codex",
+                        "timestamp": "2026-04-30T00:00:00Z",
+                        "cwd": "/remote/repo",
+                        "originator": "codex_cli_rs",
+                        "cli_version": "1.0.0",
+                        "source": "cli",
+                        "model_provider": "openai",
+                        "base_instructions": {"text": "You are an assistant."},
+                    },
+                },
+            )
+            yield TurnStart(
+                source="codex",
+                id="turn-row",
+                turn_id="turn-1",
+                cwd="/remote/repo",
+                raw={
+                    "timestamp": "2026-04-30T00:01:00Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "turn_id": "turn-1",
+                        "cwd": "/remote/repo",
+                        "model": "gpt-5",
+                    },
+                },
+            )
+
+    s = Session(id="src-codex", tool="codex", cwd=local_cwd)
+    info = _create_checkout(
+        store=Store(),
+        session=s,
+        target_tool="codex",
+        paths=TrackPaths.under(tmp_path),
+    )
+    rows = [
+        json.loads(line) for line in info.path.read_text().splitlines() if line.strip()
+    ]
+    by_type = {row["type"]: row for row in rows}
+
+    assert by_type["session_meta"]["payload"]["id"] == info.ephemeral_id
+    assert by_type["session_meta"]["payload"]["cwd"] == local_cwd
+    assert by_type["turn_context"]["payload"]["cwd"] == local_cwd
 
 
 # ------------------------------------------------------------------ #

--- a/tests/track/test_sources.py
+++ b/tests/track/test_sources.py
@@ -186,10 +186,10 @@ def test_serialize_returns_bytes(tmp_path: Path):
 # ------------------------------------------------------------------ #
 
 
-def test_default_sources_returns_all_three(tmp_path: Path):
+def test_default_sources_returns_indexable_sources(tmp_path: Path):
     sources = default_sources(home=tmp_path)
     names = [s.name for s in sources]
-    assert names == ["claude", "cursor", "codex"]
+    assert names == ["claude", "codex"]
 
 
 def test_default_sources_use_provided_home(tmp_path: Path):

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -906,3 +906,87 @@ def test_remote_store_fetches_content_and_parses_events():
 
     assert [e.type for e in events] == ["session_start", "user_message"]
     assert events[1].text == "hello"
+
+
+def test_remote_store_get_resolves_unique_prefix_across_pages():
+    from fleet.track.store import RemoteSessionStore
+
+    sid = "abcdef01-2345-6789-abcd-ef0123456789"
+    calls: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls.append(str(req.url))
+        if req.url.path == "/v1/track/sessions/abcdef01":
+            return httpx.Response(404, json={"detail": "not found"})
+        if req.url.path == "/v1/track/sessions":
+            cursor = req.url.params.get("cursor")
+            if cursor is None:
+                return httpx.Response(
+                    200,
+                    json={
+                        "items": [
+                            {
+                                "id": "11111111-1111-1111-1111-111111111111",
+                                "tool": "claude",
+                                "cwd": "/repo",
+                            }
+                        ],
+                        "next_cursor": "next",
+                    },
+                )
+            if cursor == "next":
+                return httpx.Response(
+                    200,
+                    json={
+                        "items": [
+                            {
+                                "id": sid,
+                                "tool": "codex",
+                                "cwd": "/repo",
+                            }
+                        ],
+                        "next_cursor": None,
+                    },
+                )
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    store = RemoteSessionStore(api=_remote_api(handler))
+
+    session = store.get("abcdef01")
+
+    assert session is not None
+    assert session.id == sid
+    assert any("cursor=next" in call for call in calls)
+
+
+def test_remote_store_get_ambiguous_prefix_raises():
+    from fleet.track.store import RemoteSessionStore
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/track/sessions/abcdef01":
+            return httpx.Response(404, json={"detail": "not found"})
+        if req.url.path == "/v1/track/sessions":
+            return httpx.Response(
+                200,
+                json={
+                    "items": [
+                        {
+                            "id": "abcdef01-1111-1111-1111-111111111111",
+                            "tool": "claude",
+                            "cwd": "/repo",
+                        },
+                        {
+                            "id": "abcdef01-2222-2222-2222-222222222222",
+                            "tool": "codex",
+                            "cwd": "/repo",
+                        },
+                    ],
+                    "next_cursor": None,
+                },
+            )
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    store = RemoteSessionStore(api=_remote_api(handler))
+
+    with pytest.raises(KeyError, match="Ambiguous prefix"):
+        store.get("abcdef01")


### PR DESCRIPTION
## Summary
- allow RemoteSessionStore.get() to resolve unique session-id prefixes after exact lookup misses
- materialize a local checkout for same-tool resume when the native session file is not present locally, while preserving direct native resume when it is present
- stop syncing/advertising Cursor by default until stable Cursor metadata extraction and event replay are implemented

## Why Cursor was not indexed
CursorSource was included in the default daemon source list, so raw Cursor files could upload, but metadata indexing only builds Session records for Claude and Codex and CursorSource does not implement parse/serialize. That left Cursor uploads without indexed metadata for remote ls/search/resume.

## Tests
- `uv run pytest tests/track`
- `uv run ruff check fleet/track/store.py fleet/track/resumer.py fleet/track/sources/__init__.py fleet/track/cli.py fleet/track/picker.py fleet/track/__init__.py tests/track/test_store.py tests/track/test_resumer.py tests/track/test_sources.py tests/track/test_picker.py`
- `uv run ruff format --check fleet/track/store.py fleet/track/resumer.py fleet/track/sources/__init__.py fleet/track/cli.py fleet/track/picker.py fleet/track/__init__.py tests/track/test_store.py tests/track/test_resumer.py tests/track/test_sources.py tests/track/test_picker.py`
- `git diff --check`