### PR TITLE
Restore CLI login auth fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,28 @@ To install a specific alpha version:
 pip install fleet-python==0.2.64-alpha1
 ```
 
-## API Key Setup
+## Authentication
 
-Fleet requires an API key for authentication. You can obtain one from the [Fleet Platform](https://fleetai.com/dashboard/api-keys).
+Fleet supports browser login for local CLI use and API keys for scripts,
+services, and CI.
 
-Set your API key as an environment variable:
+For local CLI use:
+
+```bash
+flt login
+```
+
+The CLI stores browser-login credentials in `~/.fleet/credentials.json` and
+sends JWT auth headers scoped to the selected team.
+
+For API-key auth, obtain a key from the
+[Fleet Platform](https://fleetai.com/dashboard/api-keys) and set:
 
 ```bash
 export FLEET_API_KEY="sk_your_key_here"
 ```
+
+When both are present, `FLEET_API_KEY` takes precedence.
 
 ## Basic Usage
 

--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -45,10 +45,25 @@ Cursor transcript syncing is intentionally disabled for now. `CursorSource`
 still exists for future parser work, but Cursor files are not included in the
 default daemon scan until the SDK can extract stable metadata and replay events.
 
-Authentication uses `FLEET_API_KEY`. Track requires an API key that resolves to
-a concrete Fleet profile so orchestrator can isolate uploaded sessions by
+Authentication prefers `FLEET_API_KEY` when set and otherwise uses stored
+`flt login` browser credentials. Track requires credentials that resolve to a
+concrete Fleet user/profile so orchestrator can isolate uploaded sessions by
 `team_id`, `user_id`, and `device_id`. The orchestrator remains the control
 plane; session bytes go directly to S3 through presigned URLs.
+
+For local use:
+
+```bash
+flt login
+flt track enable
+```
+
+For non-interactive use:
+
+```bash
+export FLEET_API_KEY="sk_your_key_here"
+flt track enable
+```
 
 ## Commands
 

--- a/docs/fleet-track/goals.md
+++ b/docs/fleet-track/goals.md
@@ -4,7 +4,7 @@
 
 FleetTrack now has a usable v1 product path:
 
-- API-key authentication through `FLEET_API_KEY`.
+- Authentication through `FLEET_API_KEY` or stored `flt login` credentials.
 - `flt track enable/status/daemon/logs/ls/resume/gc`.
 - Local source discovery for Claude and Codex. Cursor discovery code exists, but
   default syncing is disabled until metadata extraction and event replay are

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -37,10 +37,14 @@ class BaseWrapper(AuthenticatedWrapperMixin):
         self,
         *,
         api_key: Optional[str],
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
         base_url: Optional[str],
     ):
         self._init_auth(
             api_key=api_key,
+            jwt=jwt,
+            team_id=team_id,
             base_url=base_url,
         )
 

--- a/fleet/_auth_headers.py
+++ b/fleet/_auth_headers.py
@@ -16,11 +16,22 @@ class AuthenticatedWrapperMixin:
         self,
         *,
         api_key: Optional[str],
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
         base_url: Optional[str],
     ) -> None:
-        if not api_key:
-            raise ValueError("Provide api_key")
+        if not api_key and not (jwt and team_id):
+            from .auth import get_valid_token
+
+            token_info = get_valid_token()
+            if token_info:
+                jwt, team_id = token_info
+
+        if not api_key and not (jwt and team_id):
+            raise ValueError("Provide api_key, provide jwt/team_id, or run `flt login`")
         self.api_key = api_key
+        self.jwt = jwt
+        self.team_id = team_id
         self.base_url = base_url or GLOBAL_BASE_URL
 
     def get_headers(self, request_id: Optional[str] = None) -> Dict[str, str]:
@@ -28,11 +39,15 @@ class AuthenticatedWrapperMixin:
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": __version__,
         }
-        if not self.api_key:
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        elif self.jwt and self.team_id:
+            headers["X-JWT-Token"] = self.jwt
+            headers["X-Team-ID"] = self.team_id
+        else:
             raise self._authentication_error_cls(
-                "API-key auth was selected at init but api_key is no longer set"
+                "Authentication is not configured; set FLEET_API_KEY or run `flt login`"
             )
-        headers["Authorization"] = f"Bearer {self.api_key}"
 
         if request_id:
             headers["X-Request-ID"] = request_id

--- a/fleet/auth.py
+++ b/fleet/auth.py
@@ -1,0 +1,132 @@
+"""Fleet CLI authentication: credential storage and token refresh."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+from .config import GLOBAL_BASE_URL
+
+CREDENTIALS_FILE = Path.home() / ".fleet" / "credentials.json"
+AUTH_REFRESH_PATH = "/v1/auth/refresh"
+
+_REFRESH_BUFFER_SECS = 60
+
+
+def save_credentials(data: dict) -> None:
+    """Write credentials to ~/.fleet/credentials.json with mode 0600."""
+    CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=CREDENTIALS_FILE.parent,
+        prefix=f".{CREDENTIALS_FILE.name}-",
+        suffix=".tmp",
+        text=True,
+    )
+    try:
+        os.fchmod(fd, 0o600)
+        handle = os.fdopen(fd, "w")
+        fd = -1
+        with handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp, CREDENTIALS_FILE)
+        os.chmod(CREDENTIALS_FILE, 0o600)
+    except Exception:
+        if fd != -1:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def load_credentials() -> Optional[dict]:
+    """Read credentials from ~/.fleet/credentials.json."""
+    if not CREDENTIALS_FILE.exists():
+        return None
+    try:
+        with open(CREDENTIALS_FILE) as handle:
+            return json.load(handle)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def clear_credentials() -> None:
+    """Delete stored browser-login credentials."""
+    if CREDENTIALS_FILE.exists():
+        CREDENTIALS_FILE.unlink()
+
+
+def is_token_expired(access_token: str) -> bool:
+    """Return true if the JWT is expired or inside the refresh buffer."""
+    try:
+        payload_b64 = access_token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return time.time() > payload["exp"] - _REFRESH_BUFFER_SECS
+    except Exception:
+        return True
+
+
+def _auth_refresh_base_url() -> str:
+    return (
+        os.environ.get("FLEET_AUTH_BASE_URL")
+        or os.environ.get("FLEET_BASE_URL")
+        or os.environ.get("FLEET_TRACK_BASE_URL")
+        or GLOBAL_BASE_URL
+    ).rstrip("/")
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    """Exchange a stored browser-login refresh token through Fleet."""
+    response = httpx.post(
+        f"{_auth_refresh_base_url()}{AUTH_REFRESH_PATH}",
+        headers={"Content-Type": "application/json"},
+        json={"refresh_token": refresh_token},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not data.get("access_token"):
+        raise RuntimeError("Fleet auth refresh response did not include access_token")
+    return data
+
+
+def get_valid_token() -> Optional[Tuple[str, str]]:
+    """Return (access_token, team_id), refreshing stored credentials if needed."""
+    creds = load_credentials()
+    if not creds:
+        return None
+
+    access_token = creds.get("access_token")
+    team_id = creds.get("team_id")
+    if not access_token or not team_id:
+        return None
+
+    if is_token_expired(access_token):
+        refresh_token = creds.get("refresh_token")
+        if not refresh_token:
+            return None
+        try:
+            refreshed = refresh_access_token(refresh_token)
+        except Exception:
+            return None
+        access_token = refreshed["access_token"]
+        creds["access_token"] = access_token
+        if refreshed.get("refresh_token"):
+            creds["refresh_token"] = refreshed["refresh_token"]
+        save_credentials(creds)
+
+    return access_token, team_id
+

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -38,10 +38,14 @@ class BaseWrapper(AuthenticatedWrapperMixin):
         self,
         *,
         api_key: Optional[str],
+        jwt: Optional[str] = None,
+        team_id: Optional[str] = None,
         base_url: Optional[str],
     ):
         self._init_auth(
             api_key=api_key,
+            jwt=jwt,
+            team_id=team_id,
             base_url=base_url,
         )
 

--- a/fleet/cli.py
+++ b/fleet/cli.py
@@ -97,15 +97,21 @@ def format_status(status: Optional[str]) -> str:
 
 
 def get_client() -> Fleet:
-    """Get a Fleet client from FLEET_API_KEY."""
+    """Get a Fleet client, preferring FLEET_API_KEY then stored login."""
     api_key = os.getenv("FLEET_API_KEY")
     base_url = os.getenv("FLEET_BASE_URL", CLI_DEFAULT_BASE_URL)
 
     if api_key:
         return Fleet(api_key=api_key, base_url=base_url)
 
+    from .auth import get_valid_token
+
+    token_info = get_valid_token()
+    if token_info:
+        return Fleet(base_url=base_url)
+
     console.print(
-        "[red]Not authenticated.[/red] Set [bold]FLEET_API_KEY[/bold].",
+        "[red]Not authenticated.[/red] Run [bold]flt login[/bold] or set [bold]FLEET_API_KEY[/bold].",
         style="bold",
     )
     raise typer.Exit(1)
@@ -122,7 +128,16 @@ def _oversight_auth_headers() -> Optional[Dict[str, str]]:
         headers["Authorization"] = f"Bearer {api_key}"
         return headers
 
-    return None
+    from .auth import get_valid_token
+
+    token_info = get_valid_token()
+    if not token_info:
+        return None
+
+    jwt, team_id = token_info
+    headers["X-JWT-Token"] = jwt
+    headers["X-Team-ID"] = team_id
+    return headers
 
 
 def _run_oversight(job_id: str, model: str = "anthropic/claude-sonnet-4"):
@@ -1211,15 +1226,237 @@ def eval_run(
 
 
 @app.command()
+def login():
+    """Authenticate the CLI through the Fleet web app."""
+    import secrets
+    import webbrowser
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from urllib.parse import parse_qs, urlencode, urlparse
+
+    from .auth import save_credentials
+
+    state = secrets.token_urlsafe(16)
+    result: dict = {}
+    done = threading.Event()
+
+    callback_bridge = b"""<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Fleet CLI login</title></head>
+  <body>
+    <h1>Completing Fleet CLI login...</h1>
+    <script>
+      (async () => {
+        const raw = window.location.hash.length > 1
+          ? window.location.hash.slice(1)
+          : window.location.search.slice(1);
+        window.history.replaceState(null, "", "/callback");
+        if (!raw) {
+          document.body.innerHTML = "<h1>Fleet CLI login failed.</h1><p>No credentials received.</p>";
+          return;
+        }
+        const response = await fetch("/callback", {
+          method: "POST",
+          headers: {"Content-Type": "application/x-www-form-urlencoded"},
+          body: raw
+        });
+        if (response.ok) {
+          document.body.innerHTML = "<h1>Fleet CLI login complete.</h1><p>You can close this window.</p>";
+        } else {
+          document.body.innerHTML = "<h1>Fleet CLI login failed.</h1><p>Return to your terminal and retry.</p>";
+        }
+      })();
+    </script>
+  </body>
+</html>"""
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def _send_html(self, status: int, body: bytes) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self._send_html(404, b"Not found")
+                return
+            self._send_html(200, callback_bridge)
+
+        def do_POST(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self._send_html(404, b"Not found")
+                return
+
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                content_length = 0
+            if content_length <= 0 or content_length > 32_768:
+                result["error"] = "invalid callback payload"
+                done.set()
+                self._send_html(400, b"Invalid callback payload")
+                return
+
+            body = self.rfile.read(content_length).decode("utf-8", errors="replace")
+            params = {
+                key: values[0]
+                for key, values in parse_qs(body, keep_blank_values=True).items()
+            }
+            if params.get("state") != state:
+                result["error"] = "invalid callback state"
+                done.set()
+                self._send_html(400, b"Invalid state")
+                return
+            if not params.get("access_token"):
+                result["error"] = "no token received"
+                done.set()
+                self._send_html(400, b"No token received")
+                return
+            if not params.get("team_id"):
+                result["error"] = "no team_id received"
+                done.set()
+                self._send_html(400, b"No team_id received")
+                return
+
+            result.update(params)
+            done.set()
+            self._send_html(
+                200,
+                b"<html><body><h1>Fleet CLI login complete.</h1>"
+                b"<p>You can close this window.</p></body></html>",
+            )
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    try:
+        server = HTTPServer(("127.0.0.1", 0), CallbackHandler)
+    except OSError as e:
+        console.print(f"[red]Could not start local login callback server:[/red] {e}")
+        raise typer.Exit(1)
+    server.timeout = 1.0
+    port = server.server_address[1]
+
+    def serve() -> None:
+        try:
+            while not done.is_set():
+                server.handle_request()
+        finally:
+            server.server_close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+
+    login_url = "https://fleetai.com/cli-login?" + urlencode(
+        {
+            "port": port,
+            "state": state,
+            "response_mode": "fragment_post",
+        }
+    )
+    console.print("[bold]Opening Fleet login in your browser...[/bold]")
+    console.print(f"[dim]If the browser did not open, visit:[/dim] {login_url}")
+    webbrowser.open(login_url)
+
+    console.print("[dim]Waiting for authentication (Ctrl+C to cancel)...[/dim]")
+    try:
+        authenticated = done.wait(timeout=300)
+    except KeyboardInterrupt:
+        done.set()
+        thread.join(timeout=2)
+        console.print("\n[yellow]Login cancelled.[/yellow]")
+        raise typer.Exit(1)
+
+    if not authenticated:
+        done.set()
+        thread.join(timeout=2)
+        console.print("[red]Login timed out.[/red]")
+        raise typer.Exit(1)
+    thread.join(timeout=2)
+
+    if result.get("error"):
+        console.print(f"[red]Login failed - {result['error']}.[/red]")
+        raise typer.Exit(1)
+
+    access_token = result.get("access_token")
+    team_id = result.get("team_id")
+    if not access_token:
+        console.print("[red]Login failed - no token received.[/red]")
+        raise typer.Exit(1)
+    if not team_id:
+        console.print("[red]Login failed - no team_id received.[/red]")
+        raise typer.Exit(1)
+
+    save_credentials(
+        {
+            "email": result.get("email", ""),
+            "access_token": access_token,
+            "refresh_token": result.get("refresh_token", ""),
+            "team_id": team_id,
+            "team_name": result.get("team_name", ""),
+            "expires_at": result.get("expires_at", ""),
+        }
+    )
+
+    email = result.get("email", "unknown")
+    team_name = result.get("team_name", team_id)
+    console.print(
+        f"\n[green]✓[/green] Logged in as [bold]{email}[/bold] (Team: {team_name})"
+    )
+
+
+@app.command()
+def logout():
+    """Clear stored Fleet browser-login credentials."""
+    from .auth import clear_credentials, load_credentials
+
+    creds = load_credentials()
+    if not creds:
+        console.print("[dim]Not logged in.[/dim]")
+        return
+
+    clear_credentials()
+    email = creds.get("email", "")
+    suffix = f" ({email})" if email else ""
+    console.print(f"[green]✓[/green] Logged out{suffix}.")
+
+
+@app.command()
 def whoami():
     """Show current authentication status."""
+    from .auth import CREDENTIALS_FILE, get_valid_token, load_credentials
+
     api_key = os.getenv("FLEET_API_KEY")
     if api_key:
         console.print("[bold]Auth:[/bold] API key (FLEET_API_KEY)")
         console.print(f"[bold]Key:[/bold] {_mask_secret(api_key)}")
         return
 
-    console.print("[dim]Not authenticated.[/dim] Set [bold]FLEET_API_KEY[/bold].")
+    creds = load_credentials()
+    if not creds:
+        console.print(
+            "[dim]Not authenticated.[/dim] Run [bold]flt login[/bold] or set [bold]FLEET_API_KEY[/bold]."
+        )
+        return
+
+    token_info = get_valid_token()
+    if not token_info:
+        console.print(
+            "[yellow]Stored credentials are expired.[/yellow] "
+            "Run [bold]flt login[/bold] again."
+        )
+        return
+
+    console.print(f"[bold]Auth:[/bold] Browser login ({CREDENTIALS_FILE})")
+    if creds.get("email"):
+        console.print(f"[bold]Email:[/bold] {creds['email']}")
+    if creds.get("team_name"):
+        console.print(f"[bold]Team:[/bold] {creds['team_name']}")
+    if creds.get("team_id"):
+        console.print(f"[bold]Team ID:[/bold] {creds['team_id']}")
 
 
 def main():

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -23,7 +23,7 @@ import os
 import platform
 import socket
 from dataclasses import asdict, is_dataclass
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional, Tuple, Union
 
 import httpx
 
@@ -35,8 +35,8 @@ DEFAULT_TIMEOUT = 30.0
 SERVER_UPLOAD_URL_BATCH_CAP = 100  # /v1/track/upload-urls returns 400 above this.
 
 
-# API key — None when unauthenticated.
-AuthProvider = Callable[[], Optional[str]]
+AuthInfo = Union[str, Tuple[str, str]]
+AuthProvider = Callable[[], Optional[AuthInfo]]
 
 
 class TrackAPIError(Exception):
@@ -52,9 +52,14 @@ class TrackAPIError(Exception):
         self.detail = detail
 
 
-def _default_auth_provider() -> Optional[str]:
-    """Production auth: read from FLEET_API_KEY."""
-    return os.getenv("FLEET_API_KEY")
+def _default_auth_provider() -> Optional[AuthInfo]:
+    """Production auth: prefer FLEET_API_KEY, then stored `flt login` creds."""
+    if api_key := os.getenv("FLEET_API_KEY"):
+        return api_key
+
+    from ..auth import get_valid_token
+
+    return get_valid_token()
 
 
 def _default_base_url() -> str:
@@ -240,12 +245,19 @@ class TrackAPIClient:
     # ------------------------------------------------------------------ #
 
     def _headers(self, device_id: Optional[str] = None) -> dict[str, str]:
-        api_key = self._auth()
-        if not api_key:
-            raise TrackAPIError("Not authenticated — set FLEET_API_KEY")
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-        }
+        auth_info = self._auth()
+        if not auth_info:
+            raise TrackAPIError(
+                "Not authenticated — run `flt login` or set FLEET_API_KEY"
+            )
+        if isinstance(auth_info, str):
+            headers = {"Authorization": f"Bearer {auth_info}"}
+        else:
+            access_token, team_id = auth_info
+            headers = {
+                "X-JWT-Token": access_token,
+                "X-Team-ID": team_id,
+            }
         if device_id:
             headers["X-Device-ID"] = device_id
         return headers

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -136,9 +136,11 @@ def enable() -> None:
     """Scan this machine for AI sessions and start syncing."""
     paths = TrackPaths.default()
 
-    if not os.getenv("FLEET_API_KEY"):
+    from ..auth import get_valid_token
+
+    if not os.getenv("FLEET_API_KEY") and not get_valid_token():
         console.print(
-            "[red]Not authenticated.[/red] Set [bold]FLEET_API_KEY[/bold] first."
+            "[red]Not authenticated.[/red] Run [bold]flt login[/bold] or set [bold]FLEET_API_KEY[/bold] first."
         )
         raise typer.Exit(1)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+from fleet import auth
+
+
+def _jwt(exp: int) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).decode()
+    payload = payload.rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def test_save_and_load_credentials_uses_private_file(tmp_path, monkeypatch):
+    path = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth, "CREDENTIALS_FILE", path)
+
+    auth.save_credentials({"access_token": "jwt", "team_id": "team"})
+
+    assert auth.load_credentials() == {"access_token": "jwt", "team_id": "team"}
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_get_valid_token_returns_stored_unexpired_token(tmp_path, monkeypatch):
+    path = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth, "CREDENTIALS_FILE", path)
+    auth.save_credentials(
+        {
+            "access_token": _jwt(int(time.time()) + 3600),
+            "team_id": "team-1",
+        }
+    )
+
+    assert auth.get_valid_token() == (auth.load_credentials()["access_token"], "team-1")
+
+
+def test_get_valid_token_refreshes_expired_token(tmp_path, monkeypatch):
+    path = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth, "CREDENTIALS_FILE", path)
+    old_token = _jwt(int(time.time()) - 10)
+    new_token = _jwt(int(time.time()) + 3600)
+    auth.save_credentials(
+        {
+            "access_token": old_token,
+            "refresh_token": "refresh",
+            "team_id": "team-1",
+        }
+    )
+    monkeypatch.setattr(
+        auth,
+        "refresh_access_token",
+        lambda refresh_token: {
+            "access_token": new_token,
+            "refresh_token": f"{refresh_token}-next",
+        },
+    )
+
+    assert auth.get_valid_token() == (new_token, "team-1")
+    stored = auth.load_credentials()
+    assert stored["access_token"] == new_token
+    assert stored["refresh_token"] == "refresh-next"
+
+
+def test_clear_credentials_removes_file(tmp_path, monkeypatch):
+    path = tmp_path / "credentials.json"
+    monkeypatch.setattr(auth, "CREDENTIALS_FILE", path)
+    auth.save_credentials({"access_token": "jwt", "team_id": "team"})
+
+    auth.clear_credentials()
+
+    assert not path.exists()

--- a/tests/test_base_auth.py
+++ b/tests/test_base_auth.py
@@ -34,3 +34,35 @@ def test_shared_auth_headers_support_api_key(wrapper_cls, error_cls):
     wrapper.api_key = None
     with pytest.raises(error_cls):
         wrapper.get_headers()
+
+
+@pytest.mark.parametrize("wrapper_cls", [SyncBaseWrapper, AsyncBaseWrapper])
+def test_shared_auth_headers_support_jwt_team(wrapper_cls):
+    wrapper = wrapper_cls(
+        api_key=None,
+        jwt="jwt-token",
+        team_id="team-1",
+        base_url="https://api.example.com",
+    )
+
+    headers = wrapper.get_headers()
+
+    assert headers["X-JWT-Token"] == "jwt-token"
+    assert headers["X-Team-ID"] == "team-1"
+    assert "Authorization" not in headers
+
+
+@pytest.mark.parametrize("wrapper_cls", [SyncBaseWrapper, AsyncBaseWrapper])
+def test_shared_auth_headers_prefer_api_key_over_jwt(wrapper_cls):
+    wrapper = wrapper_cls(
+        api_key="fleet-api-key",
+        jwt="jwt-token",
+        team_id="team-1",
+        base_url="https://api.example.com",
+    )
+
+    headers = wrapper.get_headers()
+
+    assert headers["Authorization"] == "Bearer fleet-api-key"
+    assert "X-JWT-Token" not in headers
+    assert "X-Team-ID" not in headers

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -47,6 +47,7 @@ def test_run_oversight_uses_api_key_auth(monkeypatch):
     _FakeOversightClient.request = None
     monkeypatch.setenv("FLEET_API_KEY", "test-api-key")
     monkeypatch.setenv("FLEET_BASE_URL", "https://api.example.com")
+    monkeypatch.setattr("fleet.auth.get_valid_token", lambda: None)
     monkeypatch.setattr(httpx, "Client", _FakeOversightClient)
 
     _run_oversight("job-1")
@@ -69,10 +70,25 @@ def test_run_oversight_uses_api_key_auth(monkeypatch):
     }
 
 
-def test_run_oversight_skips_without_api_key(monkeypatch):
+def test_run_oversight_uses_browser_login_auth(monkeypatch):
     _FakeOversightClient.request = None
     monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.setenv("FLEET_BASE_URL", "https://api.example.com")
+    monkeypatch.setattr("fleet.auth.get_valid_token", lambda: ("jwt-token", "team-1"))
+    monkeypatch.setattr(httpx, "Client", _FakeOversightClient)
+
+    _run_oversight("job-1")
+
+    assert _FakeOversightClient.request["headers"]["X-JWT-Token"] == "jwt-token"
+    assert _FakeOversightClient.request["headers"]["X-Team-ID"] == "team-1"
+    assert "Authorization" not in _FakeOversightClient.request["headers"]
+
+
+def test_run_oversight_skips_without_auth(monkeypatch):
+    _FakeOversightClient.request = None
+    monkeypatch.delenv("FLEET_API_KEY", raising=False)
+    monkeypatch.setenv("FLEET_BASE_URL", "https://api.example.com")
+    monkeypatch.setattr("fleet.auth.get_valid_token", lambda: None)
     monkeypatch.setattr(httpx, "Client", _FakeOversightClient)
 
     _run_oversight("job-1")

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -19,6 +19,10 @@ def _auth() -> Optional[str]:
     return "test-api-key"
 
 
+def _jwt_auth() -> tuple[str, str]:
+    return ("jwt-token", "team-1")
+
+
 def _no_auth() -> Optional[str]:
     return None
 
@@ -49,6 +53,24 @@ def test_provision_sends_expected_payload_and_headers():
     assert captured["body"]["device_id"] == "dev1"
     assert "hostname" in captured["body"]
     assert "platform" in captured["body"]
+
+
+def test_provision_supports_browser_login_headers():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={"device_id": "dev1", "team_id": "team-1", "user_id": "user-1"},
+        )
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_jwt_auth)
+    api.provision("dev1")
+
+    assert captured["headers"]["x-jwt-token"] == "jwt-token"
+    assert captured["headers"]["x-team-id"] == "team-1"
+    assert "authorization" not in captured["headers"]
 
 
 def test_get_manifest_returns_files_dict():


### PR DESCRIPTION
## Summary
- restore flt login/logout/whoami browser-login credential flow
- use FLEET_API_KEY first, then stored login JWT/team credentials for SDK, oversight, and track API calls
- document both auth modes for FleetTrack

## Testing
- uv run ruff check fleet/auth.py fleet/_auth_headers.py fleet/base.py fleet/_async/base.py fleet/cli.py fleet/track/api.py fleet/track/cli.py tests/test_auth.py tests/test_base_auth.py tests/test_cli_auth.py tests/track/test_api.py
- uv run pytest tests/test_auth.py tests/test_base_auth.py tests/test_cli_auth.py tests/track/test_api.py -q