### PR TITLE
Add structured track search and downloads

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -28,6 +28,8 @@ The public Fleet API currently exposes:
 - `POST /v1/track/upload-urls`
 - `POST /v1/track/sessions/{id}`
 - `GET /v1/track/sessions`
+- `POST /v1/track/sessions/search`
+- `POST /v1/track/sessions/aggregate`
 - `GET /v1/track/sessions/{id}`
 - `GET /v1/track/sessions/{id}/content`
 
@@ -75,6 +77,8 @@ flt track daemon --once
 flt track logs
 flt track ls
 flt track search
+flt track aggregate
+flt track download
 flt track resume
 flt track gc
 ```
@@ -82,14 +86,16 @@ flt track gc
 ### Search
 
 `flt track ls` lists deterministic session metadata from the orchestrator's
-Postgres store. `flt track search` is Turbopuffer-only and emits JSON by default
-for agent workflows.
+Postgres store. `flt track search` uses the orchestrator-managed Turbopuffer
+session index for ranked session discovery and emits JSON by default for agent
+workflows.
 
-Search accepts one JSON object and posts it to the orchestrator-managed hybrid
-index. Pass inline JSON, `@file`, or `-` for stdin:
+Search accepts one structured JSON object. Pass inline JSON, `@file`, or `-` for
+stdin:
 
 ```bash
-flt track search '{"query":"bugbot local index","top_k":20}'
+flt track search '{"query":"bugbot local index","limit":20}'
+flt track search '{"mode":"keyword","query":"schema error","filters":{"tool":"codex"}}'
 flt track search @search.json
 flt track search -
 flt track search --filters
@@ -98,19 +104,16 @@ flt track search --filters
 The JSON body supports:
 
 ```text
-query    string   Orchestrator-managed hybrid search: BM25 over search_text
-                  plus ANN over vector.
-top_k    integer  Maximum ranked results to return. Defaults to 50.
-filters  array    Turbopuffer filter expression, forwarded as-is.
-rank_by  array    Turbopuffer ranking expression, forwarded as-is.
+query    string   Natural-language search text.
+mode     string   hybrid (default), keyword, semantic, or recent.
+limit    integer  Maximum ranked results to return. Defaults to 50.
+filters  object   Mongo-style exact/range/boolean filters.
+time     object   Shared time filter, e.g. {"field":"last_active","since":"7d"}.
 ```
 
 The command posts the body to `POST /v1/track/sessions/search`. Orchestrator
-injects the team boundary and hydrates the ranked results back to Fleet session
-metadata.
-
-Turbopuffer's query and filter docs are available at
-<https://turbopuffer.com/docs/query#filtering>.
+injects the team boundary, compiles structured filters to Turbopuffer, and
+hydrates ranked results back to Fleet session metadata.
 
 Filterable attributes are:
 
