### PR TITLE
Add flt track install-mcp

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -244,6 +244,36 @@ environment or — until the API-key flow is removed — pass `FLEET_API_KEY` in
 omitted. The MCP process keeps orchestrator as the auth boundary and downloads
 session bytes directly to the same local cache as `flt track download`.
 
+#### One-shot install for local agent clients
+
+`flt track install-mcp` writes the FleetCode MCP entry into local agent
+client configs in stdio mode using `flt login` auth. Three clients are
+supported:
+
+| Client          | Config path                                                       |
+|-----------------|-------------------------------------------------------------------|
+| Claude Code     | `~/.claude.json`                                                  |
+| Claude Desktop  | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Codex           | `~/.codex/config.toml`                                            |
+
+```bash
+flt track install-mcp                       # detect and write to all installed clients
+flt track install-mcp --client claude-code  # one specific client
+flt track install-mcp --all                 # write to every supported client, even if not detected
+flt track install-mcp --print               # print the config snippet, do not write
+flt track uninstall-mcp [--client ...]      # remove
+```
+
+The command resolves the MCP server binary in this order: `fleetcode-mcp`
+co-located with the running `flt` (same venv), then on `PATH`, then a fallback
+to `uv run --directory <fleet-sdk-checkout> --extra fleetcode fleetcode-mcp`
+if a dev checkout is detectable. No `FLEET_API_KEY` is set in the spawned
+environment; the MCP process uses your stored `flt login` credentials.
+
+Writes are idempotent and atomic, and unrelated keys (other `mcpServers`
+entries, app preferences, Codex `[projects.*]` blocks, etc.) are preserved
+verbatim. Restart each app after installing to pick up the new server.
+
 ### Compression
 
 Uploads are raw by default for safe rollout. To store new uploaded session blobs

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from typing import Optional
 
 import typer
 from rich.console import Console
