### PR TITLE
Add FleetTrack session blocklist

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -89,8 +89,29 @@ flt track search
 flt track aggregate
 flt track download
 flt track resume
+flt track block
+flt track unblock
+flt track blocked
 flt track gc
 ```
+
+### Blocking Local Sessions
+
+Use `flt track block <session-id>...` to prevent local sessions from being
+uploaded. Blocked session ids are stored in `~/.fleet/track/config.json` under
+`blocked_session_ids`. During reconciliation, blocked paths are removed from the
+local and remote manifest view, deleted from the upload queue, and skipped by
+upload-complete callbacks.
+
+```bash
+flt track block eb174545-bce7-4d7d-901a-ccbce1df60e7
+flt track blocked
+flt track unblock eb174545-bce7-4d7d-901a-ccbce1df60e7
+```
+
+Blocking prevents future uploads and removes blocked entries from the manifest
+the next time the daemon reconciles. It does not delete already-stored S3 blobs
+or remote metadata rows; that requires a server-side purge endpoint.
 
 ### Search
 

--- a/fleet/track/blocklist.py
+++ b/fleet/track/blocklist.py
@@ -1,0 +1,142 @@
+"""Local FleetTrack upload blocklist.
+
+Users may keep local sessions that should never be submitted to Fleet. The
+blocklist is stored in `~/.fleet/track/config.json` alongside the device id so
+it applies before upload URL requests, metadata indexing, or manifest writes.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .paths import TrackPaths
+
+log = logging.getLogger("fleet.track.blocklist")
+
+BLOCKED_SESSION_IDS_KEY = "blocked_session_ids"
+BLOCKED_PATHS_KEY = "blocked_paths"
+BLOCKED_PATH_GLOBS_KEY = "blocked_path_globs"
+
+
+@dataclass(frozen=True)
+class TrackBlocklist:
+    """In-memory view of locally blocked session ids and paths."""
+
+    session_ids: frozenset[str] = frozenset()
+    paths: frozenset[str] = frozenset()
+    path_globs: tuple[str, ...] = ()
+
+    @classmethod
+    def empty(cls) -> "TrackBlocklist":
+        return cls()
+
+    @classmethod
+    def from_paths(cls, paths: TrackPaths) -> "TrackBlocklist":
+        return cls.from_config(read_track_config(paths))
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "TrackBlocklist":
+        return cls(
+            session_ids=frozenset(_clean_strs(config.get(BLOCKED_SESSION_IDS_KEY))),
+            paths=frozenset(
+                _normalize_rel_path(p)
+                for p in _clean_strs(config.get(BLOCKED_PATHS_KEY))
+            ),
+            path_globs=tuple(_clean_strs(config.get(BLOCKED_PATH_GLOBS_KEY))),
+        )
+
+    def is_empty(self) -> bool:
+        return not self.session_ids and not self.paths and not self.path_globs
+
+    def is_blocked_path(self, rel_path: str) -> bool:
+        rel_path = _normalize_rel_path(rel_path)
+        if rel_path in self.paths:
+            return True
+        if any(fnmatch.fnmatch(rel_path, pattern) for pattern in self.path_globs):
+            return True
+        if not self.session_ids:
+            return False
+        stem = Path(rel_path).stem
+        for session_id in self.session_ids:
+            if stem == session_id or stem.endswith(session_id):
+                return True
+            if f"/{session_id}.jsonl" in rel_path or f"/{session_id}.txt" in rel_path:
+                return True
+        return False
+
+
+def read_track_config(paths: TrackPaths) -> dict[str, Any]:
+    try:
+        raw = paths.config_file.read_text()
+    except FileNotFoundError:
+        return {}
+    except OSError as e:
+        log.warning("failed to read track config %s: %s", paths.config_file, e)
+        return {}
+    try:
+        config = json.loads(raw)
+    except json.JSONDecodeError as e:
+        log.warning("failed to parse track config %s: %s", paths.config_file, e)
+        return {}
+    return config if isinstance(config, dict) else {}
+
+
+def write_track_config(paths: TrackPaths, config: dict[str, Any]) -> None:
+    paths.ensure_track_dir()
+    paths.config_file.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+
+
+def add_blocked_session_ids(paths: TrackPaths, session_ids: Iterable[str]) -> list[str]:
+    config = read_track_config(paths)
+    existing = set(_clean_strs(config.get(BLOCKED_SESSION_IDS_KEY)))
+    added: list[str] = []
+    for session_id in _clean_strs(session_ids):
+        if session_id not in existing:
+            existing.add(session_id)
+            added.append(session_id)
+    config[BLOCKED_SESSION_IDS_KEY] = sorted(existing)
+    write_track_config(paths, config)
+    return added
+
+
+def remove_blocked_session_ids(
+    paths: TrackPaths, session_ids: Iterable[str]
+) -> list[str]:
+    config = read_track_config(paths)
+    existing = set(_clean_strs(config.get(BLOCKED_SESSION_IDS_KEY)))
+    removed: list[str] = []
+    for session_id in _clean_strs(session_ids):
+        if session_id in existing:
+            existing.remove(session_id)
+            removed.append(session_id)
+    if existing:
+        config[BLOCKED_SESSION_IDS_KEY] = sorted(existing)
+    else:
+        config.pop(BLOCKED_SESSION_IDS_KEY, None)
+    write_track_config(paths, config)
+    return removed
+
+
+def _clean_strs(value: Any) -> list[str]:
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, Iterable):
+        return []
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        item = item.strip()
+        if item:
+            out.append(item)
+    return out
+
+
+def _normalize_rel_path(path: str) -> str:
+    return path.strip().lstrip("/").replace("\\", "/")

--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -14,6 +14,11 @@ from rich.console import Console
 from rich.table import Table
 
 from .api import TrackAPIClient, TrackAPIError
+from .blocklist import (
+    add_blocked_session_ids,
+    read_track_config,
+    remove_blocked_session_ids,
+)
 from .daemon import main as daemon_main
 from .install import install, is_installed, uninstall
 from .paths import TrackPaths
@@ -235,6 +240,64 @@ def logs() -> None:
     import subprocess
 
     subprocess.run(["tail", "-f", str(log_path)])
+
+
+@app.command("block")
+def block_sessions(
+    session_ids: list[str] = typer.Argument(
+        ...,
+        help="Session id(s) to exclude from FleetTrack uploads.",
+    ),
+) -> None:
+    """Block local session ids from upload."""
+    added = add_blocked_session_ids(TrackPaths.default(), session_ids)
+    if added:
+        console.print(f"[green]✓[/green] Blocked {len(added)} session id(s).")
+    else:
+        console.print("[dim]No changes; those session ids were already blocked.[/dim]")
+    console.print(
+        "[dim]Blocked sessions are pruned on the next daemon reconcile.[/dim]"
+    )
+
+
+@app.command("unblock")
+def unblock_sessions(
+    session_ids: list[str] = typer.Argument(
+        ...,
+        help="Session id(s) to allow for FleetTrack uploads again.",
+    ),
+) -> None:
+    """Remove local session ids from the upload blocklist."""
+    removed = remove_blocked_session_ids(TrackPaths.default(), session_ids)
+    if removed:
+        console.print(f"[green]✓[/green] Unblocked {len(removed)} session id(s).")
+    else:
+        console.print("[dim]No changes; those session ids were not blocked.[/dim]")
+
+
+@app.command("blocked")
+def list_blocked_sessions() -> None:
+    """List locally blocked upload ids and paths."""
+    config = read_track_config(TrackPaths.default())
+    session_ids = config.get("blocked_session_ids") or []
+    paths = config.get("blocked_paths") or []
+    globs = config.get("blocked_path_globs") or []
+    if not session_ids and not paths and not globs:
+        console.print("[dim]No FleetTrack upload blocks configured.[/dim]")
+        return
+
+    if session_ids:
+        console.print("[bold]Blocked session ids[/bold]")
+        for session_id in session_ids:
+            console.print(f"  {session_id}")
+    if paths:
+        console.print("[bold]Blocked paths[/bold]")
+        for path in paths:
+            console.print(f"  {path}")
+    if globs:
+        console.print("[bold]Blocked path globs[/bold]")
+        for pattern in globs:
+            console.print(f"  {pattern}")
 
 
 # ------------------------------------------------------------------ #
@@ -899,7 +962,9 @@ def install_mcp(
         False, "--all", help="Install for every supported client, even if not detected."
     ),
     print_only: bool = typer.Option(
-        False, "--print", help="Print the config snippet that would be written; do not write."
+        False,
+        "--print",
+        help="Print the config snippet that would be written; do not write.",
     ),
 ) -> None:
     """Install the FleetCode MCP server into local agent client configs.
@@ -979,8 +1044,6 @@ def uninstall_mcp(
     for r in results:
         label = _MCP_CLIENT_LABEL[r.client]
         if r.action == "removed":
-            console.print(
-                f"[green]✓[/green] {label}: removed [dim]({r.path})[/dim]"
-            )
+            console.print(f"[green]✓[/green] {label}: removed [dim]({r.path})[/dim]")
         else:
             console.print(f"[dim]·[/dim] {label}: skipped ({r.detail})")

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -26,6 +26,7 @@ import uuid
 from typing import TYPE_CHECKING, Optional
 
 from .api import TrackAPIClient, TrackAPIError
+from .blocklist import TrackBlocklist
 from .drainer import QueueDrainer
 from .merkle import HashCache, MerkleTree
 from .paths import TrackPaths
@@ -389,7 +390,9 @@ class Daemon:
         sha256: str,
         upload_payload: UploadPayload | None = None,
     ) -> None:
-        if _is_unsupported_manifest_path(rel_path):
+        if _is_unsupported_manifest_path(rel_path) or TrackBlocklist.from_paths(
+            self._paths
+        ).is_blocked_path(rel_path):
             self._queue.delete_paths([rel_path])
             with self._confirmed_lock:
                 if self._confirmed_map.pop(rel_path, None) is not None:

--- a/fleet/track/drainer.py
+++ b/fleet/track/drainer.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .api import TrackAPIClient, TrackAPIError
+from .blocklist import TrackBlocklist
 from .paths import TrackPaths
 from .queue import UploadQueue
 from .uploader import UploadPool
@@ -62,6 +63,17 @@ class QueueDrainer:
         items = self._queue.claim_batch(n=self._batch_size)
         if not items:
             return DrainResult(claimed=0, submitted=0, failed=0)
+        claimed_count = len(items)
+
+        blocklist = TrackBlocklist.from_paths(self._paths)
+        blocked_paths = [
+            item.path for item in items if blocklist.is_blocked_path(item.path)
+        ]
+        if blocked_paths:
+            self._queue.delete_paths(blocked_paths)
+            items = [item for item in items if not blocklist.is_blocked_path(item.path)]
+            if not items:
+                return DrainResult(claimed=claimed_count, submitted=0, failed=0)
 
         rel_paths = [item.path for item in items]
 
@@ -71,7 +83,7 @@ class QueueDrainer:
             log.warning("drain: failed to get upload URLs: %s", e)
             for item in items:
                 self._queue.mark_failed(item.path, item.sha256, str(e))
-            return DrainResult(claimed=len(items), submitted=0, failed=len(items))
+            return DrainResult(claimed=claimed_count, submitted=0, failed=len(items))
 
         home = self._paths.home
         submitted = 0
@@ -79,11 +91,13 @@ class QueueDrainer:
         for item in items:
             url = url_map.get(item.path)
             if not url:
-                self._queue.mark_failed(item.path, item.sha256, "no presigned URL returned")
+                self._queue.mark_failed(
+                    item.path, item.sha256, "no presigned URL returned"
+                )
                 failed += 1
                 continue
             abs_path: Path = home / item.path
             self._pool.submit(item.path, item.sha256, abs_path, url)
             submitted += 1
 
-        return DrainResult(claimed=len(items), submitted=submitted, failed=failed)
+        return DrainResult(claimed=claimed_count, submitted=submitted, failed=failed)

--- a/fleet/track/reconciler.py
+++ b/fleet/track/reconciler.py
@@ -12,6 +12,7 @@ import logging
 from dataclasses import dataclass
 
 from .api import TrackAPIClient
+from .blocklist import TrackBlocklist
 from .merkle import HashCache, MerkleTree
 from .queue import UploadQueue
 
@@ -53,8 +54,15 @@ class Reconciler:
         """
         remote_map_raw = self._api.get_manifest(device_id)
         local_map_raw, _local_root_raw = self._tree.build()
-        local_map, pruned_local = _prune_unsupported_manifest_paths(local_map_raw)
-        remote_map, pruned_remote = _prune_unsupported_manifest_paths(remote_map_raw)
+        blocklist = TrackBlocklist.from_paths(self._cache._paths)
+        local_map, pruned_local = _prune_unsupported_manifest_paths(
+            local_map_raw,
+            blocklist=blocklist,
+        )
+        remote_map, pruned_remote = _prune_unsupported_manifest_paths(
+            remote_map_raw,
+            blocklist=blocklist,
+        )
         pruned_paths = tuple(sorted(set(pruned_local) | set(pruned_remote)))
         local_root = MerkleTree.compute_root(local_map)
         remote_root = MerkleTree.compute_root(remote_map)
@@ -94,16 +102,20 @@ class Reconciler:
 
 def _prune_unsupported_manifest_paths(
     file_map: dict[str, str],
+    *,
+    blocklist: TrackBlocklist | None = None,
 ) -> tuple[dict[str, str], tuple[str, ...]]:
-    """Drop legacy paths that are no longer part of default remote sync.
+    """Drop paths that are no longer part of remote sync.
 
-    This hook is intentionally empty today; keep it so future source removals
-    can prune stale manifest entries without changing reconcile flow.
+    Includes locally blocked paths so they are neither uploaded nor kept in the
+    advertised manifest.
     """
     kept: dict[str, str] = {}
     pruned: list[str] = []
     for path, digest in file_map.items():
-        if _is_unsupported_manifest_path(path):
+        if _is_unsupported_manifest_path(path) or (
+            blocklist is not None and blocklist.is_blocked_path(path)
+        ):
             pruned.append(path)
         else:
             kept[path] = digest

--- a/tests/track/test_blocklist.py
+++ b/tests/track/test_blocklist.py
@@ -1,0 +1,59 @@
+"""Tests for FleetTrack local upload blocklist."""
+
+from __future__ import annotations
+
+from fleet.track.blocklist import (
+    TrackBlocklist,
+    add_blocked_session_ids,
+    read_track_config,
+    remove_blocked_session_ids,
+)
+from fleet.track.paths import TrackPaths
+
+
+def test_blocklist_matches_claude_session_filename():
+    blocklist = TrackBlocklist.from_config(
+        {"blocked_session_ids": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]}
+    )
+
+    assert blocklist.is_blocked_path(
+        ".claude/projects/x/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl"
+    )
+
+
+def test_blocklist_matches_codex_session_suffix():
+    sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    blocklist = TrackBlocklist.from_config({"blocked_session_ids": [sid]})
+
+    assert blocklist.is_blocked_path(
+        f".codex/sessions/2026/05/06/rollout-2026-05-06T00-00-00-{sid}.jsonl"
+    )
+
+
+def test_blocklist_matches_exact_paths_and_globs():
+    blocklist = TrackBlocklist.from_config(
+        {
+            "blocked_paths": [".cursor/projects/p/session.txt"],
+            "blocked_path_globs": [
+                "Library/Application Support/Claude/**/secret.jsonl"
+            ],
+        }
+    )
+
+    assert blocklist.is_blocked_path("/.cursor/projects/p/session.txt")
+    assert blocklist.is_blocked_path(
+        "Library/Application Support/Claude/local-agent-mode-sessions/x/secret.jsonl"
+    )
+    assert not blocklist.is_blocked_path(".cursor/projects/p/other.txt")
+
+
+def test_add_and_remove_blocked_session_ids(tmp_path):
+    paths = TrackPaths.under(tmp_path)
+
+    added = add_blocked_session_ids(paths, ["s1", "s2", "s1"])
+    assert added == ["s1", "s2"]
+    assert read_track_config(paths)["blocked_session_ids"] == ["s1", "s2"]
+
+    removed = remove_blocked_session_ids(paths, ["s2", "missing"])
+    assert removed == ["s2"]
+    assert read_track_config(paths)["blocked_session_ids"] == ["s1"]

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -226,6 +226,41 @@ def test_upload_done_accepts_cursor_paths(tmp_path: Path):
     cache.close()
 
 
+def test_upload_done_drops_blocked_path_before_manifest_or_metadata(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    paths.config_file.write_text('{"blocked_session_ids":["blocked-session"]}\n')
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree)
+
+    rel_path = ".claude/projects/x/blocked-session.jsonl"
+    queue.enqueue(rel_path, "blocked-digest")
+    daemon._confirmed_map[rel_path] = "old-digest"
+    metadata_calls: list[tuple[str, str]] = []
+
+    def record_metadata(
+        path: str,
+        digest: str,
+        *,
+        upload_payload: UploadPayload | None = None,
+    ) -> None:
+        metadata_calls.append((path, digest))
+
+    daemon._upsert_session_metadata = record_metadata  # type: ignore[method-assign]
+
+    daemon._on_upload_done(rel_path, "blocked-digest")
+
+    assert queue.stats() == {}
+    assert rel_path not in daemon._confirmed_map
+    assert daemon._manifest_dirty is True
+    assert metadata_calls == []
+
+    queue.close()
+    cache.close()
+
+
 def test_upload_done_uses_callback_digest_instead_of_stale_cache(tmp_path: Path):
     paths = TrackPaths.under(tmp_path)
     paths.ensure_track_dir()

--- a/tests/track/test_drainer.py
+++ b/tests/track/test_drainer.py
@@ -79,6 +79,58 @@ def test_drain_submits_each_item_with_its_url(tmp_path: Path):
     queue.close()
 
 
+def test_drain_deletes_blocked_items_without_requesting_urls(tmp_path: Path):
+    requests: list[httpx.Request] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        requests.append(req)
+        return httpx.Response(200, json={"urls": {}})
+
+    drainer, queue, pool, paths = _build(tmp_path, handler)
+    paths.config_file.write_text('{"blocked_session_ids":["blocked-session"]}\n')
+    queue.enqueue(".claude/projects/x/blocked-session.jsonl", "h1")
+
+    result = drainer.drain_once("dev1")
+
+    assert result.claimed == 1
+    assert result.submitted == 0
+    assert result.failed == 0
+    assert pool.submissions == []
+    assert requests == []
+    assert queue.stats() == {}
+    queue.close()
+
+
+def test_drain_skips_blocked_items_but_submits_allowed_items(tmp_path: Path):
+    requested_paths: list[list[str]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        import json as j
+
+        body = j.loads(req.content)
+        requested_paths.append(body["paths"])
+        return httpx.Response(
+            200,
+            json={"urls": {p: f"https://s3/{p}?sig=x" for p in body["paths"]}},
+        )
+
+    drainer, queue, pool, paths = _build(tmp_path, handler)
+    paths.config_file.write_text('{"blocked_session_ids":["blocked-session"]}\n')
+    queue.enqueue(".claude/projects/x/blocked-session.jsonl", "h1")
+    queue.enqueue(".claude/projects/x/allowed-session.jsonl", "h2")
+
+    result = drainer.drain_once("dev1")
+
+    assert result.claimed == 2
+    assert result.submitted == 1
+    assert result.failed == 0
+    assert requested_paths == [[".claude/projects/x/allowed-session.jsonl"]]
+    assert [s[0] for s in pool.submissions] == [
+        ".claude/projects/x/allowed-session.jsonl"
+    ]
+    queue.close()
+
+
 def test_drain_marks_failed_when_no_url_returned(tmp_path: Path):
     """Server returns an empty url map → every claimed item is marked failed."""
 

--- a/tests/track/test_reconciler.py
+++ b/tests/track/test_reconciler.py
@@ -126,6 +126,51 @@ def test_reconcile_enqueues_cursor_transcripts(tmp_path: Path):
     queue.close()
 
 
+def test_reconcile_prunes_blocked_paths_from_local_and_remote(tmp_path: Path):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    paths.config_file.write_text(
+        '{"blocked_session_ids":["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"]}\n'
+    )
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+
+    blocked_rel = ".claude/projects/x/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl"
+    kept_rel = ".claude/projects/x/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl"
+    blocked_file = _seed_file(tmp_path, blocked_rel, "blocked")
+    kept_file = _seed_file(tmp_path, kept_rel, "kept")
+    tree = MerkleTree(cache, file_iter=[blocked_file, kept_file])
+    raw_local_map, _ = tree.build()
+    queue.enqueue(blocked_rel, raw_local_map[blocked_rel])
+    remote_files = dict(raw_local_map)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "root_hash": MerkleTree.compute_root(remote_files),
+                "files": remote_files,
+            },
+        )
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+
+    reconciler = Reconciler(queue=queue, cache=cache, tree=tree, api=api)
+    result = reconciler.reconcile("dev1")
+
+    assert result.in_sync is True
+    assert result.changed_paths == ()
+    assert result.pruned_paths == (blocked_rel,)
+    assert blocked_rel not in result.local_map
+    assert blocked_rel not in result.remote_map
+    queue.close()
+
+
 def test_reconcile_only_enqueues_changed_files(tmp_path: Path):
     """Remote already has one file; only the other gets enqueued."""
     paths = TrackPaths.under(tmp_path)


### PR DESCRIPTION
## Summary
- add local FleetTrack blocklist config and CLI commands for blocking/unblocking session ids
- prune blocked paths during reconcile, skip them in the queue drainer, and ignore blocked upload-complete callbacks
- document current behavior and the remaining server-side purge gap for already stored blobs/metadata

## Tests
- uv run pytest