### PR TITLE
Add FleetCode MCP connector

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -199,6 +199,48 @@ Download behavior:
 - Repeated downloads are cache hits unless metadata such as `last_active`,
   `event_count`, `content_codec`, or byte sizes changes.
 
+### FleetCode MCP Connector
+
+The SDK ships FleetCode, a small stdio MCP server for connector hosts that have
+the Fleet SDK installed. It exposes the same three agent-facing operations as
+the CLI:
+
+- `fleetcode_search_sessions` for structured session search.
+- `fleetcode_aggregate_sessions` for grouped metadata metrics.
+- `fleetcode_download_session` for local cached JSONL downloads.
+
+It also exposes `fleetcode_query_help`, which returns filterable fields, operators,
+metrics, and examples so agents can construct valid queries.
+
+The MCP server requires Python 3.10+. If the connector machine already installs
+the SDK as `fleet-python[cli]`, the MCP dependency is included. Otherwise,
+install the smaller FleetCode extra in the environment that runs the connector:
+
+```bash
+pip install 'fleet-python[fleetcode]'
+```
+
+Then configure the connector to run:
+
+```json
+{
+  "command": "fleetcode-mcp",
+  "env": {
+    "FLEET_TRACK_BASE_URL": "https://us-west-1.fleetai.com"
+  }
+}
+```
+
+Authentication is the same as `flt track`: `FLEET_API_KEY` is preferred when
+set, otherwise the MCP process uses stored `flt login` credentials from the
+same OS user. For a connector running under a different user or on a different
+machine, either run `flt login` in that connector environment or pass
+`FLEET_API_KEY` in `env`.
+
+`FLEET_TRACK_BASE_URL` is optional; the normal Fleet default is used when it is
+omitted. The MCP process keeps orchestrator as the auth boundary and downloads
+session bytes directly to the same local cache as `flt track download`.
+
 ### Compression
 
 Uploads are raw by default for safe rollout. To store new uploaded session blobs

--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -47,11 +47,13 @@ Cursor transcript syncing is intentionally disabled for now. `CursorSource`
 still exists for future parser work, but Cursor files are not included in the
 default daemon scan until the SDK can extract stable metadata and replay events.
 
-Authentication prefers `FLEET_API_KEY` when set and otherwise uses stored
-`flt login` browser credentials. Track requires credentials that resolve to a
-concrete Fleet user/profile so orchestrator can isolate uploaded sessions by
-`team_id`, `user_id`, and `device_id`. The orchestrator remains the control
-plane; session bytes go directly to S3 through presigned URLs.
+Authentication prefers stored `flt login` browser credentials and falls back
+to `FLEET_API_KEY` for non-interactive hosts. The API-key fallback will be
+removed in a future release; new deployments should use `flt login`. Track
+requires credentials that resolve to a concrete Fleet user/profile so
+orchestrator can isolate uploaded sessions by `team_id`, `user_id`, and
+`device_id`. The orchestrator remains the control plane; session bytes go
+directly to S3 through presigned URLs.
 
 For local use:
 
