### PR TITLE
Show FleetTrack blocklist summary in status

### DIFF
--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -15,6 +15,7 @@ from rich.table import Table
 
 from .api import TrackAPIClient, TrackAPIError
 from .blocklist import (
+    TrackBlocklist,
     add_blocked_session_ids,
     read_track_config,
     remove_blocked_session_ids,
@@ -140,6 +141,7 @@ def status() -> None:
     paths = TrackPaths.default()
     running = is_running(paths)
     s = read_status(paths)
+    blocklist_summary = _blocklist_summary(read_track_config(paths))
 
     if not running:
         console.print("[yellow]Daemon not running.[/yellow]", end=" ")
@@ -149,10 +151,18 @@ def status() -> None:
             console.print("Service installed but not alive — check logs.")
         if s:
             console.print(f"  Last sync: {s.last_sync or 'never'}")
+        if blocklist_summary:
+            console.print(
+                f"  Blocked: {blocklist_summary} [dim](run flt track blocked)[/dim]"
+            )
         return
 
     if not s:
         console.print("[yellow]Daemon running but no status yet.[/yellow]")
+        if blocklist_summary:
+            console.print(
+                f"  Blocked: {blocklist_summary} [dim](run flt track blocked)[/dim]"
+            )
         return
 
     state_color = {"idle": "green", "syncing": "yellow", "error": "red"}.get(
@@ -174,6 +184,10 @@ def status() -> None:
     console.print(
         f"  Queue: [yellow]{pending}[/yellow] pending  [cyan]{in_flight}[/cyan] uploading  [green]{done}[/green] done  [red]{failed}[/red] failed"
     )
+    if blocklist_summary:
+        console.print(
+            f"  Blocked: {blocklist_summary} [dim](run flt track blocked)[/dim]"
+        )
 
     # Sources table
     if s.sources:
@@ -192,6 +206,24 @@ def status() -> None:
             console.print(f"  {err}")
 
     console.print(f"\n  Logs: {paths.log_file}")
+
+
+def _blocklist_summary(config: dict) -> str | None:
+    blocklist = TrackBlocklist.from_config(config)
+    parts = [
+        _count_label(len(blocklist.session_ids), "session id"),
+        _count_label(len(blocklist.paths), "path"),
+        _count_label(len(blocklist.path_globs), "path glob"),
+    ]
+    parts = [p for p in parts if p]
+    return ", ".join(parts) if parts else None
+
+
+def _count_label(count: int, label: str) -> str | None:
+    if count == 0:
+        return None
+    suffix = "" if count == 1 else "s"
+    return f"{count} {label}{suffix}"
 
 
 @app.command()

--- a/tests/track/test_cli.py
+++ b/tests/track/test_cli.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from fleet.track import cli
 from fleet.track.api import TrackAPIError
 from fleet.track.paths import TrackPaths
+from fleet.track.status import TrackStatus
 from fleet.track.store import LocalSessionStore, RemoteSessionStore, Session
 
 
@@ -73,6 +74,41 @@ def test_resolve_session_store_only_accepts_remote_or_local(tmp_path, monkeypatc
     for source in ("auto", "stub", "native"):
         with pytest.raises(typer.BadParameter):
             cli._resolve_session_store(source)
+
+
+def test_status_shows_blocklist_summary(tmp_path, monkeypatch):
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    paths.config_file.write_text(
+        json.dumps(
+            {
+                "blocked_session_ids": ["s1", "s2"],
+                "blocked_paths": [".cursor/projects/p/session.jsonl"],
+                "blocked_path_globs": [".claude/projects/private/*.jsonl"],
+            }
+        )
+    )
+
+    monkeypatch.setattr(cli.TrackPaths, "default", lambda: paths)
+    monkeypatch.setattr(cli, "is_running", lambda p: True)
+    monkeypatch.setattr(
+        cli,
+        "read_status",
+        lambda p: TrackStatus(
+            pid=123,
+            state="idle",
+            last_sync="2026-05-06T00:00:00Z",
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Blocked:" in result.stdout
+    assert "2 session ids" in result.stdout
+    assert "1 path" in result.stdout
+    assert "1 path glob" in result.stdout
+    assert "flt track blocked" in result.stdout
 
 
 def test_track_ls_defaults_remote_and_forwards_query(monkeypatch):


### PR DESCRIPTION
## Summary
- show a compact FleetTrack blocklist count in `flt track status`
- keep the full blocked IDs behind `flt track blocked`
- cover the status summary in CLI tests

## Tests
- `uv run pytest tests/track/test_cli.py tests/track/test_blocklist.py`
- `uv run flt track status`

Note: full `uv run pytest` currently fails in unrelated `tests/test_instance_dispatch.py::TestAsyncFleetInMemoryTests::test_memory_namespace_syntax`; rerunning that single test passes, which points to existing in-memory SQLite test state leakage.