@@ -854,3 +855,130 @@ def resume(
     except Exception as e:
         console.print(f"[red]Resume failed:[/red] {e}")
         raise typer.Exit(1)
+
+
+# ------------------------------------------------------------------ #
+# install-mcp / uninstall-mcp                                          #
+# ------------------------------------------------------------------ #
+
+
+_MCP_CLIENT_LABEL = {
+    "claude-code": "Claude Code",
+    "claude-desktop": "Claude Desktop",
+    "codex": "Codex",
+}
+
+
+def _mcp_clients_to_target(client: Optional[str], all_clients: bool) -> list[str]:
+    from .mcp_install import CLIENT_CHOICES, detect_installed_clients
+
+    if client and all_clients:
+        console.print("[red]--client and --all are mutually exclusive.[/red]")
+        raise typer.Exit(2)
+    if client:
+        if client not in CLIENT_CHOICES:
+            console.print(
+                f"[red]Unknown client:[/red] {client}. "
+                f"Choose from: {', '.join(CLIENT_CHOICES)}"
+            )
+            raise typer.Exit(2)
+        return [client]
+    if all_clients:
+        return list(CLIENT_CHOICES)
+    return detect_installed_clients()
+
+
+@app.command(name="install-mcp")
+def install_mcp(
+    client: Optional[str] = typer.Option(
+        None, "--client", help="Target one client (claude-code|claude-desktop|codex)."
+    ),
+    all_clients: bool = typer.Option(
+        False, "--all", help="Install for every supported client, even if not detected."
+    ),
+    print_only: bool = typer.Option(
+        False, "--print", help="Print the config snippet that would be written; do not write."
+    ),
+) -> None:
+    """Install the FleetCode MCP server into local agent client configs.
+
+    By default, detects which clients have a config file present and writes
+    to all of them. Uses the `flt login` auth path; no FLEET_API_KEY is set
+    in the spawned environment.
+    """
+    from .mcp_install import (
+        config_path_for,
+        install_many,
+        render_snippet,
+        resolve_command_spec,
+    )
+
+    targets = _mcp_clients_to_target(client, all_clients)
+    if not targets:
+        console.print(
+            "[yellow]No supported MCP client configs detected.[/yellow] "
+            "Open Claude Code, Claude Desktop, or Codex once to create their "
+            "config, then re-run — or use --all / --client."
+        )
+        raise typer.Exit(0)
+
+    try:
+        spec = resolve_command_spec()
+    except RuntimeError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+
+    if print_only:
+        for t in targets:
+            console.print(
+                f"\n[bold]{_MCP_CLIENT_LABEL[t]}[/bold] "
+                f"[dim]({config_path_for(t)})[/dim]"
+            )
+            console.print(render_snippet(t, spec), markup=False, highlight=False)
+        return
+
+    results = install_many(targets, spec=spec)
+    for r in results:
+        label = _MCP_CLIENT_LABEL[r.client]
+        if r.action == "added":
+            console.print(f"[green]✓[/green] {label}: added [dim]({r.path})[/dim]")
+        elif r.action == "updated":
+            console.print(f"[green]✓[/green] {label}: updated [dim]({r.path})[/dim]")
+        elif r.action == "unchanged":
+            console.print(f"[dim]·[/dim] {label}: already up to date")
+        elif r.action == "skipped":
+            console.print(f"[dim]·[/dim] {label}: skipped ({r.detail})")
+    console.print(
+        "\nDone. [bold]Restart[/bold] each app to pick up the new MCP server."
+    )
+
+
+@app.command(name="uninstall-mcp")
+def uninstall_mcp(
+    client: Optional[str] = typer.Option(
+        None, "--client", help="Target one client (claude-code|claude-desktop|codex)."
+    ),
+    all_clients: bool = typer.Option(
+        False, "--all", help="Uninstall from every supported client."
+    ),
+) -> None:
+    """Remove the FleetCode MCP server entry from local agent client configs."""
+    from .mcp_install import uninstall_many
+
+    targets = _mcp_clients_to_target(client, all_clients)
+    if not targets:
+        # Default to all when nothing detected, since the entry might exist in
+        # a config we haven't otherwise touched.
+        from .mcp_install import CLIENT_CHOICES
+
+        targets = list(CLIENT_CHOICES)
+
+    results = uninstall_many(targets)
+    for r in results:
+        label = _MCP_CLIENT_LABEL[r.client]
+        if r.action == "removed":
+            console.print(
+                f"[green]✓[/green] {label}: removed [dim]({r.path})[/dim]"
+            )
+        else:
+            console.print(f"[dim]·[/dim] {label}: skipped ({r.detail})")

--- a/fleet/track/mcp_install.py
+++ b/fleet/track/mcp_install.py
@@ -1,0 +1,337 @@
+"""Install the FleetCode MCP server into local agent client configs.
+
+Supports three clients, all stdio + `flt login` auth:
+
+  - claude-code     ~/.claude.json                                       (JSON)
+  - claude-desktop  ~/Library/Application Support/Claude/                (JSON)
+  - codex           ~/.codex/config.toml                                 (TOML)
+
+The writers are idempotent and atomic: existing keys outside `mcpServers`
+(or `mcp_servers` for Codex) are preserved exactly, and writes go through
+a temp file + rename. TOML formatting/comments are preserved via tomlkit.
+
+`tomlkit` is imported lazily inside the Codex writer so the rest of the
+SDK does not require it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+ENTRY_NAME = "fleetcode"
+
+CLIENT_CHOICES = ("claude-code", "claude-desktop", "codex")
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Stdio launch spec written into client configs."""
+
+    command: str
+    args: list[str]
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    client: str
+    path: Path
+    action: str  # "added" | "updated" | "unchanged" | "skipped" | "removed"
+    detail: str = ""
+
+
+# ------------------------------------------------------------------ #
+# Path resolution                                                     #
+# ------------------------------------------------------------------ #
+
+
+def claude_code_config_path() -> Path:
+    return Path.home() / ".claude.json"
+
+
+def claude_desktop_config_path() -> Path:
+    if platform.system() == "Darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    if platform.system() == "Windows":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / "claude_desktop_config.json"
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def codex_config_path() -> Path:
+    return Path.home() / ".codex" / "config.toml"
+
+
+def config_path_for(client: str) -> Path:
+    if client == "claude-code":
+        return claude_code_config_path()
+    if client == "claude-desktop":
+        return claude_desktop_config_path()
+    if client == "codex":
+        return codex_config_path()
+    raise ValueError(f"Unknown client: {client}")
+
+
+# ------------------------------------------------------------------ #
+# Command resolution                                                  #
+# ------------------------------------------------------------------ #
+
+
+def resolve_command_spec(*, fleet_sdk_root: Optional[Path] = None) -> CommandSpec:
+    """Find the best `fleetcode-mcp` invocation for the current install.
+
+    Priority:
+      1. `fleetcode-mcp` co-located with the current Python interpreter (same
+         venv as `flt`).
+      2. `fleetcode-mcp` anywhere on PATH.
+      3. `uv run --directory <repo> --extra fleetcode fleetcode-mcp` if a dev
+         checkout is detectable.
+    Otherwise raises RuntimeError with an install hint.
+    """
+    candidate = Path(sys.executable).parent / "fleetcode-mcp"
+    if candidate.exists():
+        return CommandSpec(command=str(candidate), args=[])
+
+    on_path = shutil.which("fleetcode-mcp")
+    if on_path:
+        return CommandSpec(command=on_path, args=[])
+
+    repo = fleet_sdk_root or _detect_dev_checkout()
+    if repo is not None:
+        uv = shutil.which("uv")
+        if uv:
+            return CommandSpec(
+                command=uv,
+                args=[
+                    "run",
+                    "--directory",
+                    str(repo),
+                    "--extra",
+                    "fleetcode",
+                    "fleetcode-mcp",
+                ],
+            )
+
+    raise RuntimeError(
+        "Could not find `fleetcode-mcp`. Install with: "
+        "pip install 'fleet-python[fleetcode]'"
+    )
+
+
+def _detect_dev_checkout() -> Optional[Path]:
+    """Walk up from this module to find a fleet-python pyproject."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        pyproject = parent / "pyproject.toml"
+        if pyproject.is_file():
+            try:
+                text = pyproject.read_text()
+            except OSError:
+                return None
+            if 'name = "fleet-python"' in text:
+                return parent
+            return None
+    return None
+
+
+# ------------------------------------------------------------------ #
+# Writers — one per client                                            #
+# ------------------------------------------------------------------ #
+
+
+def install_for(client: str, *, spec: CommandSpec) -> InstallResult:
+    """Install / update the FleetCode entry for one client. Idempotent."""
+    path = config_path_for(client)
+    if client in ("claude-code", "claude-desktop"):
+        return _install_json(client, path, spec)
+    if client == "codex":
+        return _install_toml(client, path, spec)
+    raise ValueError(f"Unknown client: {client}")
+
+
+def uninstall_for(client: str) -> InstallResult:
+    path = config_path_for(client)
+    if client in ("claude-code", "claude-desktop"):
+        return _uninstall_json(client, path)
+    if client == "codex":
+        return _uninstall_toml(client, path)
+    raise ValueError(f"Unknown client: {client}")
+
+
+def render_snippet(client: str, spec: CommandSpec) -> str:
+    """Return the JSON/TOML snippet that would be written, for --print mode."""
+    if client in ("claude-code", "claude-desktop"):
+        return json.dumps(
+            {"mcpServers": {ENTRY_NAME: _json_entry(spec)}}, indent=2
+        )
+    if client == "codex":
+        return _toml_snippet(spec)
+    raise ValueError(f"Unknown client: {client}")
+
+
+def _json_entry(spec: CommandSpec) -> dict:
+    return {"command": spec.command, "args": list(spec.args)}
+
+
+def _install_json(client: str, path: Path, spec: CommandSpec) -> InstallResult:
+    existing = _read_json(path)
+    servers = existing.setdefault("mcpServers", {})
+    new_entry = _json_entry(spec)
+    prior = servers.get(ENTRY_NAME)
+    if prior == new_entry:
+        return InstallResult(client, path, "unchanged")
+    action = "updated" if prior is not None else "added"
+    servers[ENTRY_NAME] = new_entry
+    _atomic_write(path, json.dumps(existing, indent=2) + "\n")
+    return InstallResult(client, path, action)
+
+
+def _uninstall_json(client: str, path: Path) -> InstallResult:
+    if not path.exists():
+        return InstallResult(client, path, "skipped", "config not found")
+    existing = _read_json(path)
+    servers = existing.get("mcpServers")
+    if not isinstance(servers, dict) or ENTRY_NAME not in servers:
+        return InstallResult(client, path, "skipped", "entry not present")
+    servers.pop(ENTRY_NAME)
+    if not servers:
+        existing.pop("mcpServers", None)
+    _atomic_write(path, json.dumps(existing, indent=2) + "\n")
+    return InstallResult(client, path, "removed")
+
+
+def _read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    raw = path.read_text()
+    if not raw.strip():
+        return {}
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"{path} does not contain a JSON object; refusing to overwrite."
+        )
+    return data
+
+
+def _install_toml(client: str, path: Path, spec: CommandSpec) -> InstallResult:
+    import tomlkit
+    from tomlkit.items import Table
+
+    doc = _read_toml_doc(path)
+    servers = doc.get("mcp_servers")
+    if servers is None:
+        servers = tomlkit.table()
+        doc["mcp_servers"] = servers
+    elif not isinstance(servers, Table):
+        raise RuntimeError(
+            f"{path}: mcp_servers must be a table; refusing to overwrite."
+        )
+
+    new_entry = tomlkit.table()
+    new_entry["command"] = spec.command
+    new_entry["args"] = list(spec.args)
+
+    prior = servers.get(ENTRY_NAME)
+    if prior is not None and dict(prior) == {"command": spec.command, "args": list(spec.args)}:
+        return InstallResult(client, path, "unchanged")
+    action = "updated" if prior is not None else "added"
+    servers[ENTRY_NAME] = new_entry
+    _atomic_write(path, tomlkit.dumps(doc))
+    return InstallResult(client, path, action)
+
+
+def _uninstall_toml(client: str, path: Path) -> InstallResult:
+    import tomlkit
+
+    if not path.exists():
+        return InstallResult(client, path, "skipped", "config not found")
+    doc = _read_toml_doc(path)
+    servers = doc.get("mcp_servers")
+    if servers is None or ENTRY_NAME not in servers:
+        return InstallResult(client, path, "skipped", "entry not present")
+    del servers[ENTRY_NAME]
+    if len(servers) == 0:
+        del doc["mcp_servers"]
+    _atomic_write(path, tomlkit.dumps(doc))
+    return InstallResult(client, path, "removed")
+
+
+def _read_toml_doc(path: Path):
+    import tomlkit
+
+    if not path.exists():
+        return tomlkit.document()
+    raw = path.read_text()
+    if not raw.strip():
+        return tomlkit.document()
+    return tomlkit.parse(raw)
+
+
+def _toml_snippet(spec: CommandSpec) -> str:
+    """Render a copy-pasteable TOML block for --print mode."""
+    import tomlkit
+
+    body = tomlkit.dumps(
+        {"command": spec.command, "args": list(spec.args)}
+    ).rstrip()
+    return f"[mcp_servers.{ENTRY_NAME}]\n{body}\n"
+
+
+# ------------------------------------------------------------------ #
+# Atomic write                                                        #
+# ------------------------------------------------------------------ #
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ------------------------------------------------------------------ #
+# Detection                                                           #
+# ------------------------------------------------------------------ #
+
+
+def detect_installed_clients() -> list[str]:
+    """Return clients whose config file currently exists.
+
+    Note: Claude Code's `~/.claude.json` is created on first run of `claude`,
+    so a non-existent path means the user hasn't run Claude Code yet — we
+    skip writing rather than create a config the user never opted into.
+    """
+    return [c for c in CLIENT_CHOICES if config_path_for(c).exists()]
+
+
+def install_many(
+    clients: Iterable[str], *, spec: CommandSpec
+) -> list[InstallResult]:
+    return [install_for(c, spec=spec) for c in clients]
+
+
+def uninstall_many(clients: Iterable[str]) -> list[InstallResult]:
+    return [uninstall_for(c) for c in clients]

--- a/fleet/track/mcp_install.py
+++ b/fleet/track/mcp_install.py
@@ -196,7 +196,7 @@ def _install_json(client: str, path: Path, spec: CommandSpec) -> InstallResult:
         return InstallResult(client, path, "unchanged")
     action = "updated" if prior is not None else "added"
     servers[ENTRY_NAME] = new_entry
-    _atomic_write(path, json.dumps(existing, indent=2) + "\n")
+    _atomic_write(path, _dump_json(existing))
     return InstallResult(client, path, action)
 
 
@@ -210,8 +210,18 @@ def _uninstall_json(client: str, path: Path) -> InstallResult:
     servers.pop(ENTRY_NAME)
     if not servers:
         existing.pop("mcpServers", None)
-    _atomic_write(path, json.dumps(existing, indent=2) + "\n")
+    _atomic_write(path, _dump_json(existing))
     return InstallResult(client, path, "removed")
+
+
+def _dump_json(data: dict) -> str:
+    """Serialize JSON without escaping non-ASCII characters.
+
+    `ensure_ascii=True` (Python's default) replaces `—` with `\\u2014`
+    everywhere in the file, producing a noisy diff against any config
+    Claude Code or Claude Desktop wrote with `ensure_ascii=False`.
+    """
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
 
 
 def _read_json(path: Path) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ cli = [
     "rich>=10.0.0",
     "watchdog>=4.0.0",
     "textual>=0.50.0",
+    "tomlkit>=0.13.0",
     "mcp==1.24.0; python_version >= '3.10'",
 ]
 fleetcode = [

--- a/tests/track/test_mcp_install.py
+++ b/tests/track/test_mcp_install.py
@@ -119,6 +119,26 @@ def test_json_uninstall_is_noop_when_absent(client, tmp_path, monkeypatch):
     assert uninstall_for(client).action == "skipped"
 
 
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_install_does_not_escape_non_ascii(client, tmp_path, monkeypatch):
+    """Configs typically contain em-dashes, bullets, etc. — they must round-trip
+    unchanged. Python's default `ensure_ascii=True` would mangle them."""
+    paths = _patch_paths(monkeypatch, tmp_path)
+    paths[client].write_text(
+        '{"prompt": "use — these • characters █░"}',
+        encoding="utf-8",
+    )
+
+    install_for(client, spec=SPEC)
+
+    text = paths[client].read_text(encoding="utf-8")
+    assert "—" in text
+    assert "•" in text
+    assert "█" in text
+    assert "░" in text
+    assert "\\u2014" not in text  # em-dash, must NOT be ASCII-escaped
+
+
 # ------------------------------------------------------------------ #
 # TOML writer (Codex)                                                 #
 # ------------------------------------------------------------------ #

--- a/tests/track/test_mcp_install.py
+++ b/tests/track/test_mcp_install.py
@@ -1,0 +1,267 @@
+"""Unit tests for fleet.track.mcp_install — config writers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fleet.track import mcp_install
+from fleet.track.mcp_install import CommandSpec, install_for, uninstall_for
+
+
+SPEC = CommandSpec(command="/usr/local/bin/fleetcode-mcp", args=[])
+
+
+def _patch_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    paths = {
+        "claude-code": tmp_path / "claude_code.json",
+        "claude-desktop": tmp_path / "claude_desktop.json",
+        "codex": tmp_path / "codex.toml",
+    }
+    monkeypatch.setattr(
+        mcp_install, "claude_code_config_path", lambda: paths["claude-code"]
+    )
+    monkeypatch.setattr(
+        mcp_install, "claude_desktop_config_path", lambda: paths["claude-desktop"]
+    )
+    monkeypatch.setattr(mcp_install, "codex_config_path", lambda: paths["codex"])
+    return paths
+
+
+# ------------------------------------------------------------------ #
+# JSON writers (Claude Code + Claude Desktop)                         #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_install_creates_config_when_absent(client, tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    result = install_for(client, spec=SPEC)
+
+    assert result.action == "added"
+    body = json.loads(paths[client].read_text())
+    assert body == {
+        "mcpServers": {
+            "fleetcode": {"command": SPEC.command, "args": []}
+        }
+    }
+
+
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_install_preserves_unrelated_keys(client, tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    paths[client].write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "mcpServers": {
+                    "other": {"command": "other-mcp", "args": ["--keep"]},
+                },
+            }
+        )
+    )
+
+    install_for(client, spec=SPEC)
+
+    body = json.loads(paths[client].read_text())
+    assert body["preferences"] == {"theme": "dark"}
+    assert body["mcpServers"]["other"] == {"command": "other-mcp", "args": ["--keep"]}
+    assert body["mcpServers"]["fleetcode"] == {"command": SPEC.command, "args": []}
+
+
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_install_is_idempotent(client, tmp_path, monkeypatch):
+    _patch_paths(monkeypatch, tmp_path)
+    assert install_for(client, spec=SPEC).action == "added"
+    assert install_for(client, spec=SPEC).action == "unchanged"
+
+
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_install_updates_changed_command(client, tmp_path, monkeypatch):
+    _patch_paths(monkeypatch, tmp_path)
+    install_for(client, spec=SPEC)
+    new_spec = CommandSpec(command="/different/path/fleetcode-mcp", args=["x"])
+
+    result = install_for(client, spec=new_spec)
+
+    assert result.action == "updated"
+
+
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_uninstall_removes_only_fleetcode(client, tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    paths[client].write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "mcpServers": {
+                    "fleetcode": {"command": "old", "args": []},
+                    "other": {"command": "other-mcp", "args": []},
+                },
+            }
+        )
+    )
+
+    result = uninstall_for(client)
+
+    assert result.action == "removed"
+    body = json.loads(paths[client].read_text())
+    assert "fleetcode" not in body["mcpServers"]
+    assert body["mcpServers"]["other"]["command"] == "other-mcp"
+    assert body["preferences"] == {"theme": "dark"}
+
+
+@pytest.mark.parametrize("client", ["claude-code", "claude-desktop"])
+def test_json_uninstall_is_noop_when_absent(client, tmp_path, monkeypatch):
+    _patch_paths(monkeypatch, tmp_path)
+    assert uninstall_for(client).action == "skipped"
+
+
+# ------------------------------------------------------------------ #
+# TOML writer (Codex)                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_codex_install_preserves_existing_servers_and_other_keys(tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    existing = (
+        'service_tier = "fast"\n'
+        'approval_policy = "never"\n'
+        '\n'
+        '[projects."/Users/me/repo"]\n'
+        'trust_level = "trusted"\n'
+        '\n'
+        '[mcp_servers.linear-server]\n'
+        'url = "https://mcp.linear.app/mcp"\n'
+    )
+    paths["codex"].write_text(existing)
+
+    result = install_for("codex", spec=SPEC)
+
+    assert result.action == "added"
+    text = paths["codex"].read_text()
+    # Original keys + sections preserved verbatim by tomlkit.
+    assert 'service_tier = "fast"' in text
+    assert '[projects."/Users/me/repo"]' in text
+    assert 'trust_level = "trusted"' in text
+    assert '[mcp_servers.linear-server]' in text
+    assert 'url = "https://mcp.linear.app/mcp"' in text
+    # New entry added.
+    assert "fleetcode" in text
+    assert SPEC.command in text
+
+
+def test_codex_install_creates_config_when_absent(tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    result = install_for("codex", spec=SPEC)
+
+    assert result.action == "added"
+    text = paths["codex"].read_text()
+    assert "fleetcode" in text
+    assert SPEC.command in text
+
+
+def test_codex_install_is_idempotent(tmp_path, monkeypatch):
+    _patch_paths(monkeypatch, tmp_path)
+    assert install_for("codex", spec=SPEC).action == "added"
+    assert install_for("codex", spec=SPEC).action == "unchanged"
+
+
+def test_codex_uninstall_removes_only_fleetcode(tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    install_for("codex", spec=SPEC)
+    # Add another server so we can verify it survives.
+    text = paths["codex"].read_text()
+    paths["codex"].write_text(
+        text + '\n[mcp_servers.other]\ncommand = "other-mcp"\nargs = []\n'
+    )
+
+    result = uninstall_for("codex")
+
+    assert result.action == "removed"
+    text = paths["codex"].read_text()
+    assert "fleetcode" not in text
+    assert "[mcp_servers.other]" in text
+
+
+def test_codex_uninstall_is_noop_when_absent(tmp_path, monkeypatch):
+    _patch_paths(monkeypatch, tmp_path)
+    assert uninstall_for("codex").action == "skipped"
+
+
+# ------------------------------------------------------------------ #
+# Detection                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_detect_only_returns_clients_whose_config_exists(tmp_path, monkeypatch):
+    paths = _patch_paths(monkeypatch, tmp_path)
+    paths["claude-code"].write_text("{}")
+    paths["codex"].write_text("")
+
+    detected = mcp_install.detect_installed_clients()
+
+    assert detected == ["claude-code", "codex"]
+
+
+# ------------------------------------------------------------------ #
+# Command resolution                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_resolve_command_spec_prefers_venv_co_located_binary(tmp_path, monkeypatch):
+    fake_bin = tmp_path / "fleetcode-mcp"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_bin.chmod(0o755)
+    monkeypatch.setattr(mcp_install.sys, "executable", str(tmp_path / "python"))
+
+    spec = mcp_install.resolve_command_spec()
+
+    assert spec.command == str(fake_bin)
+    assert spec.args == []
+
+
+def test_resolve_command_spec_falls_back_to_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(mcp_install.sys, "executable", str(tmp_path / "python"))
+    monkeypatch.setattr(
+        mcp_install.shutil,
+        "which",
+        lambda name: "/usr/local/bin/fleetcode-mcp" if name == "fleetcode-mcp" else None,
+    )
+
+    spec = mcp_install.resolve_command_spec()
+
+    assert spec.command == "/usr/local/bin/fleetcode-mcp"
+    assert spec.args == []
+
+
+def test_resolve_command_spec_falls_back_to_uv_run_dev_checkout(tmp_path, monkeypatch):
+    monkeypatch.setattr(mcp_install.sys, "executable", str(tmp_path / "python"))
+    monkeypatch.setattr(
+        mcp_install.shutil,
+        "which",
+        lambda name: "/opt/homebrew/bin/uv" if name == "uv" else None,
+    )
+
+    spec = mcp_install.resolve_command_spec(fleet_sdk_root=tmp_path)
+
+    assert spec.command == "/opt/homebrew/bin/uv"
+    assert spec.args == [
+        "run",
+        "--directory",
+        str(tmp_path),
+        "--extra",
+        "fleetcode",
+        "fleetcode-mcp",
+    ]
+
+
+def test_resolve_command_spec_raises_when_nothing_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(mcp_install.sys, "executable", str(tmp_path / "python"))
+    monkeypatch.setattr(mcp_install.shutil, "which", lambda name: None)
+    monkeypatch.setattr(mcp_install, "_detect_dev_checkout", lambda: None)
+
+    with pytest.raises(RuntimeError, match="fleet-python\\[fleetcode\\]"):
+        mcp_install.resolve_command_spec()

--- a/uv.lock
+++ b/uv.lock
@@ -679,6 +679,7 @@ cli = [
     { name = "mcp", marker = "python_full_version >= '3.10'" },
     { name = "rich" },
     { name = "textual" },
+    { name = "tomlkit" },
     { name = "typer" },
     { name = "watchdog" },
 ]
@@ -739,6 +740,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "textual", marker = "extra == 'cli'", specifier = ">=0.50.0" },
     { name = "textual", marker = "extra == 'dev'", specifier = ">=0.50.0" },
+    { name = "tomlkit", marker = "extra == 'cli'", specifier = ">=0.13.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9.0" },
     { name = "typer", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
@@ -2643,6 +2645,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reopens the install-mcp work from #117 against main. #117 was merged into the already-merged stacked branch codex/track-mcp-server-20260506, so its commits were not included on main.\n\nChanges:\n- Adds flt track install-mcp and uninstall-mcp for Claude Code, Claude Desktop, and Codex local MCP config.\n- Adds fleet.track.mcp_install config writers.\n- Documents install/uninstall usage.\n- Preserves non-ASCII characters when updating JSON MCP config files.\n\nVerification:\n- uv run --all-extras --with pytest pytest tests/track/test_mcp_install.py tests/track/test_mcp_server.py