@@ -231,11 +233,12 @@ Then configure the connector to run:
 }
 ```
 
-Authentication is the same as `flt track`: `FLEET_API_KEY` is preferred when
-set, otherwise the MCP process uses stored `flt login` credentials from the
-same OS user. For a connector running under a different user or on a different
-machine, either run `flt login` in that connector environment or pass
-`FLEET_API_KEY` in `env`.
+Authentication is the same as `flt track`: the MCP process prefers stored
+`flt login` credentials from the same OS user and falls back to
+`FLEET_API_KEY` for headless hosts. For a connector running under a different
+user or on a different machine, either run `flt login` in that connector
+environment or — until the API-key flow is removed — pass `FLEET_API_KEY` in
+`env`.
 
 `FLEET_TRACK_BASE_URL` is optional; the normal Fleet default is used when it is
 omitted. The MCP process keeps orchestrator as the auth boundary and downloads

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -54,13 +54,21 @@ class TrackAPIError(Exception):
 
 
 def _default_auth_provider() -> Optional[AuthInfo]:
-    """Production auth: prefer FLEET_API_KEY, then stored `flt login` creds."""
+    """Production auth: prefer stored `flt login` creds, then FLEET_API_KEY.
+
+    `flt login` is the canonical user-bound auth path for Track. FLEET_API_KEY
+    remains a fallback for non-interactive hosts (CI, headless connectors)
+    and will be removed in a future release.
+    """
+    from ..auth import get_valid_token
+
+    if token := get_valid_token():
+        return token
+
     if api_key := os.getenv("FLEET_API_KEY"):
         return api_key
 
-    from ..auth import get_valid_token
-
-    return get_valid_token()
+    return None
 
 
 def _default_base_url() -> str:

--- a/fleet/track/mcp_server.py
+++ b/fleet/track/mcp_server.py
@@ -1,0 +1,251 @@
+"""FleetCode MCP server.
+
+This module intentionally keeps the `mcp` import inside `create_mcp()` so the
+base SDK and normal track tests do not require MCP dependencies. The connector
+runtime should install the `fleetcode` extra and run `fleetcode-mcp` with either
+`FLEET_API_KEY` or stored `flt login` credentials available to the process.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from .api import TrackAPIClient
+from .download import ensure_local_session
+from .paths import TrackPaths
+from .query_schema import (
+    AGGREGATE_METRICS,
+    SEARCH_FILTER_FIELDS,
+    SEARCH_FILTER_OPERATORS,
+    SEARCH_LOGICAL_OPERATORS,
+    SEARCH_TIME_FIELDS,
+)
+
+FILTERABLE_ATTRIBUTES = [field["name"] for field in SEARCH_FILTER_FIELDS]
+FILTER_OPERATORS = list(SEARCH_FILTER_OPERATORS)
+LOGICAL_OPERATORS = list(SEARCH_LOGICAL_OPERATORS)
+SEARCH_MODES = ["hybrid", "keyword", "semantic", "recent"]
+TIME_FIELDS = list(SEARCH_TIME_FIELDS)
+
+
+def fleetcode_query_guide() -> dict[str, Any]:
+    """Return the FleetCode query contract for agents."""
+    return {
+        "tools": {
+            "fleetcode_search_sessions": {
+                "purpose": "Find relevant sessions. Returns hydrated session metadata.",
+                "backend": "Turbopuffer via orchestrator",
+                "body_fields": {
+                    "query": "Natural-language search text.",
+                    "mode": SEARCH_MODES,
+                    "limit": "Maximum result count. Defaults to 50.",
+                    "filters": "Mongo-style filters over filterable attributes.",
+                    "time": "Shared time filter, e.g. {'field':'last_active','since':'7d'}.",
+                },
+            },
+            "fleetcode_aggregate_sessions": {
+                "purpose": "Summarize sessions by metadata fields. Returns grouped metrics, not sessions.",
+                "backend": "Postgres via orchestrator",
+                "body_fields": {
+                    "group_by": FILTERABLE_ATTRIBUTES,
+                    "metrics": AGGREGATE_METRICS,
+                    "filters": "Same Mongo-style filters as search.",
+                    "time": "Same time filter as search.",
+                    "time_bucket": "Optional bucket: {'field':'last_active','interval':'day'}.",
+                    "order_by": "Metric/key ordering, e.g. [{'field':'count','direction':'desc'}].",
+                    "having": "Metric filters after grouping, e.g. {'count': {'$gte': 5}}.",
+                    "limit": "Maximum number of groups. Defaults server-side.",
+                },
+            },
+            "fleetcode_download_session": {
+                "purpose": "Download one session to local cache for exact intra-session analysis.",
+                "next_step": "Use local tools such as rg, jq, sed, or Python against the returned JSONL path.",
+            },
+        },
+        "filters": {
+            "attributes": FILTERABLE_ATTRIBUTES,
+            "operators": FILTER_OPERATORS,
+            "logical_operators": LOGICAL_OPERATORS,
+            "examples": [
+                {"tool": "codex"},
+                {"event_count": {"$gte": 1000}},
+                {"repo_url": "github.com/fleet-ai/theseus", "tool": "codex"},
+                {
+                    "$or": [
+                        {"repo_url": {"$contains": "theseus"}},
+                        {"repo_url": {"$contains": "fleet-sdk"}},
+                    ]
+                },
+            ],
+        },
+        "time": {
+            "fields": TIME_FIELDS,
+            "operators": ["since", "gte", "gt", "lte", "lt"],
+            "examples": [
+                {"field": "last_active", "since": "7d"},
+                {"field": "started_at", "gte": "2026-05-01T00:00:00Z"},
+            ],
+        },
+        "examples": {
+            "search": {
+                "query": "deployment debugging",
+                "mode": "hybrid",
+                "filters": {"repo_url": {"$contains": "theseus"}},
+                "time": {"field": "last_active", "since": "30d"},
+                "limit": 25,
+            },
+            "aggregate": {
+                "group_by": ["repo_url", "tool"],
+                "metrics": ["count", "sum_event_count"],
+                "time": {"field": "last_active", "since": "30d"},
+                "time_bucket": {"field": "last_active", "interval": "day"},
+                "having": {"count": {"$gte": 5}},
+                "order_by": [{"field": "count", "direction": "desc"}],
+            },
+        },
+    }
+
+
+def _body_dict(body: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(body, Mapping):
+        raise TypeError("body must be a JSON object")
+    return dict(body)
+
+
+def _with_api(
+    api: Optional[TrackAPIClient],
+    fn,
+) -> Any:
+    if api is not None:
+        return fn(api)
+    with TrackAPIClient() as client:
+        return fn(client)
+
+
+def fleetcode_search_sessions(
+    body: Mapping[str, Any],
+    *,
+    api: Optional[TrackAPIClient] = None,
+) -> dict[str, Any]:
+    """Run structured FleetCode session search."""
+    payload = _body_dict(body)
+    if "limit" not in payload and "top_k" not in payload:
+        payload["limit"] = 50
+    return _with_api(api, lambda client: client.search_sessions(payload))
+
+
+def fleetcode_aggregate_sessions(
+    body: Mapping[str, Any],
+    *,
+    api: Optional[TrackAPIClient] = None,
+) -> dict[str, Any]:
+    """Run structured FleetCode aggregate session query."""
+    payload = _body_dict(body)
+    return _with_api(api, lambda client: client.aggregate_sessions(payload))
+
+
+def fleetcode_download_session(
+    session_id: str,
+    *,
+    force: bool = False,
+    api: Optional[TrackAPIClient] = None,
+    paths: Optional[TrackPaths] = None,
+) -> dict[str, Any]:
+    """Download a session to local cache for exact local analysis."""
+    cached = _with_api(
+        api,
+        lambda client: ensure_local_session(
+            session_id,
+            api=client,
+            paths=paths,
+            force=force,
+        ),
+    )
+    payload = cached.to_dict()
+    path = payload["path"]
+    payload["local_analysis"] = {
+        "description": "Use local tools against this canonical JSONL file.",
+        "examples": {
+            "grep": f"rg '<pattern>' {path}",
+            "json_messages": f"jq 'select(.type==\"message\")' {path}",
+        },
+    }
+    return payload
+
+
+def _mcp_install_error_message() -> str:
+    if sys.version_info < (3, 10):
+        return (
+            "FleetCode MCP requires Python 3.10+ and the MCP extra. "
+            "Run with Python 3.10+ and install with: "
+            "pip install 'fleet-python[fleetcode]'"
+        )
+    return (
+        "FleetCode MCP requires the MCP extra. "
+        "Install with: pip install 'fleet-python[fleetcode]'"
+    )
+
+
+def create_mcp():
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:
+        print(_mcp_install_error_message(), file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    mcp = FastMCP("fleetcode")
+    search_impl = globals()["fleetcode_search_sessions"]
+    aggregate_impl = globals()["fleetcode_aggregate_sessions"]
+    download_impl = globals()["fleetcode_download_session"]
+
+    @mcp.tool()
+    def fleetcode_query_help() -> dict[str, Any]:
+        """Return FleetCode search, aggregate, filter, and download guidance."""
+        return fleetcode_query_guide()
+
+    @mcp.tool()
+    def fleetcode_search_sessions(body: dict[str, Any]) -> dict[str, Any]:
+        """Find relevant sessions using structured FleetCode search.
+
+        Body fields: query, mode, limit, filters, and time. Modes are hybrid,
+        keyword, semantic, and recent. Filters use Mongo-style `$and`, `$or`,
+        `$not`, field operators such as `$in` and `$gte`, and the documented
+        session metadata fields.
+        """
+        return search_impl(body)
+
+    @mcp.tool()
+    def fleetcode_aggregate_sessions(body: dict[str, Any]) -> dict[str, Any]:
+        """Aggregate tracked session metadata.
+
+        Body fields: group_by, metrics, filters, time, time_bucket, order_by,
+        having, and limit. Metrics include counts, event_count summaries, and
+        distinct user/device/repo/model counts. No raw SQL is accepted.
+        """
+        return aggregate_impl(body)
+
+    @mcp.tool()
+    def fleetcode_download_session(
+        session_id: str,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Download one session to local cache for exact analysis.
+
+        Returns a canonical JSONL path. After download, use local tools such as
+        rg, jq, sed, or Python against the returned path for intra-session grep
+        or transcript analysis.
+        """
+        return download_impl(session_id, force=force)
+
+    return mcp
+
+
+def main() -> None:
+    """Run the FleetCode MCP server for connector hosts."""
+    create_mcp().run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 
 [project.scripts]
 flt = "fleet.cli:main"
+fleetcode-mcp = "fleet.track.mcp_server:main"
 
 [project.optional-dependencies]
 cli = [
@@ -42,6 +43,10 @@ cli = [
     "rich>=10.0.0",
     "watchdog>=4.0.0",
     "textual>=0.50.0",
+    "mcp==1.24.0; python_version >= '3.10'",
+]
+fleetcode = [
+    "mcp==1.24.0; python_version >= '3.10'",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -412,3 +412,37 @@ def test_context_manager_closes_owned_client():
     # Injected client was NOT owned by the API; should still be usable.
     assert not injected.is_closed
     injected.close()
+
+
+def test_default_auth_provider_prefers_flt_login_over_api_key(monkeypatch):
+    """flt login is the canonical auth path; FLEET_API_KEY is a fallback."""
+    from fleet import auth as auth_module
+    from fleet.track import api as api_module
+
+    monkeypatch.setenv("FLEET_API_KEY", "sk_should_be_ignored")
+    monkeypatch.setattr(
+        auth_module, "get_valid_token", lambda: ("jwt-token", "team-1")
+    )
+
+    assert api_module._default_auth_provider() == ("jwt-token", "team-1")
+
+
+def test_default_auth_provider_falls_back_to_api_key(monkeypatch):
+    """Without flt login creds, FLEET_API_KEY still works for headless hosts."""
+    from fleet import auth as auth_module
+    from fleet.track import api as api_module
+
+    monkeypatch.setenv("FLEET_API_KEY", "sk_fallback")
+    monkeypatch.setattr(auth_module, "get_valid_token", lambda: None)
+
+    assert api_module._default_auth_provider() == "sk_fallback"
+
+
+def test_default_auth_provider_returns_none_when_unauthenticated(monkeypatch):
+    from fleet import auth as auth_module
+    from fleet.track import api as api_module
+
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
+    monkeypatch.setattr(auth_module, "get_valid_token", lambda: None)
+
+    assert api_module._default_auth_provider() is None

--- a/tests/track/test_mcp_server.py
+++ b/tests/track/test_mcp_server.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from fleet.track import mcp_server
+
+
+class FakeAPI:
+    def __init__(self):
+        self.search_bodies = []
+        self.aggregate_bodies = []
+
+    def search_sessions(self, body):
+        self.search_bodies.append(body)
+        return {"items": [{"id": "s1"}], "next_cursor": None}
+
+    def aggregate_sessions(self, body):
+        self.aggregate_bodies.append(body)
+        return {"groups": [{"key": {"tool": "codex"}, "count": 1}]}
+
+
+@dataclass(frozen=True)
+class FakeCachedSession:
+    path: str = "/tmp/session.jsonl"
+
+    def to_dict(self):
+        return {
+            "session_id": "s1",
+            "path": self.path,
+            "metadata_path": "/tmp/metadata.json",
+            "cache_status": "downloaded",
+            "content_codec": "raw",
+            "raw_bytes": 10,
+            "stored_bytes": 10,
+            "event_count": 1,
+            "last_active": "2026-05-06T00:00:00Z",
+        }
+
+
+def test_fleetcode_query_guide_describes_query_contract():
+    guide = mcp_server.fleetcode_query_guide()
+
+    assert "fleetcode_search_sessions" in guide["tools"]
+    assert "fleetcode_aggregate_sessions" in guide["tools"]
+    assert "fleetcode_download_session" in guide["tools"]
+    assert "repo_url" in guide["filters"]["attributes"]
+    assert "gte/$gte" in guide["filters"]["operators"]
+    assert "$or" in guide["filters"]["logical_operators"]
+    assert (
+        "avg_event_count"
+        in guide["tools"]["fleetcode_aggregate_sessions"]["body_fields"]["metrics"]
+    )
+    assert "time_bucket" in guide["tools"]["fleetcode_aggregate_sessions"]["body_fields"]
+
+
+def test_fleetcode_search_sessions_defaults_limit_and_calls_api():
+    api = FakeAPI()
+
+    out = mcp_server.fleetcode_search_sessions({"query": "deployment"}, api=api)
+
+    assert out["items"][0]["id"] == "s1"
+    assert api.search_bodies == [{"query": "deployment", "limit": 50}]
+
+
+def test_fleetcode_search_sessions_preserves_explicit_limit():
+    api = FakeAPI()
+
+    mcp_server.fleetcode_search_sessions({"query": "deployment", "limit": 5}, api=api)
+
+    assert api.search_bodies == [{"query": "deployment", "limit": 5}]
+
+
+def test_fleetcode_aggregate_sessions_calls_api():
+    api = FakeAPI()
+    body = {"group_by": ["tool"], "metrics": ["count"]}
+
+    out = mcp_server.fleetcode_aggregate_sessions(body, api=api)
+
+    assert out["groups"][0]["count"] == 1
+    assert api.aggregate_bodies == [body]
+
+
+def test_fleetcode_download_session_returns_path_and_local_guidance(monkeypatch):
+    calls = []
+    clients = []
+
+    def fake_ensure(session_id, *, api=None, paths=None, force=False):
+        calls.append((session_id, api, paths, force))
+        return FakeCachedSession()
+
+    class FakeTrackAPIClient:
+        closed = False
+
+        def __enter__(self):
+            clients.append(self)
+            return self
+
+        def __exit__(self, *exc):
+            self.closed = True
+
+    monkeypatch.setattr(mcp_server, "ensure_local_session", fake_ensure)
+    monkeypatch.setattr(mcp_server, "TrackAPIClient", FakeTrackAPIClient)
+
+    out = mcp_server.fleetcode_download_session("s1", force=True)
+
+    assert calls == [("s1", clients[0], None, True)]
+    assert clients[0].closed is True
+    assert out["path"] == "/tmp/session.jsonl"
+    assert "rg '<pattern>' /tmp/session.jsonl" == out["local_analysis"]["examples"]["grep"]
+
+
+def test_fleetcode_tools_reject_non_object_body():
+    with pytest.raises(TypeError, match="body must be a JSON object"):
+        mcp_server.fleetcode_search_sessions(["not", "an", "object"])  # type: ignore[arg-type]
+
+
+def test_mcp_install_error_mentions_python_requirement(monkeypatch):
+    monkeypatch.setattr(mcp_server.sys, "version_info", (3, 9, 0))
+
+    message = mcp_server._mcp_install_error_message()
+
+    assert "Python 3.10+" in message
+    assert "fleet-python[fleetcode]" in message
+
+
+def test_main_allows_flt_login_auth_without_api_key(monkeypatch):
+    calls = []
+
+    class FakeMCP:
+        def run(self, *, transport):
+            calls.append(transport)
+
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
+    monkeypatch.setattr(mcp_server, "create_mcp", lambda: FakeMCP())
+
+    mcp_server.main()
+
+    assert calls == ["stdio"]

--- a/uv.lock
+++ b/uv.lock
@@ -676,6 +676,7 @@ dependencies = [
 
 [package.optional-dependencies]
 cli = [
+    { name = "mcp", marker = "python_full_version >= '3.10'" },
     { name = "rich" },
     { name = "textual" },
     { name = "typer" },
@@ -705,6 +706,9 @@ eval = [
     { name = "google-genai", version = "1.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mcp", marker = "python_full_version >= '3.10'" },
 ]
+fleetcode = [
+    { name = "mcp", marker = "python_full_version >= '3.10'" },
+]
 playwright = [
     { name = "playwright" },
 ]
@@ -719,7 +723,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx-retries", specifier = ">=0.4.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'cli'", specifier = "==1.24.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'eval'", specifier = "==1.24.0" },
+    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'fleetcode'", specifier = "==1.24.0" },
     { name = "modulegraph2", specifier = ">=0.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.40.0" },
@@ -739,7 +745,7 @@ requires-dist = [
     { name = "unasync", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "watchdog", marker = "extra == 'cli'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["cli", "dev", "playwright", "eval"]
+provides-extras = ["cli", "fleetcode", "dev", "playwright", "eval"]
 
 [[package]]
 name = "frozenlist"


### PR DESCRIPTION
## Summary
- Add `fleetcode-mcp`, a stdio MCP server for FleetCode connector hosts.
- Expose `fleetcode_query_help`, `fleetcode_search_sessions`, `fleetcode_aggregate_sessions`, and `fleetcode_download_session`.
- Document the same Mongo-style filter contract and aggregate DSL as the CLI, including `time_bucket`, `order_by`, and `having`.
- Add a `fleetcode` extra and include MCP in the CLI extra on Python 3.10+ for connector machines that already install the CLI.
- Document connector env configuration with `FLEET_API_KEY` and optional `FLEET_TRACK_BASE_URL`.

Stacked on #113.

## Tests
- `uv run ruff check fleet/track/api.py fleet/track/cli.py fleet/track/daemon.py fleet/track/download.py fleet/track/mcp_server.py fleet/track/paths.py fleet/track/uploader.py tests/track/test_api.py tests/track/test_cli.py tests/track/test_uploader.py tests/track/test_download.py tests/track/test_mcp_server.py`
- `uv run pytest tests/track/test_api.py tests/track/test_cli.py tests/track/test_uploader.py tests/track/test_download.py tests/track/test_mcp_server.py -q`
- `env -u FLEET_API_KEY uv run fleetcode-mcp`
- `FLEET_API_KEY=test uv run --extra fleetcode python - <<PY ... create_mcp() ... PY`