### PR TITLE
Add Claude Desktop and Cursor sources to FleetTrack

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -8,8 +8,12 @@ resuming them locally or across tools.
 The SDK scans:
 
 - `~/.claude/projects/**/*.jsonl`
+- `~/Library/Application Support/Claude/local-agent-mode-sessions/**/local_*/.claude/projects/**/*.jsonl`
+- `~/Library/Application Support/Claude-3p/local-agent-mode-sessions/**/local_*/.claude/projects/**/*.jsonl`
 - `~/.codex/sessions/**/*.jsonl`
 - `~/.codex/archived_sessions/**/*.jsonl`
+- `~/.cursor/projects/**/agent-transcripts/**/*.jsonl`
+- `~/.cursor/projects/**/agent-transcripts/**/*.txt`
 
 The v1 syncer uses full reconciliation as the sync trigger. On startup, and then
 every 10 minutes, it scans local session files, diffs them against the remote
@@ -40,12 +44,15 @@ fleet-track-sessions/
   {team_id}/{user_id}/{device_id}/
     manifest.json
     raw/.claude/projects/...
+    raw/Library/Application Support/Claude/local-agent-mode-sessions/...
+    raw/Library/Application Support/Claude-3p/local-agent-mode-sessions/...
     raw/.codex/sessions/...