@@ -119,26 +122,98 @@ session_id, user_id, device_id, tool, cwd, repo_url, git_branch, model,
 forked_from, event_count, started_at, last_active
 ```
 
-`team_id` is always injected by orchestrator. Filters use Turbopuffer filter
-arrays. Common operators include `And`, `Or`, `Not`, `Eq`, `NotEq`, `In`,
-`NotIn`, `Lt`, `Lte`, `Gt`, `Gte`, `Contains`, and `ContainsAny`.
+`team_id` is always injected by orchestrator. Filters support direct equality,
+Mongo-style field operators, and boolean operators:
+
+```json
+{"tool": "codex"}
+{"event_count": {"$gte": 1000}}
+{"$or": [{"repo_url": {"$contains": "theseus"}}, {"repo_url": {"$contains": "fleet-sdk"}}]}
+```
+
+Supported field operators are `eq/$eq`, `ne/$ne`, `in/$in`, `nin/$nin`,
+`gt/$gt`, `gte/$gte`, `lt/$lt`, `lte/$lte`, `contains/$contains`,
+`glob/$glob`, and `regex/$regex`. Supported boolean operators are `$and`,
+`$or`, `$not`, and `$nor`.
 
 Example body:
 
 ```json
 {
   "query": "deployment debugging",
-  "filters": [
-    "And",
-    [
-      ["repo_url", "Eq", "git@github.com:fleet-ai/theseus.git"],
-      ["tool", "Eq", "codex"],
-      ["last_active", "Gte", "2026-05-01T00:00:00Z"]
-    ]
-  ],
-  "top_k": 25
+  "filters": {
+    "repo_url": {"$contains": "theseus"},
+    "tool": {"$in": ["codex", "claude"]},
+    "event_count": {"$gte": 1000}
+  },
+  "time": {"field": "last_active", "gte": "2026-05-01T00:00:00Z"},
+  "limit": 25
 }
 ```
+
+### Aggregate
+
+`flt track aggregate` runs structured Postgres-backed aggregate queries. It does not
+accept raw SQL.
+
+```bash
+flt track aggregate '{"group_by":["repo_url","tool"],"metrics":["count","sum_event_count"]}'
+flt track aggregate '{"time":{"field":"last_active","since":"30d"},"group_by":["tool"]}'
+flt track aggregate '{"group_by":["repo_url"],"time_bucket":{"field":"last_active","interval":"day"},"having":{"count":{"$gte":5}},"order_by":[{"field":"count","direction":"desc"}]}'
+```
+
+Supported metrics:
+
+```text
+count, sum_event_count, min_event_count, max_event_count, avg_event_count,
+distinct_user_count, distinct_device_count, distinct_repo_count,
+distinct_model_count
+```
+
+Aggregate bodies also support:
+
+- `time_bucket`: `{"field":"last_active","interval":"hour|day|week|month"}`.
+- `order_by`: list of `{"field":"count","direction":"desc"}` entries. Fields
+  may be metrics or grouped key fields.
+- `having`: metric filters after grouping, for example `{"count":{"$gte":5}}`.
+
+### Download For Intra-Session Analysis
+
+`flt track download <session_id>` downloads the session into the local cache and
+prints the canonical JSONL path. This is the intended primitive for
+intra-session agentic search. After downloading, use local tools:
+
+```bash
+flt track download 019dfbd6-0600-70b1-8a0b-c6f4cdbf1c57
+rg "started_at schema" ~/.fleet/track/cache/sessions/019dfbd6-0600-70b1-8a0b-c6f4cdbf1c57/session.jsonl
+jq 'select(.type=="message")' ~/.fleet/track/cache/sessions/019dfbd6-0600-70b1-8a0b-c6f4cdbf1c57/session.jsonl
+```
+
+Download behavior:
+
+- Orchestrator authorizes and returns a presigned S3 URL plus content metadata.
+- The SDK downloads directly from S3 and caches under
+  `~/.fleet/track/cache/sessions/<session_id>/`.
+- If the S3 object is stored as gzip, the SDK writes decompressed canonical JSONL
+  locally.
+- Repeated downloads are cache hits unless metadata such as `last_active`,
+  `event_count`, `content_codec`, or byte sizes changes.
+
+### Compression
+
+Uploads are raw by default for safe rollout. To store new uploaded session blobs
+compressed in S3, set one of:
+
+```bash
+export FLEET_TRACK_UPLOAD_CODEC=gzip
+# or
+export FLEET_TRACK_COMPRESS_UPLOADS=1
+```
+
+Compression happens after local scrubbing. Metadata upserts include
+`content_codec`, `raw_bytes`, and `stored_bytes`, and downloads decode based on
+that metadata. Existing raw S3 objects remain readable because missing codec
+metadata defaults to `raw`.
 
 ## Design Notes
 

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -22,6 +22,7 @@ import logging
 import os
 import platform
 import socket
+import gzip
 from dataclasses import asdict, is_dataclass
 from typing import Any, Callable, Mapping, Optional, Tuple, Union
 
@@ -152,6 +153,10 @@ class TrackAPIClient:
         device_id: str,
         path: str,
         session: Any,
+        content_codec: str = "raw",
+        raw_bytes: Optional[int] = None,
+        stored_bytes: Optional[int] = None,
+        include_content_metadata: bool = True,
     ) -> None:
         """Register metadata for a session file already uploaded to S3.
 
@@ -159,13 +164,22 @@ class TrackAPIClient:
         orchestrator owns translation from that relative path to the final S3
         key, so the SDK never has to construct team/user/device storage paths.
         """
+        body = {
+            "device_id": device_id,
+            "path": path,
+            "session": _session_payload(session),
+        }
+        if include_content_metadata:
+            body.update(
+                {
+                    "content_codec": content_codec,
+                    "raw_bytes": raw_bytes,
+                    "stored_bytes": stored_bytes,
+                }
+            )
         resp = self._client.post(
             f"/v1/track/sessions/{_session_id(session)}",
-            json={
-                "device_id": device_id,
-                "path": path,
-                "session": _session_payload(session),
-            },
+            json=body,
             headers=self._headers(),
         )
         _raise(resp)
@@ -198,16 +212,40 @@ class TrackAPIClient:
         _raise(resp)
         return resp.json()
 
+    def _post_session_search(self, body: Mapping[str, Any]) -> dict:
+        resp = self._client.post(
+            "/v1/track/sessions/search",
+            json=dict(body),
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
     def search_sessions_raw(self, body: Mapping[str, Any]) -> dict:
-        """Run agent-facing raw Turbopuffer-shaped session search.
+        """Run legacy/debug raw Turbopuffer-shaped session search.
 
         The body is forwarded to orchestrator's
         `POST /v1/track/sessions/search`. Orchestrator owns auth, team-scope
         wrapping, server-side embeddings for `query`, and hydration back to
-        Fleet session metadata.
+        Fleet session metadata. New CLI/MCP code should use `search_sessions`
+        with structured filters instead.
         """
+        return self._post_session_search(body)
+
+    def search_sessions(self, body: Mapping[str, Any]) -> dict:
+        """Run structured session search.
+
+        This posts the stable Fleet search shape to the same orchestrator route
+        as the legacy raw Turbopuffer body. Prefer this for agents and CLI use:
+        filters are objects, `time` is shared with aggregate queries, and the
+        server compiles the request to Turbopuffer.
+        """
+        return self._post_session_search(body)
+
+    def aggregate_sessions(self, body: Mapping[str, Any]) -> dict:
+        """Run structured Postgres aggregates over session metadata."""
         resp = self._client.post(
-            "/v1/track/sessions/search",
+            "/v1/track/sessions/aggregate",
             json=dict(body),
             headers=self._headers(),
         )
@@ -222,23 +260,32 @@ class TrackAPIClient:
         _raise(resp)
         return resp.json()
 
-    def get_session_content_url(self, session_id: str) -> str:
+    def get_session_content_info(self, session_id: str) -> dict:
         resp = self._client.get(
             f"/v1/track/sessions/{session_id}/content",
             headers=self._headers(),
         )
         _raise(resp)
-        url = resp.json().get("url")
+        data = resp.json()
+        url = data.get("url")
         if not url:
             raise TrackAPIError("Session content response did not include a URL")
-        return str(url)
+        data["url"] = str(url)
+        data.setdefault("content_codec", "raw")
+        return data
+
+    def get_session_content_url(self, session_id: str) -> str:
+        return str(self.get_session_content_info(session_id)["url"])
 
     def download_session_content(self, session_id: str) -> bytes:
         """Fetch native session bytes via the orchestrator-issued S3 URL."""
-        url = self.get_session_content_url(session_id)
-        resp = self._client.get(url)
+        info = self.get_session_content_info(session_id)
+        resp = self._client.get(info["url"])
         _raise(resp)
-        return resp.content
+        content = resp.content
+        if info.get("content_codec") == "gzip":
+            return gzip.decompress(content)
+        return content
 
     # ------------------------------------------------------------------ #
     # Internals                                                            #

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -16,6 +16,7 @@ from .api import TrackAPIClient, TrackAPIError
 from .daemon import main as daemon_main
 from .install import install, is_installed, uninstall
 from .paths import TrackPaths
+from .query_schema import search_filter_catalog
 from .queue import UploadQueue
 from .sources import detect_sources
 from .status import is_running, read_status
@@ -28,100 +29,8 @@ console = Console()
 DEFAULT_SESSION_SOURCE = "remote"
 LOCAL_SESSION_SOURCE = "local"
 DEFAULT_SEARCH_TOP_K = 50
-TURBOPUFFER_QUERY_DOCS_URL = "https://turbopuffer.com/docs/query#filtering"
-SEARCH_FILTER_FIELDS = (
-    {
-        "name": "session_id",
-        "type": "string",
-        "description": "Fleet session id.",
-    },
-    {
-        "name": "user_id",
-        "type": "string",
-        "description": "Fleet user id that owns the session.",
-    },
-    {
-        "name": "device_id",
-        "type": "string",
-        "description": "Tracked local device id.",
-    },
-    {
-        "name": "tool",
-        "type": "string",
-        "description": "AI tool name, for example codex or claude.",
-    },
-    {
-        "name": "cwd",
-        "type": "string",
-        "description": "Working directory captured for the session.",
-    },
-    {
-        "name": "repo_url",
-        "type": "string",
-        "description": "Detected repository remote URL.",
-    },
-    {
-        "name": "git_branch",
-        "type": "string",
-        "description": "Detected git branch.",
-    },
-    {
-        "name": "model",
-        "type": "string",
-        "description": "Model name when captured by the source tool.",
-    },
-    {
-        "name": "forked_from",
-        "type": "string",
-        "description": "Parent Fleet session id when this session was forked.",
-    },
-    {
-        "name": "event_count",
-        "type": "integer",
-        "description": "Number of tracked events in the session.",
-    },
-    {
-        "name": "started_at",
-        "type": "datetime",
-        "description": "Session start timestamp in ISO-8601 format.",
-    },
-    {
-        "name": "last_active",
-        "type": "datetime",
-        "description": "Most recent session activity timestamp in ISO-8601 format.",
-    },
-)
-SEARCH_FILTER_OPERATORS = (
-    "And",
-    "Or",
-    "Not",
-    "Eq",
-    "NotEq",
-    "In",
-    "NotIn",
-    "Contains",
-    "NotContains",
-    "ContainsAny",
-    "NotContainsAny",
-    "Lt",
-    "Lte",
-    "Gt",
-    "Gte",
-    "AnyLt",
-    "AnyLte",
-    "AnyGt",
-    "AnyGte",
-    "Glob",
-    "NotGlob",
-    "IGlob",
-    "NotIGlob",
-    "Regex",
-    "ContainsAllTokens",
-    "ContainsTokenSequence",
-    "ContainsAnyToken",
-)
 SOURCE_HELP = (
-    "Where to read sessions from: remote (default, orchestrator/Turbopuffer) "
+    "Where to read sessions from: remote (default, orchestrator) "
     "or local (manually built Fleet local index)."
 )
 
@@ -410,7 +319,7 @@ def _read_json_argument(value: str) -> dict:
     except json.JSONDecodeError as e:
         raise typer.BadParameter(f"invalid JSON: {e}") from e
     if not isinstance(parsed, dict):
-        raise typer.BadParameter("search body must be a JSON object")
+        raise typer.BadParameter("body must be a JSON object")
     return parsed
 
 
@@ -421,22 +330,7 @@ def _sessions_from_api_items(items: list[dict]):
 
 
 def _search_filter_catalog() -> dict:
-    return {
-        "docs_url": TURBOPUFFER_QUERY_DOCS_URL,
-        "filterable_attributes": list(SEARCH_FILTER_FIELDS),
-        "operators": list(SEARCH_FILTER_OPERATORS),
-        "examples": [
-            ["tool", "Eq", "codex"],
-            ["last_active", "Gte", "2026-05-01T00:00:00Z"],
-            [
-                "And",
-                [
-                    ["repo_url", "Eq", "git@github.com:fleet-ai/theseus.git"],
-                    ["tool", "Eq", "codex"],
-                ],
-            ],
-        ],
-    }
+    return search_filter_catalog()
 
 
 def _print_search_filter_catalog(json_out: bool) -> None:
@@ -456,7 +350,9 @@ def _print_search_filter_catalog(json_out: bool) -> None:
     console.print("[bold]Operators[/bold]")
     console.print(", ".join(catalog["operators"]))
     console.print()
-    console.print(f"[bold]Turbopuffer docs[/bold] {catalog['docs_url']}")
+    console.print("[bold]Logical operators[/bold] " + ", ".join(catalog["logical_operators"]))
+    console.print()
+    console.print("[bold]Time fields[/bold] " + ", ".join(catalog["time_fields"]))
 
 
 def _render_sessions_table(sessions, next_cursor: str | None) -> None:
@@ -573,14 +469,17 @@ def search_sessions(
 ) -> None:
     """Search tracked sessions.
 
-    Search is Turbopuffer-only. `flt track ls` lists deterministic metadata from
-    Postgres; `flt track search` posts a JSON object to the search index for
-    ranked results and returns hydrated Fleet session metadata.
+    Search uses Fleet's structured session search shape. Orchestrator compiles
+    filters/time into the Turbopuffer session index, injects the caller's team
+    boundary, and returns hydrated Fleet session metadata. Use `flt track aggregate`
+    for aggregate Postgres queries and `flt track download` before intra-session
+    analysis with local tools such as `rg`, `jq`, or Python.
 
     Input:
 
     \b
-      flt track search '{"query":"bugbot local index","top_k":20}'
+      flt track search '{"query":"bugbot local index","limit":20}'
+      flt track search '{"mode":"keyword","query":"schema error","filters":{"tool":"codex"}}'
       flt track search @search.json
       flt track search -
       flt track search --filters
@@ -588,20 +487,11 @@ def search_sessions(
     JSON fields:
 
     \b
-      query    string   Orchestrator-managed hybrid search: BM25 over
-                        `search_text` plus ANN over `vector`.
-      top_k    integer  Maximum ranked results to return. Defaults to 50.
-      filters  array    Turbopuffer filter expression, forwarded as-is.
-      rank_by  array    Turbopuffer ranking expression, forwarded as-is.
-
-    The command posts this body to `POST /v1/track/sessions/search`. The server
-    always injects the caller's team boundary and returns hydrated Fleet session
-    metadata.
-
-    Turbopuffer query/filter docs:
-
-    \b
-      https://turbopuffer.com/docs/query#filtering
+      query    string   Natural-language search text.
+      mode     string   hybrid (default), keyword, semantic, or recent.
+      limit    integer  Maximum ranked results to return. Defaults to 50.
+      filters  object   Mongo-style exact/range/boolean filters.
+      time     object   Shared time range, e.g. {"field":"last_active","since":"7d"}.
 
     Filterable attributes:
 
@@ -609,23 +499,21 @@ def search_sessions(
       session_id, user_id, device_id, tool, cwd, repo_url, git_branch,
       model, forked_from, event_count, started_at, last_active
 
-    `team_id` is always injected by orchestrator. Use Turbopuffer filter arrays:
+    `team_id` is always injected by orchestrator. Filters support direct field
+    equality, Mongo-style field operators, and boolean operators:
 
     \b
-      ["tool","Eq","codex"]
-      ["last_active","Gte","2026-05-01T00:00:00Z"]
-      ["And",[[...],[...]]]
-
-    Common filter operators: And, Or, Not, Eq, NotEq, In, NotIn, Lt, Lte,
-    Gt, Gte, Contains, ContainsAny.
+      {"tool":"codex"}
+      {"event_count":{"$gte":1000}}
+      {"$or":[{"repo_url":{"$contains":"theseus"}},{"repo_url":{"$contains":"fleet-sdk"}}]}
 
     Example body:
 
     \b
       {"query":"deployment debugging",
-       "filters":["And",[["repo_url","Eq","git@github.com:fleet-ai/theseus.git"],
-                         ["tool","Eq","codex"]]],
-       "top_k":25}
+       "filters":{"repo_url":{"$contains":"theseus"},"tool":{"$in":["codex","claude"]}},
+       "time":{"field":"last_active","gte":"2026-05-01T00:00:00Z"},
+       "limit":25}
     """
     if show_filters:
         _print_search_filter_catalog(json_out)
@@ -636,8 +524,9 @@ def search_sessions(
 
     body = _read_json_argument(body_arg)
 
-    body.setdefault("top_k", DEFAULT_SEARCH_TOP_K)
-    data = TrackAPIClient().search_sessions_raw(body)
+    if "limit" not in body and "top_k" not in body:
+        body["limit"] = DEFAULT_SEARCH_TOP_K
+    data = TrackAPIClient().search_sessions(body)
     sessions = _sessions_from_api_items(data.get("items", []))
     next_cursor = data.get("next_cursor")
 
@@ -647,7 +536,7 @@ def search_sessions(
             source="remote",
             sessions=sessions,
             next_cursor=next_cursor,
-            mode="tpuf",
+            mode=str(body.get("mode") or "hybrid"),
         )
         return
 
@@ -656,6 +545,84 @@ def search_sessions(
         return
 
     _render_sessions_table(sessions, next_cursor)
+
+
+@app.command(name="aggregate")
+def aggregate_sessions(
+    body_arg: str = typer.Argument(
+        ...,
+        metavar="BODY",
+        help="JSON aggregate body. Pass inline JSON, @file, or - for stdin.",
+    ),
+    json_out: bool = typer.Option(
+        True,
+        "--json/--table",
+        help="Emit agent-friendly JSON by default; use --table for a human table.",
+    ),
+) -> None:
+    """Aggregate tracked session metadata.
+
+    Aggregates are Postgres-backed and use the same Mongo-style `filters` and
+    `time` shapes as search. No raw SQL is accepted. The body also supports
+    `time_bucket`, `order_by`, and `having` for SQL-like grouped summaries.
+
+    \b
+      flt track aggregate '{"group_by":["repo_url","tool"],"metrics":["count","sum_event_count"]}'
+      flt track aggregate '{"time":{"field":"last_active","since":"30d"},"group_by":["tool"]}'
+      flt track aggregate '{"group_by":["repo_url"],"time_bucket":{"field":"last_active","interval":"day"},"having":{"count":{"$gte":5}},"order_by":[{"field":"count","direction":"desc"}]}'
+    """
+    body = _read_json_argument(body_arg)
+    data = TrackAPIClient().aggregate_sessions(body)
+    if json_out:
+        console.print_json(json.dumps(data))
+        return
+
+    groups = data.get("groups") or []
+    if not groups:
+        console.print("[dim]No aggregate rows found.[/dim]")
+        return
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Key")
+    metric_names = [k for k in groups[0].keys() if k != "key"]
+    for name in metric_names:
+        table.add_column(name, justify="right")
+    for group in groups:
+        table.add_row(
+            json.dumps(group.get("key", {}), sort_keys=True),
+            *[str(group.get(name, "")) for name in metric_names],
+        )
+    console.print(table)
+
+
+@app.command(name="download")
+def download_session(
+    session_id: str = typer.Argument(..., help="Session id to download into cache."),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-download even if the cached metadata signature matches.",
+    ),
+    json_out: bool = typer.Option(
+        True,
+        "--json/--path",
+        help="Emit JSON by default; use --path to print only the local JSONL path.",
+    ),
+) -> None:
+    """Download a session for local intra-session analysis.
+
+    The command asks orchestrator for an authorized presigned URL, downloads the
+    session into `~/.fleet/track/cache/sessions/<id>/session.jsonl`, and
+    transparently decompresses gzip-stored objects. After this, agents should use
+    local tools such as `rg`, `jq`, `sed`, or Python against the returned path.
+    """
+    from .download import ensure_local_session
+
+    cached = ensure_local_session(session_id, force=force)
+    payload = cached.to_dict()
+    if json_out:
+        console.print_json(json.dumps(payload))
+    else:
+        console.print(payload["path"])
 
 
 @app.command()

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -39,7 +39,7 @@ from .status import (
     write_status,
 )
 from .store import session_from_native_path
-from .uploader import HttpxTransport, Transport, UploadPool
+from .uploader import HttpxTransport, Transport, UploadPayload, UploadPool
 
 if TYPE_CHECKING:
     from .reconciler import ReconcileResult
@@ -383,7 +383,12 @@ class Daemon:
     # Upload callbacks                                                     #
     # ------------------------------------------------------------------ #
 
-    def _on_upload_done(self, rel_path: str, sha256: str) -> None:
+    def _on_upload_done(
+        self,
+        rel_path: str,
+        sha256: str,
+        upload_payload: UploadPayload | None = None,
+    ) -> None:
         if _is_unsupported_manifest_path(rel_path):
             self._queue.delete_paths([rel_path])
             with self._confirmed_lock:
@@ -398,7 +403,7 @@ class Daemon:
         with self._confirmed_lock:
             self._confirmed_map[rel_path] = sha256
         self._manifest_dirty = True
-        self._upsert_session_metadata(rel_path, sha256)
+        self._upsert_session_metadata(rel_path, sha256, upload_payload=upload_payload)
 
     def _on_upload_failed(self, rel_path: str, sha256: str, error: str) -> None:
         self._queue.mark_failed(rel_path, sha256, error)
@@ -416,13 +421,23 @@ class Daemon:
         for rel_path, digest in file_map.items():
             self._upsert_session_metadata(rel_path, digest)
 
-    def _upsert_session_metadata(self, rel_path: str, sha256: str) -> None:
+    def _upsert_session_metadata(
+        self,
+        rel_path: str,
+        sha256: str,
+        *,
+        upload_payload: UploadPayload | None = None,
+    ) -> None:
         """Best-effort metadata index update for a confirmed S3 object.
 
         The v1 syncer's correctness still comes from S3 bytes + manifest. The
         metadata index is a read-side accelerator for listing/resume, so a
         transient failure here should be retried on a later reconcile rather
         than marking the file upload failed.
+
+        `upload_payload` is only present immediately after this process uploads
+        the file. For files merely confirmed by the remote manifest, omit
+        content metadata so orchestrator preserves the known S3 codec/size.
         """
         if rel_path == "manifest.json":
             return
@@ -435,11 +450,20 @@ class Daemon:
         if session is None:
             return
 
+        kwargs = {"include_content_metadata": False}
+        if upload_payload is not None:
+            kwargs = {
+                "content_codec": upload_payload.content_codec,
+                "raw_bytes": upload_payload.raw_bytes,
+                "stored_bytes": upload_payload.stored_bytes,
+            }
+
         try:
             self._api.upsert_session(
                 device_id=self._device_id,
                 path=rel_path,
                 session=session,
+                **kwargs,
             )
         except Exception as e:
             log.warning("metadata upsert failed %s: %s", rel_path, e)

--- a/fleet/track/download.py
+++ b/fleet/track/download.py
@@ -1,0 +1,130 @@
+"""Local session content cache for agentic intra-session analysis.
+
+The orchestrator remains the auth boundary: it returns content metadata plus a
+presigned S3 URL. The SDK downloads/decompresses into a deterministic local
+cache, then agents can use normal local tools (`rg`, `jq`, `sed`, Python) on the
+canonical JSONL file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import zlib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+from .api import TrackAPIClient
+from .paths import TrackPaths
+
+
+@dataclass(frozen=True)
+class CachedSession:
+    session_id: str
+    path: str
+    metadata_path: str
+    cache_status: str
+    content_codec: str
+    raw_bytes: Optional[int]
+    stored_bytes: Optional[int]
+    event_count: int
+    last_active: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _session_cache_dir(paths: TrackPaths, session_id: str) -> Path:
+    return paths.cache_dir / "sessions" / session_id
+
+
+def _signature(info: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content_codec": info.get("content_codec") or "raw",
+        "raw_bytes": info.get("raw_bytes"),
+        "stored_bytes": info.get("stored_bytes"),
+        "event_count": info.get("event_count") or 0,
+        "last_active": info.get("last_active"),
+    }
+
+
+def _metadata_matches(metadata_path: Path, info: dict[str, Any]) -> bool:
+    try:
+        current = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return current.get("signature") == _signature(info)
+
+
+def _write_stream(url: str, codec: str, dest: Path) -> None:
+    timeout = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
+    decompressor = (
+        zlib.decompressobj(16 + zlib.MAX_WBITS) if codec == "gzip" else None
+    )
+    with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+        with client.stream("GET", url) as resp:
+            resp.raise_for_status()
+            with dest.open("wb") as out:
+                for chunk in resp.iter_bytes():
+                    if not chunk:
+                        continue
+                    if decompressor is not None:
+                        out.write(decompressor.decompress(chunk))
+                    else:
+                        out.write(chunk)
+                if decompressor is not None:
+                    out.write(decompressor.flush())
+
+
+def ensure_local_session(
+    session_id: str,
+    *,
+    api: Optional[TrackAPIClient] = None,
+    paths: Optional[TrackPaths] = None,
+    force: bool = False,
+) -> CachedSession:
+    """Ensure a session's canonical JSONL exists in the local cache."""
+    api = api or TrackAPIClient()
+    paths = paths or TrackPaths.default()
+    info = api.get_session_content_info(session_id)
+    codec = str(info.get("content_codec") or "raw")
+    if codec not in {"raw", "gzip"}:
+        raise ValueError(f"unsupported session content codec: {codec}")
+
+    cache_dir = _session_cache_dir(paths, session_id)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    session_path = cache_dir / "session.jsonl"
+    metadata_path = cache_dir / "metadata.json"
+
+    cache_status = "hit"
+    if force or not session_path.exists() or not _metadata_matches(metadata_path, info):
+        cache_status = "refreshed" if session_path.exists() else "downloaded"
+        tmp_path = cache_dir / "session.jsonl.tmp"
+        try:
+            _write_stream(info["url"], codec, tmp_path)
+            os.replace(tmp_path, session_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+        metadata = {
+            "session_id": session_id,
+            "path": str(session_path),
+            "downloaded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "signature": _signature(info),
+        }
+        metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True))
+
+    return CachedSession(
+        session_id=session_id,
+        path=str(session_path),
+        metadata_path=str(metadata_path),
+        cache_status=cache_status,
+        content_codec=codec,
+        raw_bytes=info.get("raw_bytes"),
+        stored_bytes=info.get("stored_bytes"),
+        event_count=int(info.get("event_count") or 0),
+        last_active=info.get("last_active"),
+    )

--- a/fleet/track/paths.py
+++ b/fleet/track/paths.py
@@ -27,6 +27,7 @@ class TrackPaths:
     pid_file: Path
     log_file: Path
     config_file: Path
+    cache_dir: Path
 
     @classmethod
     def default(cls) -> "TrackPaths":
@@ -50,6 +51,7 @@ class TrackPaths:
             pid_file=track_dir / "daemon.pid",
             log_file=track_dir / "daemon.log",
             config_file=track_dir / "config.json",
+            cache_dir=track_dir / "cache",
         )
 
     def ensure_track_dir(self) -> None:

--- a/fleet/track/query_schema.py
+++ b/fleet/track/query_schema.py
@@ -1,0 +1,128 @@
+"""Shared schema descriptions for Fleet track query tools."""
+
+from __future__ import annotations
+
+SEARCH_FILTER_FIELDS = (
+    {
+        "name": "session_id",
+        "type": "string",
+        "description": "Fleet session id.",
+    },
+    {
+        "name": "user_id",
+        "type": "string",
+        "description": "Fleet user id that owns the session.",
+    },
+    {
+        "name": "device_id",
+        "type": "string",
+        "description": "Tracked local device id.",
+    },
+    {
+        "name": "tool",
+        "type": "string",
+        "description": "AI tool name, for example codex or claude.",
+    },
+    {
+        "name": "cwd",
+        "type": "string",
+        "description": "Working directory captured for the session.",
+    },
+    {
+        "name": "repo_url",
+        "type": "string",
+        "description": "Detected repository remote URL.",
+    },
+    {
+        "name": "git_branch",
+        "type": "string",
+        "description": "Detected git branch.",
+    },
+    {
+        "name": "model",
+        "type": "string",
+        "description": "Model name when captured by the source tool.",
+    },
+    {
+        "name": "forked_from",
+        "type": "string",
+        "description": "Parent Fleet session id when this session was forked.",
+    },
+    {
+        "name": "event_count",
+        "type": "integer",
+        "description": "Number of tracked events in the session.",
+    },
+    {
+        "name": "started_at",
+        "type": "datetime",
+        "description": "Session start timestamp in ISO-8601 format.",
+    },
+    {
+        "name": "last_active",
+        "type": "datetime",
+        "description": "Most recent session activity timestamp in ISO-8601 format.",
+    },
+)
+
+SEARCH_FILTER_OPERATORS = (
+    "eq/$eq",
+    "ne/$ne",
+    "in/$in",
+    "nin/$nin",
+    "gt/$gt",
+    "gte/$gte",
+    "lt/$lt",
+    "lte/$lte",
+    "contains/$contains",
+    "glob/$glob",
+    "regex/$regex",
+)
+
+SEARCH_LOGICAL_OPERATORS = ("$and", "$or", "$not", "$nor")
+SEARCH_TIME_FIELDS = ("last_active", "started_at")
+
+AGGREGATE_METRICS = (
+    "count",
+    "sum_event_count",
+    "min_event_count",
+    "max_event_count",
+    "avg_event_count",
+    "distinct_user_count",
+    "distinct_device_count",
+    "distinct_repo_count",
+    "distinct_model_count",
+)
+AGGREGATE_FEATURES = ("time_bucket", "order_by", "having")
+
+
+def search_filter_catalog() -> dict:
+    return {
+        "description": "Structured Fleet session filters. Orchestrator compiles these to Postgres or Turbopuffer as needed.",
+        "filterable_attributes": list(SEARCH_FILTER_FIELDS),
+        "operators": list(SEARCH_FILTER_OPERATORS),
+        "logical_operators": list(SEARCH_LOGICAL_OPERATORS),
+        "time_fields": list(SEARCH_TIME_FIELDS),
+        "aggregate_metrics": list(AGGREGATE_METRICS),
+        "aggregate_features": list(AGGREGATE_FEATURES),
+        "examples": [
+            {"filters": {"tool": "codex"}},
+            {
+                "filters": {
+                    "$or": [
+                        {"repo_url": {"$contains": "theseus"}},
+                        {"repo_url": {"$contains": "fleet-sdk"}},
+                    ],
+                    "event_count": {"$gte": 1000},
+                }
+            },
+            {"time": {"field": "last_active", "since": "7d"}},
+            {
+                "filters": {
+                    "repo_url": "github.com/fleet-ai/theseus",
+                    "tool": "codex",
+                    "event_count": {"gte": 1000},
+                }
+            },
+        ],
+    }

--- a/fleet/track/uploader.py
+++ b/fleet/track/uploader.py
@@ -10,8 +10,11 @@ purpose-built `RecordingTransport`.
 
 from __future__ import annotations
 
+import gzip
 import logging
+import os
 import threading
+from dataclasses import dataclass
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable, Optional, Protocol
@@ -26,6 +29,15 @@ WORKERS = 8
 # Per-phase timeouts: connect/read can be short, write is generous for
 # large JSONL files on slow connections.
 DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=300.0, pool=10.0)
+SUPPORTED_CONTENT_CODECS = {"raw", "gzip"}
+
+
+@dataclass(frozen=True)
+class UploadPayload:
+    content: bytes
+    content_codec: str
+    raw_bytes: int
+    stored_bytes: int
 
 
 # ------------------------------------------------------------------ #
@@ -89,10 +101,76 @@ def _read_safe(path: Path) -> Optional[bytes]:
     return data
 
 
+def upload_content_codec() -> str:
+    """Return the configured S3 storage codec for session uploads.
+
+    Defaults to raw for safe rollout. Set FLEET_TRACK_UPLOAD_CODEC=gzip or
+    FLEET_TRACK_COMPRESS_UPLOADS=1 to store scrubbed session JSONL compressed
+    in S3. Downloads use orchestrator metadata to decode transparently.
+    """
+    explicit = os.getenv("FLEET_TRACK_UPLOAD_CODEC")
+    if explicit:
+        codec = explicit.strip().lower()
+    elif os.getenv("FLEET_TRACK_COMPRESS_UPLOADS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        codec = "gzip"
+    else:
+        codec = "raw"
+    if codec not in SUPPORTED_CONTENT_CODECS:
+        log.warning("unsupported track upload codec %r; falling back to raw", codec)
+        return "raw"
+    return codec
+
+
+def prepare_upload_payload(path: Path) -> Optional[UploadPayload]:
+    """Read, scrub, and encode a file exactly as it will be stored in S3."""
+    data = _read_safe(path)
+    if data is None:
+        return None
+
+    scrubbed = scrub_bytes(data)
+    codec = upload_content_codec()
+    if codec == "gzip":
+        content = gzip.compress(scrubbed, compresslevel=6)
+    else:
+        content = scrubbed
+    return UploadPayload(
+        content=content,
+        content_codec=codec,
+        raw_bytes=len(scrubbed),
+        stored_bytes=len(content),
+    )
+
+
 def upload_one(path: Path, presigned_url: str, transport: Transport) -> bool:
     """Scrub and upload a single file. Returns True on success."""
     ok, _bytes_uploaded = _upload_one_with_size(path, presigned_url, transport)
     return ok
+
+
+def _upload_one_with_payload(
+    path: Path,
+    presigned_url: str,
+    transport: Transport,
+) -> tuple[bool, Optional[UploadPayload]]:
+    """Upload one file and return whether it succeeded plus exact stored payload."""
+    payload = prepare_upload_payload(path)
+    if payload is None:
+        return False, None
+
+    try:
+        status = transport.put(presigned_url, payload.content)
+        if status not in (200, 204):
+            log.warning("upload %s → HTTP %s", path.name, status)
+            return False, None
+        return True, payload
+    except httpx.RequestError as e:
+        log.warning("upload %s network error: %s", path.name, e)
+        return False, None
 
 
 def _upload_one_with_size(
@@ -101,21 +179,8 @@ def _upload_one_with_size(
     transport: Transport,
 ) -> tuple[bool, int]:
     """Upload one file and return whether it succeeded plus uploaded bytes."""
-    data = _read_safe(path)
-    if data is None:
-        return False, 0
-
-    scrubbed = scrub_bytes(data)
-
-    try:
-        status = transport.put(presigned_url, scrubbed)
-        if status not in (200, 204):
-            log.warning("upload %s → HTTP %s", path.name, status)
-            return False, 0
-        return True, len(scrubbed)
-    except httpx.RequestError as e:
-        log.warning("upload %s network error: %s", path.name, e)
-        return False, 0
+    ok, payload = _upload_one_with_payload(path, presigned_url, transport)
+    return ok, payload.stored_bytes if payload is not None else 0
 
 
 # ------------------------------------------------------------------ #
@@ -128,7 +193,7 @@ class UploadPool:
 
     def __init__(
         self,
-        on_done: Callable[[str, str], None],
+        on_done: Callable[[str, str, UploadPayload], None],
         on_failed: Callable[[str, str, str], None],
         transport: Optional[Transport] = None,
         on_uploaded_bytes: Optional[Callable[[str, int], None]] = None,
@@ -154,7 +219,7 @@ class UploadPool:
         self, rel_path: str, sha256: str, abs_path: Path, presigned_url: str
     ) -> None:
         try:
-            ok, bytes_uploaded = _upload_one_with_size(
+            ok, payload = _upload_one_with_payload(
                 abs_path,
                 presigned_url,
                 self._transport,
@@ -162,8 +227,8 @@ class UploadPool:
             if ok:
                 log.debug("uploaded %s", rel_path)
                 if self._on_uploaded_bytes is not None:
-                    self._on_uploaded_bytes(rel_path, bytes_uploaded)
-                self._on_done(rel_path, sha256)
+                    self._on_uploaded_bytes(rel_path, payload.stored_bytes)
+                self._on_done(rel_path, sha256, payload)
             else:
                 self._on_failed(rel_path, sha256, "upload returned failure")
         except Exception as e:

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import gzip
 from typing import Optional
 
 import httpx
@@ -167,6 +168,9 @@ def test_upsert_session_posts_relative_path_and_session_payload():
             "event_count": 3,
             "metadata": {"title": "demo"},
         },
+        content_codec="gzip",
+        raw_bytes=1000,
+        stored_bytes=200,
     )
 
     assert captured["url"] == (
@@ -175,6 +179,35 @@ def test_upsert_session_posts_relative_path_and_session_payload():
     assert captured["body"]["device_id"] == "dev1"
     assert captured["body"]["path"].startswith(".codex/sessions/")
     assert captured["body"]["session"]["tool"] == "codex"
+    assert captured["body"]["content_codec"] == "gzip"
+    assert captured["body"]["raw_bytes"] == 1000
+    assert captured["body"]["stored_bytes"] == 200
+
+
+def test_upsert_session_can_omit_content_metadata():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(204)
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    api.upsert_session(
+        device_id="dev1",
+        path=".codex/sessions/rollout-2026-05-05T00-00-00-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+        session={
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "tool": "codex",
+            "cwd": "/tmp/project",
+            "event_count": 3,
+        },
+        include_content_metadata=False,
+    )
+
+    assert captured["body"]["device_id"] == "dev1"
+    assert "content_codec" not in captured["body"]
+    assert "raw_bytes" not in captured["body"]
+    assert "stored_bytes" not in captured["body"]
 
 
 def test_list_sessions_sends_filters_and_returns_json():
@@ -251,6 +284,54 @@ def test_search_sessions_raw_posts_turbopuffer_body_and_returns_json():
     assert out["items"][0]["id"] == "s1"
 
 
+def test_search_sessions_posts_structured_body_and_returns_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"items": [], "next_cursor": None})
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.search_sessions(
+        {
+            "query": "schema failure",
+            "filters": {"tool": "codex"},
+            "time": {"field": "last_active", "since": "7d"},
+            "limit": 5,
+        }
+    )
+
+    assert captured["url"] == "http://test/v1/track/sessions/search"
+    assert captured["body"]["filters"] == {"tool": "codex"}
+    assert out["items"] == []
+
+
+def test_aggregate_sessions_posts_body_and_returns_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "backend": "postgres",
+                "groups": [{"key": {"tool": "codex"}, "count": 2}],
+                "row_count": 2,
+                "total_groups": 1,
+                "truncated": False,
+            },
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.aggregate_sessions({"group_by": ["tool"], "metrics": ["count"]})
+
+    assert captured["url"] == "http://test/v1/track/sessions/aggregate"
+    assert captured["body"]["group_by"] == ["tool"]
+    assert out["groups"][0]["count"] == 2
+
+
 def test_download_session_content_uses_presigned_url_without_auth_headers():
     seen: list[tuple[str, str | None]] = []
 
@@ -268,6 +349,23 @@ def test_download_session_content_uses_presigned_url_without_auth_headers():
         ("http://test/v1/track/sessions/s1/content", "Bearer test-api-key"),
         ("https://s3.test/session", None),
     ]
+
+
+def test_download_session_content_decompresses_gzip_content():
+    compressed = gzip.compress(b'{"ok": true}\n')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/track/sessions/s1/content":
+            return httpx.Response(
+                200,
+                json={"url": "https://s3.test/session", "content_codec": "gzip"},
+            )
+        if str(request.url) == "https://s3.test/session":
+            return httpx.Response(200, content=compressed)
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    assert api.download_session_content("s1") == b'{"ok": true}\n'
 
 
 def test_unauthenticated_raises_track_api_error():

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -142,11 +142,11 @@ def test_track_ls_honors_explicit_local_source(monkeypatch):
     assert json.loads(result.stdout)["source"] == "local"
 
 
-def test_track_search_posts_inline_json_to_raw_remote_search(monkeypatch):
+def test_track_search_posts_inline_json_to_remote_search(monkeypatch):
     calls: list[dict] = []
 
     class FakeAPI:
-        def search_sessions_raw(self, body):
+        def search_sessions(self, body):
             calls.append(body)
             return {
                 "items": [
@@ -170,16 +170,16 @@ def test_track_search_posts_inline_json_to_raw_remote_search(monkeypatch):
             json.dumps(
                 {
                     "query": "who worked on turbopuffer indexing",
-                    "top_k": 5,
+                    "limit": 5,
                 }
             ),
         ],
     )
 
     assert result.exit_code == 0, result.stdout
-    assert calls == [{"query": "who worked on turbopuffer indexing", "top_k": 5}]
+    assert calls == [{"query": "who worked on turbopuffer indexing", "limit": 5}]
     payload = json.loads(result.stdout)
-    assert payload["mode"] == "tpuf"
+    assert payload["mode"] == "hybrid"
     assert payload["source"] == "remote"
     assert payload["query"] == "who worked on turbopuffer indexing"
     assert payload["items"][0]["metadata"]["title"] == "Turbopuffer indexing"
@@ -208,7 +208,7 @@ def test_track_search_requires_json_object(monkeypatch):
     result = runner.invoke(cli.app, ["search", json.dumps(["not", "an", "object"])])
 
     assert result.exit_code != 0
-    assert "search body must be a JSON object" in (result.stdout + result.stderr)
+    assert "body must be a JSON object" in (result.stdout + result.stderr)
 
 
 def test_track_search_requires_body_unless_listing_filters(monkeypatch):
@@ -237,22 +237,24 @@ def test_track_search_filters_outputs_catalog_json(monkeypatch):
 
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
-    assert payload["docs_url"] == "https://turbopuffer.com/docs/query#filtering"
+    assert "Structured Fleet session filters" in payload["description"]
     assert {field["name"] for field in payload["filterable_attributes"]} >= {
         "tool",
         "repo_url",
         "event_count",
         "last_active",
     }
-    assert "Eq" in payload["operators"]
-    assert "ContainsAnyToken" in payload["operators"]
+    assert "gte/$gte" in payload["operators"]
+    assert "contains/$contains" in payload["operators"]
+    assert "$or" in payload["logical_operators"]
+    assert "time_bucket" in payload["aggregate_features"]
 
 
 def test_track_search_applies_default_top_k(monkeypatch):
     calls: list[dict] = []
 
     class FakeAPI:
-        def search_sessions_raw(self, body):
+        def search_sessions(self, body):
             calls.append(body)
             return {"items": [], "next_cursor": None}
 
@@ -262,15 +264,15 @@ def test_track_search_applies_default_top_k(monkeypatch):
         cli.app,
         [
             "search",
-            json.dumps({"filters": ["tool", "Eq", "claude"]}),
+            json.dumps({"filters": {"tool": "claude"}}),
         ],
     )
 
     assert result.exit_code == 0, result.stdout
     assert calls == [
         {
-            "filters": ["tool", "Eq", "claude"],
-            "top_k": 50,
+            "filters": {"tool": "claude"},
+            "limit": 50,
         }
     ]
 
@@ -279,20 +281,17 @@ def test_track_search_posts_json_file_to_remote_api(tmp_path, monkeypatch):
     calls: list[dict] = []
     spec = {
         "query": "bugbot local index",
-        "filters": [
-            "And",
-            [
-                ["repo_url", "Eq", "git@github.com:fleet-ai/fleet-sdk.git"],
-                ["tool", "Eq", "codex"],
-            ],
-        ],
-        "top_k": 10,
+        "filters": {
+            "repo_url": "github.com/fleet-ai/fleet-sdk",
+            "tool": "codex",
+        },
+        "limit": 10,
     }
     spec_path = tmp_path / "search.json"
     spec_path.write_text(json.dumps(spec))
 
     class FakeAPI:
-        def search_sessions_raw(self, body):
+        def search_sessions(self, body):
             calls.append(body)
             return {
                 "items": [
@@ -314,7 +313,7 @@ def test_track_search_posts_json_file_to_remote_api(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     assert calls == [spec]
     payload = json.loads(result.stdout)
-    assert payload["mode"] == "tpuf"
+    assert payload["mode"] == "hybrid"
     assert payload["source"] == "remote"
     assert payload["query"] == "bugbot local index"
     assert payload["items"][0]["id"] == "session-raw"
@@ -324,7 +323,7 @@ def test_track_search_reads_json_from_stdin(monkeypatch):
     calls: list[dict] = []
 
     class FakeAPI:
-        def search_sessions_raw(self, body):
+        def search_sessions(self, body):
             calls.append(body)
             return {"items": [], "next_cursor": None}
 
@@ -333,11 +332,11 @@ def test_track_search_reads_json_from_stdin(monkeypatch):
     result = runner.invoke(
         cli.app,
         ["search", "-"],
-        input=json.dumps({"rank_by": ["last_active", "desc"], "top_k": 25}),
+        input=json.dumps({"mode": "recent", "limit": 25}),
     )
 
     assert result.exit_code == 0, result.stdout
-    assert calls == [{"rank_by": ["last_active", "desc"], "top_k": 25}]
+    assert calls == [{"mode": "recent", "limit": 25}]
 
 
 def test_track_search_help_documents_json_body_mode():
@@ -346,10 +345,9 @@ def test_track_search_help_documents_json_body_mode():
     assert result.exit_code == 0, result.stdout
     assert "JSON search body" in result.stdout
     assert "flt track search @search.json" in result.stdout
-    assert "https://turbopuffer.com/docs/query#filtering" in result.stdout
-    assert "rank_by" in result.stdout
+    assert "mode" in result.stdout
     assert "filters" in result.stdout
-    assert "top_k" in result.stdout
+    assert "limit" in result.stdout
     assert "Filterable attributes" in result.stdout
     assert "repo_url" in result.stdout
     assert "last_active" in result.stdout
@@ -363,6 +361,66 @@ def test_track_search_help_documents_json_body_mode():
     assert "--since" not in result.stdout
     assert "--cursor" not in result.stdout
     assert "--source" not in result.stdout
+
+
+def test_track_aggregate_posts_json_to_aggregate_api(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeAPI:
+        def aggregate_sessions(self, body):
+            calls.append(body)
+            return {
+                "backend": "postgres",
+                "groups": [{"key": {"tool": "codex"}, "count": 2}],
+                "row_count": 2,
+                "total_groups": 1,
+                "truncated": False,
+            }
+
+    monkeypatch.setattr(cli, "TrackAPIClient", FakeAPI)
+
+    body = {"group_by": ["tool"], "metrics": ["count"]}
+    result = runner.invoke(cli.app, ["aggregate", json.dumps(body)])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == [body]
+    payload = json.loads(result.stdout)
+    assert payload["backend"] == "postgres"
+    assert payload["groups"][0]["count"] == 2
+
+
+def test_track_download_outputs_cached_session_json(monkeypatch):
+    from fleet.track import download as download_mod
+
+    class FakeCached:
+        def to_dict(self):
+            return {
+                "session_id": "s1",
+                "path": "/tmp/session.jsonl",
+                "metadata_path": "/tmp/metadata.json",
+                "cache_status": "downloaded",
+                "content_codec": "gzip",
+                "raw_bytes": 1000,
+                "stored_bytes": 200,
+                "event_count": 10,
+                "last_active": "2026-05-06T00:00:00Z",
+            }
+
+    calls: list[tuple[str, bool]] = []
+
+    def fake_ensure(session_id, *, force=False):
+        calls.append((session_id, force))
+        return FakeCached()
+
+    monkeypatch.setattr(download_mod, "ensure_local_session", fake_ensure)
+
+    result = runner.invoke(cli.app, ["download", "s1", "--force"])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == [("s1", True)]
+    payload = json.loads(result.stdout)
+    assert payload["path"] == "/tmp/session.jsonl"
+    assert payload["cache_status"] == "downloaded"
 
 
 def test_build_local_index_scans_native_files_into_local_store(tmp_path, monkeypatch):

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -13,6 +13,7 @@ from fleet.track.daemon import Daemon
 from fleet.track.merkle import HashCache, MerkleTree
 from fleet.track.paths import TrackPaths
 from fleet.track.queue import UploadQueue
+from fleet.track.uploader import UploadPayload
 
 
 def _auth() -> str:
@@ -109,6 +110,9 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
     assert upsert["session"]["cwd"] == "/tmp"
     assert upsert["session"]["event_count"] == 1
     assert upsert["session"]["metadata"]["origin_cwd"] == "/tmp"
+    assert upsert["content_codec"] == "raw"
+    assert upsert["raw_bytes"] == len(transport.calls[0][1])
+    assert upsert["stored_bytes"] == len(transport.calls[0][1])
 
     queue.close()
     cache.close()
@@ -210,7 +214,12 @@ def test_upload_done_ignores_legacy_cursor_paths(tmp_path: Path):
     daemon._confirmed_map[rel_path] = "old-digest"
     metadata_calls: list[tuple[str, str]] = []
 
-    def record_metadata(path: str, digest: str) -> None:
+    def record_metadata(
+        path: str,
+        digest: str,
+        *,
+        upload_payload: UploadPayload | None = None,
+    ) -> None:
         metadata_calls.append((path, digest))
 
     daemon._upsert_session_metadata = record_metadata  # type: ignore[method-assign]
@@ -245,7 +254,12 @@ def test_upload_done_uses_callback_digest_instead_of_stale_cache(tmp_path: Path)
     cache._conn.commit()
     metadata_calls: list[tuple[str, str]] = []
 
-    def record_metadata(path: str, digest: str) -> None:
+    def record_metadata(
+        path: str,
+        digest: str,
+        *,
+        upload_payload: UploadPayload | None = None,
+    ) -> None:
         metadata_calls.append((path, digest))
 
     daemon._upsert_session_metadata = record_metadata  # type: ignore[method-assign]
@@ -254,6 +268,102 @@ def test_upload_done_uses_callback_digest_instead_of_stale_cache(tmp_path: Path)
 
     assert daemon._confirmed_map[rel_path] == "fresh-digest"
     assert metadata_calls == [(rel_path, "fresh-digest")]
+
+    queue.close()
+    cache.close()
+
+
+def test_upload_done_upserts_exact_uploaded_payload_metadata(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    rel_path = (
+        ".codex/sessions/"
+        "rollout-2026-05-05T00-00-00-cccccccc-cccc-cccc-cccc-cccccccccccc.jsonl"
+    )
+    session_file = tmp_path / rel_path
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        '{"type":"session_meta","payload":{"id":"s3","cwd":"/tmp"}}\n'
+    )
+
+    metadata_upserts: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
+            metadata_upserts.append(json.loads(req.content))
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[session_file])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree, api=api)
+    payload = UploadPayload(
+        content=b"compressed",
+        content_codec="gzip",
+        raw_bytes=1000,
+        stored_bytes=10,
+    )
+
+    daemon._on_upload_done(rel_path, "fresh-digest", payload)
+
+    assert len(metadata_upserts) == 1
+    upsert = metadata_upserts[0]
+    assert upsert["content_codec"] == "gzip"
+    assert upsert["raw_bytes"] == 1000
+    assert upsert["stored_bytes"] == 10
+
+    queue.close()
+    cache.close()
+
+
+def test_confirmed_existing_metadata_upsert_omits_content_metadata(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    rel_path = (
+        ".codex/sessions/"
+        "rollout-2026-05-05T00-00-00-dddddddd-dddd-dddd-dddd-dddddddddddd.jsonl"
+    )
+    session_file = tmp_path / rel_path
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        '{"type":"session_meta","payload":{"id":"s4","cwd":"/tmp"}}\n'
+    )
+
+    metadata_upserts: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
+            metadata_upserts.append(json.loads(req.content))
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[session_file])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree, api=api)
+
+    daemon._upsert_metadata_for_paths({rel_path: "existing-digest"})
+
+    assert len(metadata_upserts) == 1
+    upsert = metadata_upserts[0]
+    assert "content_codec" not in upsert
+    assert "raw_bytes" not in upsert
+    assert "stored_bytes" not in upsert
 
     queue.close()
     cache.close()

--- a/tests/track/test_download.py
+++ b/tests/track/test_download.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fleet.track.download import ensure_local_session
+from fleet.track.paths import TrackPaths
+
+
+class FakeAPI:
+    def __init__(self, info):
+        self.info = info
+
+    def get_session_content_info(self, session_id: str):
+        assert session_id == "s1"
+        return dict(self.info)
+
+
+def test_ensure_local_session_downloads_and_caches(tmp_path: Path, monkeypatch):
+    paths = TrackPaths.under(tmp_path)
+    writes: list[tuple[str, str]] = []
+
+    def fake_write_stream(url: str, codec: str, dest: Path) -> None:
+        writes.append((url, codec))
+        dest.write_bytes(b'{"ok": true}\n')
+
+    monkeypatch.setattr("fleet.track.download._write_stream", fake_write_stream)
+
+    info = {
+        "url": "https://s3.test/session",
+        "content_codec": "gzip",
+        "raw_bytes": 1000,
+        "stored_bytes": 200,
+        "event_count": 10,
+        "last_active": "2026-05-06T00:00:00Z",
+    }
+    first = ensure_local_session("s1", api=FakeAPI(info), paths=paths)
+    second = ensure_local_session("s1", api=FakeAPI(info), paths=paths)
+
+    assert first.cache_status == "downloaded"
+    assert second.cache_status == "hit"
+    assert writes == [("https://s3.test/session", "gzip")]
+    assert Path(first.path).read_bytes() == b'{"ok": true}\n'
+
+
+def test_ensure_local_session_refreshes_when_signature_changes(tmp_path: Path, monkeypatch):
+    paths = TrackPaths.under(tmp_path)
+    bodies = [b'{"v": 1}\n', b'{"v": 2}\n']
+
+    def fake_write_stream(_url: str, _codec: str, dest: Path) -> None:
+        dest.write_bytes(bodies.pop(0))
+
+    monkeypatch.setattr("fleet.track.download._write_stream", fake_write_stream)
+
+    base = {
+        "url": "https://s3.test/session",
+        "content_codec": "raw",
+        "raw_bytes": 9,
+        "stored_bytes": 9,
+        "event_count": 1,
+        "last_active": "2026-05-06T00:00:00Z",
+    }
+    ensure_local_session("s1", api=FakeAPI(base), paths=paths)
+    changed = {**base, "event_count": 2}
+    refreshed = ensure_local_session("s1", api=FakeAPI(changed), paths=paths)
+
+    assert refreshed.cache_status == "refreshed"
+    assert Path(refreshed.path).read_bytes() == b'{"v": 2}\n'

--- a/tests/track/test_uploader.py
+++ b/tests/track/test_uploader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+import gzip
 from pathlib import Path
 from typing import Optional
 
@@ -14,6 +15,7 @@ from fleet.track.uploader import (
     Transport,
     UploadPool,
     _read_safe,
+    prepare_upload_payload,
     upload_one,
 )
 
@@ -95,6 +97,22 @@ def test_upload_one_scrubs_secrets(tmp_path: Path):
     assert b"REDACTED" in body
 
 
+def test_prepare_upload_payload_can_gzip_scrubbed_content(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FLEET_TRACK_UPLOAD_CODEC", "gzip")
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"key": "AKIAIOSFODNN7EXAMPLE"}\n')
+
+    payload = prepare_upload_payload(f)
+
+    assert payload is not None
+    assert payload.content_codec == "gzip"
+    decoded = gzip.decompress(payload.content)
+    assert b"AKIAIOSFODNN7EXAMPLE" not in decoded
+    assert b"REDACTED" in decoded
+    assert payload.raw_bytes == len(decoded)
+    assert payload.stored_bytes == len(payload.content)
+
+
 def test_upload_one_returns_false_on_4xx(tmp_path: Path):
     f = tmp_path / "x.jsonl"
     f.write_text("hi")
@@ -124,10 +142,12 @@ def test_pool_calls_on_done_for_success(tmp_path: Path):
     f = tmp_path / "x.jsonl"
     f.write_text("ok")
 
-    done: list[tuple[str, str]] = []
+    done: list[tuple[str, str, str, int, int]] = []
     failed: list[tuple[str, str, str]] = []
     pool = UploadPool(
-        on_done=lambda p, s: done.append((p, s)),
+        on_done=lambda p, s, payload: done.append(
+            (p, s, payload.content_codec, payload.raw_bytes, payload.stored_bytes)
+        ),
         on_failed=lambda p, s, e: failed.append((p, s, e)),
         transport=RecordingTransport(),
     )
@@ -136,7 +156,7 @@ def test_pool_calls_on_done_for_success(tmp_path: Path):
     pool.drain(timeout=5)
     pool.shutdown()
 
-    assert done == [("rel/x.jsonl", "h1")]
+    assert done == [("rel/x.jsonl", "h1", "raw", 2, 2)]
     assert failed == []
 
 
@@ -147,7 +167,7 @@ def test_pool_calls_on_failed_for_4xx(tmp_path: Path):
     done: list = []
     failed: list = []
     pool = UploadPool(
-        on_done=lambda p, s: done.append((p, s)),
+        on_done=lambda p, s, _payload: done.append((p, s)),
         on_failed=lambda p, s, e: failed.append((p, s, e)),
         transport=RecordingTransport(status_for_url={"https://s3/x": 403}),
     )


### PR DESCRIPTION
## Summary
- Add structured `flt track search BODY` for hybrid, keyword, semantic, and recent session search.
- Document Mongo-style filters for search/aggregate, including `$and`, `$or`, field operators, and time filters.
- Add `flt track aggregate BODY` for aggregate metadata queries, including `time_bucket`, `order_by`, `having`, and distinct/min metrics.
- Add `flt track download SESSION_ID` for local agentic analysis.
- Add backward-compatible upload/download compression metadata with raw as the default and gzip opt-in.
- Update fleet-track docs and focused tests.

## Tests
- `uv run ruff check fleet/track/api.py fleet/track/cli.py fleet/track/daemon.py fleet/track/download.py fleet/track/paths.py fleet/track/uploader.py tests/track/test_api.py tests/track/test_cli.py tests/track/test_uploader.py tests/track/test_download.py`
- `uv run pytest tests/track/test_api.py tests/track/test_cli.py tests/track/test_uploader.py tests/track/test_download.py -q`