+    raw/.cursor/projects/...
 ```
 
-Cursor transcript syncing is intentionally disabled for now. `CursorSource`
-still exists for future parser work, but Cursor files are not included in the
-default daemon scan until the SDK can extract stable metadata and replay events.
+Cursor transcript bytes are uploaded and minimally indexed for download/search
+by artifact metadata. Cursor replay/resume remains disabled until the SDK can
+extract stable metadata and parse events.
 
 Authentication prefers stored `flt login` browser credentials and falls back
 to `FLEET_API_KEY` for non-interactive hosts. The API-key fallback will be

--- a/docs/fleet-track/goals.md
+++ b/docs/fleet-track/goals.md
@@ -6,9 +6,9 @@ FleetTrack now has a usable v1 product path:
 
 - Authentication through `FLEET_API_KEY` or stored `flt login` credentials.
 - `flt track enable/status/daemon/logs/ls/resume/gc`.
-- Local source discovery for Claude and Codex. Cursor discovery code exists, but
-  default syncing is disabled until metadata extraction and event replay are
-  implemented.
+- Local source discovery and raw-byte sync for Claude, Claude Desktop
+  local-agent, Codex, and Cursor. Cursor replay remains disabled until metadata
+  extraction and event replay are implemented.
 - Periodic full reconciliation into a SQLite upload queue.
 - Scrubbed whole-file uploads to S3 through orchestrator-issued presigned URLs.
 - Remote session metadata indexing for listing/search/resume.

--- a/fleet/track/__init__.py
+++ b/fleet/track/__init__.py
@@ -39,6 +39,7 @@ from .resumer import (
 
 # --- Session store + chained view --- #
 from .sources import (
+    ClaudeDesktopSource,
     ClaudeSource,
     CodexSource,
     CursorSource,
@@ -99,6 +100,7 @@ __all__ = [
     "Source",
     "SourceSummary",
     "ClaudeSource",
+    "ClaudeDesktopSource",
     "CodexSource",
     "CursorSource",
     "default_sources",

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -94,7 +94,7 @@ def enable() -> None:
     found = [s for s in sources if s.is_present()]
     if not found:
         console.print(
-            "[yellow]No AI tool sessions found[/yellow] (~/.claude, ~/.codex)"
+            "[yellow]No AI tool sessions found[/yellow] (~/.claude, Claude Desktop local-agent sessions, ~/.codex, ~/.cursor)"
         )
     else:
         for s in found:
@@ -350,7 +350,9 @@ def _print_search_filter_catalog(json_out: bool) -> None:
     console.print("[bold]Operators[/bold]")
     console.print(", ".join(catalog["operators"]))
     console.print()
-    console.print("[bold]Logical operators[/bold] " + ", ".join(catalog["logical_operators"]))
+    console.print(
+        "[bold]Logical operators[/bold] " + ", ".join(catalog["logical_operators"])
+    )
     console.print()
     console.print("[bold]Time fields[/bold] " + ", ".join(catalog["time_fields"]))
 

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -305,8 +305,8 @@ class Daemon:
     def _apply_reconcile_result(self, result: "ReconcileResult") -> None:
         # Seed confirmed_map from S3 — these are files we know are safely stored.
         # Pruned paths are legacy manifest entries that are no longer part of
-        # default sync (currently Cursor); mark the manifest dirty so the next
-        # upload stops advertising them.
+        # default sync; mark the manifest dirty so the next upload stops
+        # advertising them.
         confirmed_existing: dict[str, str] = {}
         with self._confirmed_lock:
             if result.pruned_paths:

--- a/fleet/track/reconciler.py
+++ b/fleet/track/reconciler.py
@@ -95,7 +95,11 @@ class Reconciler:
 def _prune_unsupported_manifest_paths(
     file_map: dict[str, str],
 ) -> tuple[dict[str, str], tuple[str, ...]]:
-    """Drop legacy paths that are no longer part of default remote sync."""
+    """Drop legacy paths that are no longer part of default remote sync.
+
+    This hook is intentionally empty today; keep it so future source removals
+    can prune stale manifest entries without changing reconcile flow.
+    """
     kept: dict[str, str] = {}
     pruned: list[str] = []
     for path, digest in file_map.items():
@@ -106,6 +110,5 @@ def _prune_unsupported_manifest_paths(
     return kept, tuple(sorted(pruned))
 
 
-def _is_unsupported_manifest_path(path: str) -> bool:
-    normalized = path.lstrip("/")
-    return normalized == ".cursor" or normalized.startswith(".cursor/")
+def _is_unsupported_manifest_path(_path: str) -> bool:
+    return False

--- a/fleet/track/sources/__init__.py
+++ b/fleet/track/sources/__init__.py
@@ -3,7 +3,7 @@
 Public surface:
     Source                 — abstract base class
     SourceSummary          — reportable view of one source
-    ClaudeSource, CursorSource, CodexSource — concrete impls
+    ClaudeSource, ClaudeDesktopSource, CursorSource, CodexSource — concrete impls
     default_sources(home)  — list of standard sources for a given home
     relative_to_home       — shared util
 
@@ -26,6 +26,7 @@ from .base import (
     relative_to_home,
 )
 from .claude import ClaudeSource
+from .claude_desktop import ClaudeDesktopSource
 from .codex import CodexSource
 from .cursor import CursorSource
 
@@ -33,6 +34,7 @@ __all__ = [
     "Source",
     "SourceSummary",
     "ClaudeSource",
+    "ClaudeDesktopSource",
     "CursorSource",
     "CodexSource",
     "default_sources",
@@ -48,11 +50,11 @@ __all__ = [
 
 def default_sources(home: Optional[Path] = None) -> list[Source]:
     """The standard set of sources we sync from. Tests pass a tmp home."""
-    # CursorSource remains importable, but it is not in the default sync set
-    # until we have stable metadata extraction and event parsing for resume.
     return [
         ClaudeSource(home=home),
+        ClaudeDesktopSource(home=home),
         CodexSource(home=home),
+        CursorSource(home=home),
     ]
 
 
@@ -66,7 +68,18 @@ EXCLUDE_PATTERNS = DEFAULT_EXCLUDE_PATTERNS
 # Path.home(); but exposed as a module attribute for legacy callers.
 WATCH_ROOTS = [
     Path.home() / ".claude" / "projects",
+    Path.home()
+    / "Library"
+    / "Application Support"
+    / "Claude"
+    / "local-agent-mode-sessions",
+    Path.home()
+    / "Library"
+    / "Application Support"
+    / "Claude-3p"
+    / "local-agent-mode-sessions",
     Path.home() / ".codex",
+    Path.home() / ".cursor" / "projects",
 ]
 
 

--- a/fleet/track/sources/claude_desktop.py
+++ b/fleet/track/sources/claude_desktop.py
@@ -1,0 +1,62 @@
+"""ClaudeDesktopSource — Claude Desktop local-agent transcript files.
+
+Claude Desktop/Cowork local-agent sessions live under macOS app data, with a
+per-session working directory that contains an embedded Claude Code transcript:
+
+  ~/Library/Application Support/Claude/local-agent-mode-sessions/
+    .../local_<uuid>/.claude/projects/**/*.jsonl
+
+Those nested JSONL files use the same shape as normal Claude Code transcripts,
+so parsing/serialization can reuse `ClaudeSource`; this source only changes
+where discovery looks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+from .base import _walk_glob
+from .claude import ClaudeSource
+
+
+class ClaudeDesktopSource(ClaudeSource):
+    """Claude Desktop local-agent transcripts embedded in app support data."""
+
+    name = "claude-desktop"
+
+    @property
+    def root(self) -> Path:
+        for root in self.roots:
+            if root.is_dir():
+                return root
+        return self.roots[0]
+
+    @property
+    def roots(self) -> list[Path]:
+        """Known Claude Desktop local-agent roots.
+
+        `Claude-3p` is used by Anthropic's 3P distribution. Most machines only
+        have the normal `Claude` root, but scanning both keeps discovery aligned
+        with Anthropic's documented layouts.
+        """
+        app_support = self._home / "Library" / "Application Support"
+        return [
+            app_support / "Claude" / "local-agent-mode-sessions",
+            app_support / "Claude-3p" / "local-agent-mode-sessions",
+        ]
+
+    @property
+    def watch_roots(self) -> list[Path]:
+        return self.roots
+
+    def is_present(self) -> bool:
+        return any(root.is_dir() for root in self.roots)
+
+    def iter_files(self) -> Iterator[Path]:
+        for root in self.roots:
+            yield from _walk_glob(
+                root,
+                "**/local_*/.claude/projects/**/*.jsonl",
+                self.exclude_patterns,
+            )

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -39,6 +39,7 @@ revisit if we ever ship multi-process scenarios.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -892,8 +893,9 @@ class RemoteSessionStore:
 class NativeFilesSessionStore:
     """Read-only `SessionStore` view of native CLI session files.
 
-    Walks `~/.claude/projects/` and `~/.codex/sessions/` (via the same
-    `Source` classes the daemon uses). Useful as a "show me what's
+    Walks `~/.claude/projects/`, Claude Desktop local-agent transcripts,
+    `~/.codex/sessions/`, and Cursor agent transcripts (via the same `Source`
+    classes the daemon uses). Useful as a "show me what's
     actually on disk" backend for `flt track ls` / `flt track resume`
     before the remote backend exists or before LocalSessionStore has
     been seeded.
@@ -991,6 +993,8 @@ class NativeFilesSessionStore:
             yield from ClaudeSource(home=self._home).parse(path)
         elif s.tool == "codex":
             yield from CodexSource(home=self._home).parse(path)
+        elif s.tool == "cursor":
+            raise NotImplementedError("Cursor transcript replay is not implemented yet")
 
     # Native session files don't carry forked_from links, so events()
     # here never walks a fork chain — own_events is the same stream.
@@ -1020,8 +1024,6 @@ class NativeFilesSessionStore:
         query: Optional[str] = None,
     ) -> Iterator[Session]:
         for source, build_session in self._sources_with_session_builders():
-            if tool is not None and source.name != tool:
-                continue
             if not source.is_present():
                 continue
             for path in source.iter_files():
@@ -1035,6 +1037,8 @@ class NativeFilesSessionStore:
                     continue
                 if s is None:
                     continue
+                if tool is not None and s.tool != tool:
+                    continue
                 if cwd is not None and s.cwd != cwd:
                     continue
                 if since is not None and (s.last_active or "") < since:
@@ -1045,11 +1049,18 @@ class NativeFilesSessionStore:
 
     def _sources_with_session_builders(self):
         """Each tuple is (source_instance, fn(path)→Session|None)."""
-        from .sources import ClaudeSource, CodexSource
+        from .sources import (
+            ClaudeDesktopSource,
+            ClaudeSource,
+            CodexSource,
+            CursorSource,
+        )
 
         return [
             (ClaudeSource(home=self._home), self._build_claude_session),
+            (ClaudeDesktopSource(home=self._home), self._build_claude_session),
             (CodexSource(home=self._home), self._build_codex_session),
+            (CursorSource(home=self._home), self._build_cursor_session),
         ]
 
     def _build_claude_session(self, path) -> Optional[Session]:
@@ -1085,16 +1096,45 @@ class NativeFilesSessionStore:
             cwd=cwd,
         )
 
+    def _build_cursor_session(self, path) -> Optional[Session]:
+        if path.suffix not in {".jsonl", ".txt"}:
+            return None
+        try:
+            rel = path.relative_to(self._home)
+        except ValueError:
+            return None
+        if not _is_cursor_transcript_path(rel.parts):
+            return None
+        return _build_session_from_path(
+            tool="cursor",
+            id=_cursor_session_id(path, home=self._home),
+            path=path,
+            cwd=None,
+        )
+
     def _path_for(self, session: Session) -> Optional["Path"]:  # noqa: F821
-        from .sources import ClaudeSource, CodexSource
+        from .sources import (
+            ClaudeDesktopSource,
+            ClaudeSource,
+            CodexSource,
+            CursorSource,
+        )
 
         if session.tool == "claude":
-            for p in ClaudeSource(home=self._home).iter_files():
-                if p.stem == session.id:
-                    return p
+            for source in (
+                ClaudeSource(home=self._home),
+                ClaudeDesktopSource(home=self._home),
+            ):
+                for p in source.iter_files():
+                    if p.stem == session.id:
+                        return p
         elif session.tool == "codex":
             for p in CodexSource(home=self._home).iter_files():
                 if p.stem.endswith(session.id):
+                    return p
+        elif session.tool == "cursor":
+            for p in CursorSource(home=self._home).iter_files():
+                if _cursor_session_id(p, home=self._home) == session.id:
                     return p
         return None
 
@@ -1496,7 +1536,7 @@ def session_from_native_path(path, *, home: Optional[Path] = None) -> Optional[S
 
     parts = rel.parts
     native = NativeFilesSessionStore(home=home)
-    if len(parts) >= 3 and parts[0] == ".claude" and parts[1] == "projects":
+    if _is_claude_projects_path(parts):
         if path.suffix != ".jsonl":
             return None
         return native._build_claude_session(path)
@@ -1512,7 +1552,48 @@ def session_from_native_path(path, *, home: Optional[Path] = None) -> Optional[S
         if path.suffix != ".jsonl":
             return None
         return native._build_codex_session(path)
+    if _is_cursor_transcript_path(parts):
+        if path.suffix not in {".jsonl", ".txt"}:
+            return None
+        return native._build_cursor_session(path)
     return None
+
+
+def _is_claude_projects_path(parts: tuple[str, ...]) -> bool:
+    """True for normal and embedded Claude Code transcript paths.
+
+    Normal Claude Code sessions live at `.claude/projects/...`. Claude Desktop
+    local-agent sessions embed the same layout deeper under app data, e.g.
+    `Library/Application Support/Claude/local-agent-mode-sessions/.../.claude/projects/...`.
+    """
+    for idx in range(len(parts) - 1):
+        if parts[idx] == ".claude" and parts[idx + 1] == "projects":
+            return True
+    return False
+
+
+def _is_cursor_transcript_path(parts: tuple[str, ...]) -> bool:
+    """True for Cursor agent transcript files under `.cursor/projects`."""
+    return (
+        len(parts) >= 5
+        and parts[0] == ".cursor"
+        and parts[1] == "projects"
+        and "agent-transcripts" in parts
+    )
+
+
+def _cursor_session_id(path, *, home: Path) -> str:
+    """Stable path-derived id for Cursor transcript artifacts.
+
+    Cursor transcript metadata is not stable enough for replay yet, but a
+    deterministic id lets Fleet index and download the raw uploaded artifact.
+    """
+    try:
+        rel = path.relative_to(home).as_posix()
+    except ValueError:
+        rel = str(path)
+    digest = hashlib.sha256(rel.encode("utf-8")).hexdigest()[:24]
+    return f"cursor-{digest}"
 
 
 def _decode_claude_cwd(path) -> Optional[str]:

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -118,40 +118,25 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
     cache.close()
 
 
-def test_run_once_rewrites_manifest_without_legacy_cursor_paths(tmp_path: Path):
+def test_run_once_uploads_cursor_transcript_and_indexes_artifact(tmp_path: Path):
     paths = TrackPaths.under(tmp_path)
     paths.ensure_track_dir()
 
-    rel_path = (
-        ".codex/sessions/"
-        "rollout-2026-05-05T00-00-00-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl"
-    )
+    rel_path = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
     session_file = tmp_path / rel_path
     session_file.parent.mkdir(parents=True)
-    session_file.write_text(
-        '{"type":"session_meta","payload":{"id":"s2","cwd":"/tmp"}}\n'
-    )
+    session_file.write_text('{"role":"user","content":"cursor hi"}\n')
 
     queue = UploadQueue(paths)
     cache = HashCache(paths)
     tree = MerkleTree(cache, file_iter=[session_file])
-    local_map, _ = tree.build()
-    cursor_rel = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
-    queue.enqueue(cursor_rel, "legacy-cursor-digest")
-    remote_files = {**local_map, cursor_rel: "legacy-cursor-digest"}
 
     api_requests: list[tuple[str, dict]] = []
     metadata_upserts: list[dict] = []
 
     def handler(req: httpx.Request) -> httpx.Response:
         if req.method == "GET" and req.url.path.endswith("/v1/track/manifest"):
-            return httpx.Response(
-                200,
-                json={
-                    "root_hash": MerkleTree.compute_root(remote_files),
-                    "files": remote_files,
-                },
-            )
+            return httpx.Response(200, json={"root_hash": "", "files": {}})
         if req.method == "POST" and req.url.path.endswith("/v1/track/upload-urls"):
             body = json.loads(req.content)
             api_requests.append((req.url.path, body))
@@ -183,25 +168,32 @@ def test_run_once_rewrites_manifest_without_legacy_cursor_paths(tmp_path: Path):
 
     result = daemon.run_once(device_id="dev1")
 
-    assert result.in_sync is True
-    assert result.changed_paths == ()
-    assert result.pruned_paths == (cursor_rel,)
-    assert queue.stats() == {}
+    assert result.in_sync is False
+    assert result.changed_paths == (rel_path,)
+    assert result.pruned_paths == ()
+    assert queue.stats().get("done") == 1
 
-    assert [url for url, _ in transport.calls] == ["https://s3.test/manifest.json"]
+    assert [url for url, _ in transport.calls] == [
+        f"https://s3.test/{rel_path}",
+        "https://s3.test/manifest.json",
+    ]
     manifest = json.loads(transport.calls[-1][1])
-    assert manifest["files"] == local_map
-    assert cursor_rel not in daemon._confirmed_map
+    assert manifest["files"] == {rel_path: result.local_map[rel_path]}
 
     upload_url_paths = [body["paths"] for _, body in api_requests]
-    assert upload_url_paths == [["manifest.json"]]
+    assert upload_url_paths == [[rel_path], ["manifest.json"]]
     assert len(metadata_upserts) == 1
+    upsert = metadata_upserts[0]
+    assert upsert["path"] == rel_path
+    assert upsert["session"]["tool"] == "cursor"
+    assert upsert["session"]["id"].startswith("cursor-")
+    assert upsert["content_codec"] == "raw"
 
     queue.close()
     cache.close()
 
 
-def test_upload_done_ignores_legacy_cursor_paths(tmp_path: Path):
+def test_upload_done_accepts_cursor_paths(tmp_path: Path):
     paths = TrackPaths.under(tmp_path)
     paths.ensure_track_dir()
     queue = UploadQueue(paths)
@@ -226,10 +218,9 @@ def test_upload_done_ignores_legacy_cursor_paths(tmp_path: Path):
 
     daemon._on_upload_done(rel_path, "cursor-digest")
 
-    assert queue.stats() == {}
-    assert rel_path not in daemon._confirmed_map
+    assert daemon._confirmed_map[rel_path] == "cursor-digest"
     assert daemon._manifest_dirty is True
-    assert metadata_calls == []
+    assert metadata_calls == [(rel_path, "cursor-digest")]
 
     queue.close()
     cache.close()

--- a/tests/track/test_reconciler.py
+++ b/tests/track/test_reconciler.py
@@ -92,26 +92,21 @@ def test_reconcile_when_in_sync_enqueues_nothing(tmp_path: Path):
     queue.close()
 
 
-def test_reconcile_prunes_legacy_cursor_manifest_paths(tmp_path: Path):
-    """Old Cursor entries should not keep the manifest out of sync."""
+def test_reconcile_enqueues_cursor_transcripts(tmp_path: Path):
+    """Cursor transcripts are raw-synced even though replay is unsupported."""
     paths = TrackPaths.under(tmp_path)
     paths.ensure_track_dir()
     queue = UploadQueue(paths)
     cache = HashCache(paths)
 
-    f1 = _seed_file(tmp_path, ".codex/sessions/2026/05/05/rollout-s1.jsonl", "AAA")
-    tree = MerkleTree(cache, file_iter=[f1])
-    local_map, _ = tree.build()
     cursor_rel = ".cursor/projects/p1/agent-transcripts/t1/session.jsonl"
-    remote_files = {**local_map, cursor_rel: "legacy-cursor-digest"}
+    f1 = _seed_file(tmp_path, cursor_rel, '{"type":"user"}\n')
+    tree = MerkleTree(cache, file_iter=[f1])
 
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            json={
-                "root_hash": MerkleTree.compute_root(remote_files),
-                "files": remote_files,
-            },
+            json={"root_hash": MerkleTree.compute_root({}), "files": {}},
         )
 
     api = TrackAPIClient(
@@ -124,12 +119,10 @@ def test_reconcile_prunes_legacy_cursor_manifest_paths(tmp_path: Path):
     reconciler = Reconciler(queue=queue, cache=cache, tree=tree, api=api)
     result = reconciler.reconcile("dev1")
 
-    assert result.in_sync is True
-    assert result.changed_paths == ()
-    assert result.pruned_paths == (cursor_rel,)
-    assert result.local_map == local_map
-    assert result.remote_map == local_map
-    assert queue.stats() == {}
+    assert result.in_sync is False
+    assert result.changed_paths == (cursor_rel,)
+    assert result.pruned_paths == ()
+    assert queue.stats().get("pending", 0) == 1
     queue.close()
 
 

--- a/tests/track/test_sources.py
+++ b/tests/track/test_sources.py
@@ -8,6 +8,7 @@ import pytest
 
 from fleet.track.sources import (
     DEFAULT_EXCLUDE_PATTERNS,
+    ClaudeDesktopSource,
     ClaudeSource,
     CodexSource,
     CursorSource,
@@ -28,6 +29,26 @@ def _seed_claude(home: Path) -> None:
     base.mkdir(parents=True)
     (base / "abc.jsonl").write_text('{"role": "user"}\n')
     (base / "session-env").write_text("FOO=bar")  # excluded
+
+
+def _seed_claude_desktop(home: Path, app_name: str = "Claude") -> Path:
+    base = (
+        home
+        / "Library"
+        / "Application Support"
+        / app_name
+        / "local-agent-mode-sessions"
+        / "account"
+        / "workspace"
+        / "local_11111111-2222-3333-4444-555555555555"
+        / ".claude"
+        / "projects"
+        / "-desktop-cwd"
+    )
+    base.mkdir(parents=True)
+    f = base / "22222222-3333-4444-5555-666666666666.jsonl"
+    f.write_text('{"type": "user"}\n')
+    return f
 
 
 def _seed_cursor(home: Path) -> None:
@@ -88,6 +109,47 @@ def test_claude_read_for_upload_trims_partial_jsonl_line(tmp_path: Path):
     f = next(s.iter_files())
     f.write_text('{"a": 1}\n{"partial":')  # mid-write
     assert s.read_for_upload(f) == b'{"a": 1}\n'
+
+
+# ------------------------------------------------------------------ #
+# ClaudeDesktopSource                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_claude_desktop_iter_files_finds_embedded_project_jsonl(tmp_path: Path):
+    expected = _seed_claude_desktop(tmp_path)
+    s = ClaudeDesktopSource(home=tmp_path)
+
+    assert s.is_present() is True
+    assert list(s.iter_files()) == [expected]
+
+
+def test_claude_desktop_checks_3p_root_too(tmp_path: Path):
+    expected = _seed_claude_desktop(tmp_path, app_name="Claude-3p")
+    s = ClaudeDesktopSource(home=tmp_path)
+
+    assert s.is_present() is True
+    assert list(s.iter_files()) == [expected]
+
+
+def test_claude_desktop_skips_non_session_embedded_claude_dirs(tmp_path: Path):
+    base = (
+        tmp_path
+        / "Library"
+        / "Application Support"
+        / "Claude"
+        / "local-agent-mode-sessions"
+        / "account"
+        / "workspace"
+        / "not-a-session"
+        / ".claude"
+        / "projects"
+        / "-desktop-cwd"
+    )
+    base.mkdir(parents=True)
+    (base / "22222222-3333-4444-5555-666666666666.jsonl").write_text("{}\n")
+
+    assert list(ClaudeDesktopSource(home=tmp_path).iter_files()) == []
 
 
 # ------------------------------------------------------------------ #
@@ -189,7 +251,7 @@ def test_serialize_returns_bytes(tmp_path: Path):
 def test_default_sources_returns_indexable_sources(tmp_path: Path):
     sources = default_sources(home=tmp_path)
     names = [s.name for s in sources]
-    assert names == ["claude", "codex"]
+    assert names == ["claude", "claude-desktop", "codex", "cursor"]
 
 
 def test_default_sources_use_provided_home(tmp_path: Path):

--- a/tests/track/test_store_native.py
+++ b/tests/track/test_store_native.py
@@ -17,6 +17,7 @@ from fleet.track.store import (
     LocalSessionStore,
     NativeFilesSessionStore,
     Session,
+    session_from_native_path,
 )
 from fleet.track.unified import UserMessage
 
@@ -57,6 +58,48 @@ def _seed_native_claude(home: Path, *, sid: str, encoded_cwd: str = "-tmp-x") ->
     return f
 
 
+def _seed_native_claude_desktop(home: Path, *, sid: str) -> Path:
+    base = (
+        home
+        / "Library"
+        / "Application Support"
+        / "Claude"
+        / "local-agent-mode-sessions"
+        / "account"
+        / "workspace"
+        / "local_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        / ".claude"
+        / "projects"
+        / "-tmp-desktop"
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    f = base / f"{sid}.jsonl"
+    rows = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": sid,
+            "cwd": "/tmp/desktop",
+            "gitBranch": "main",
+            "version": "0.5",
+            "timestamp": "2026-05-06T00:00:00Z",
+            "message": {"role": "user", "content": "desktop hi"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "parentUuid": "u1",
+            "timestamp": "2026-05-06T00:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "desktop yo"}],
+            },
+        },
+    ]
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
 def _seed_native_codex(home: Path, *, sid: str, cwd: str = "/tmp/y") -> Path:
     base = home / ".codex" / "sessions" / "2026" / "05" / "01"
     base.mkdir(parents=True, exist_ok=True)
@@ -86,6 +129,14 @@ def _seed_native_codex(home: Path, *, sid: str, cwd: str = "/tmp/y") -> Path:
     return f
 
 
+def _seed_native_cursor(home: Path) -> Path:
+    base = home / ".cursor" / "projects" / "p1" / "agent-transcripts" / "t1"
+    base.mkdir(parents=True, exist_ok=True)
+    f = base / "session.jsonl"
+    f.write_text('{"role":"user","content":"cursor hi"}\n')
+    return f
+
+
 # ------------------------------------------------------------------ #
 # NativeFilesSessionStore                                              #
 # ------------------------------------------------------------------ #
@@ -103,6 +154,27 @@ def test_native_store_lists_claude_session_by_filename(tmp_path: Path):
     assert s.event_count == 2  # 2 lines
 
 
+def test_native_store_lists_claude_desktop_embedded_session(tmp_path: Path):
+    sid = "33333333-4444-5555-6666-777777777777"
+    path = _seed_native_claude_desktop(tmp_path, sid=sid)
+    store = NativeFilesSessionStore(home=tmp_path)
+
+    session = store.get(sid)
+    assert session is not None
+    assert session.id == sid
+    assert session.tool == "claude"
+    assert session.cwd == "/tmp/desktop"
+
+    sessions = store.list(tool="claude")
+    assert sid in {s.id for s in sessions}
+    assert list(store.events(sid))
+
+    indexed = session_from_native_path(path, home=tmp_path)
+    assert indexed is not None
+    assert indexed.id == sid
+    assert indexed.tool == "claude"
+
+
 def test_native_store_lists_codex_session_by_uuid_in_filename(tmp_path: Path):
     sid = "abcdef01-2345-6789-abcd-ef0123456789"
     _seed_native_codex(tmp_path, sid=sid, cwd="/tmp/cdx")
@@ -113,12 +185,36 @@ def test_native_store_lists_codex_session_by_uuid_in_filename(tmp_path: Path):
     assert s.cwd == "/tmp/cdx"
 
 
+def test_native_store_lists_cursor_transcript_as_downloadable_artifact(
+    tmp_path: Path,
+):
+    path = _seed_native_cursor(tmp_path)
+    store = NativeFilesSessionStore(home=tmp_path)
+
+    sessions = store.list(tool="cursor")
+    assert len(sessions) == 1
+    session = sessions[0]
+    assert session.id.startswith("cursor-")
+    assert session.tool == "cursor"
+    assert session.event_count == 1
+
+    indexed = session_from_native_path(path, home=tmp_path)
+    assert indexed is not None
+    assert indexed.id == session.id
+    assert indexed.tool == "cursor"
+
+    with pytest.raises(NotImplementedError):
+        list(store.events(session.id))
+
+
 def test_native_store_filters_by_tool(tmp_path: Path):
     _seed_native_claude(tmp_path, sid="11111111-1111-1111-1111-111111111111")
     _seed_native_codex(tmp_path, sid="22222222-2222-2222-2222-222222222222")
+    _seed_native_cursor(tmp_path)
     store = NativeFilesSessionStore(home=tmp_path)
     assert {s.tool for s in store.list(tool="claude")} == {"claude"}
     assert {s.tool for s in store.list(tool="codex")} == {"codex"}
+    assert {s.tool for s in store.list(tool="cursor")} == {"cursor"}
 
 
 def test_native_store_skips_fleet_checkouts(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a Claude Desktop local-agent source that scans embedded Claude Code JSONL transcripts under Claude/Claude-3p app data
- include Cursor agent transcript files in default raw-byte sync and minimally index them with stable path-derived ids
- update native session discovery, metadata indexing, docs, and FleetTrack tests for the new sources

## Tests
- uv run pytest