### PR TITLE
Fix track daemon restart on reinstall

### DIFF
--- a/fleet/track/cli.py
+++ b/fleet/track/cli.py
@@ -106,10 +106,12 @@ def enable() -> None:
         for s in found:
             console.print(f"  [green]✓[/green] Found {s.name} at {s.root}")
 
-    # Install and start daemon
-    if is_installed() and is_running(paths):
-        console.print("[yellow]Daemon already running.[/yellow] Restarting...")
-        uninstall()
+    # Install and restart daemon. The installer reloads the service definition
+    # so users who upgrade fleet-python do not keep the old daemon process.
+    if is_installed():
+        console.print(
+            "[yellow]Daemon service already installed.[/yellow] Restarting..."
+        )
 
     console.print("Installing daemon service...")
     try:

--- a/fleet/track/install.py
+++ b/fleet/track/install.py
@@ -80,7 +80,9 @@ def is_installed() -> bool:
 # ------------------------------------------------------------------ #
 
 
-def render_launchd_plist(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
+def render_launchd_plist(
+    paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin"
+) -> str:
     """Return the plist XML body. Pure: no filesystem side-effects."""
     extra_env = "\n".join(
         f"        <key>{key}</key>\n        <string>{escape(value)}</string>"
@@ -120,7 +122,9 @@ def render_launchd_plist(paths: TrackPaths, flt_path: str, env_path: str = "/usr
 """
 
 
-def render_systemd_unit(paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin") -> str:
+def render_systemd_unit(
+    paths: TrackPaths, flt_path: str, env_path: str = "/usr/local/bin:/usr/bin:/bin"
+) -> str:
     """Return the systemd service unit body. Pure: no filesystem side-effects."""
     extra_env = "\n".join(
         f'Environment="{key}={_escape_systemd_env_value(value)}"'
@@ -177,6 +181,58 @@ def _launchd_plist_path() -> Path:
     return Path.home() / "Library" / "LaunchAgents" / f"{PLIST_LABEL}.plist"
 
 
+def _launchd_user_domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _launchd_service_target() -> str:
+    return f"{_launchd_user_domain()}/{PLIST_LABEL}"
+
+
+def _stop_launchd_service(plist_path: Path) -> None:
+    """Best-effort stop for both modern launchd and legacy loaded jobs."""
+    subprocess.run(
+        ["launchctl", "bootout", _launchd_service_target()],
+        capture_output=True,
+    )
+    subprocess.run(
+        ["launchctl", "bootout", _launchd_user_domain(), str(plist_path)],
+        capture_output=True,
+    )
+    subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+
+
+def _bootstrap_launchd_service(plist_path: Path) -> None:
+    result = subprocess.run(
+        ["launchctl", "bootstrap", _launchd_user_domain(), str(plist_path)],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return
+
+    legacy = subprocess.run(["launchctl", "load", str(plist_path)], capture_output=True)
+    if legacy.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            result.args,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def _kickstart_launchd_service() -> None:
+    result = subprocess.run(
+        ["launchctl", "kickstart", "-k", _launchd_service_target()],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return
+
+    # Older launchctl implementations may not have kickstart. The loaded plist
+    # has RunAtLoad=true, and this legacy start gives those systems a nudge.
+    subprocess.run(["launchctl", "start", PLIST_LABEL], capture_output=True)
+
+
 def _install_launchd(paths: TrackPaths) -> None:
     paths.ensure_track_dir()
     body = render_launchd_plist(
@@ -186,16 +242,17 @@ def _install_launchd(paths: TrackPaths) -> None:
     )
     plist_path = _launchd_plist_path()
     plist_path.parent.mkdir(parents=True, exist_ok=True)
+    _stop_launchd_service(plist_path)
     _write_private_text(plist_path, body)
 
-    subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+    _bootstrap_launchd_service(plist_path)
+    _kickstart_launchd_service()
 
 
 def _uninstall_launchd() -> None:
     plist_path = _launchd_plist_path()
     if plist_path.exists():
-        subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+        _stop_launchd_service(plist_path)
         plist_path.unlink()
 
 
@@ -220,10 +277,14 @@ def _install_systemd(paths: TrackPaths) -> None:
     _write_private_text(service_path, body)
 
     subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
-    subprocess.run(["systemctl", "--user", "enable", "--now", SYSTEMD_SERVICE], check=True)
+    subprocess.run(["systemctl", "--user", "enable", SYSTEMD_SERVICE], check=True)
+    subprocess.run(["systemctl", "--user", "restart", SYSTEMD_SERVICE], check=True)
 
 
 def _uninstall_systemd() -> None:
-    subprocess.run(["systemctl", "--user", "disable", "--now", SYSTEMD_SERVICE], capture_output=True)
+    subprocess.run(
+        ["systemctl", "--user", "disable", "--now", SYSTEMD_SERVICE],
+        capture_output=True,
+    )
     _systemd_service_path().unlink(missing_ok=True)
     subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True)

--- a/tests/track/test_install.py
+++ b/tests/track/test_install.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import stat
+import subprocess
 from pathlib import Path
 
 from fleet.track.install import (
     PRIVATE_FILE_MODE,
     PLIST_LABEL,
     SYSTEMD_SERVICE,
+    _install_launchd,
+    _install_systemd,
+    _launchd_service_target,
+    _launchd_user_domain,
     _write_private_text,
     flt_executable,
     render_launchd_plist,
@@ -34,7 +39,9 @@ def test_render_launchd_plist_has_required_keys(tmp_path: Path):
     assert str(tmp_path) in body
 
 
-def test_render_launchd_plist_excludes_track_base_url_when_unset(tmp_path: Path, monkeypatch):
+def test_render_launchd_plist_excludes_track_base_url_when_unset(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
     body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
@@ -42,7 +49,9 @@ def test_render_launchd_plist_excludes_track_base_url_when_unset(tmp_path: Path,
     assert "FLEET_API_KEY" not in body
 
 
-def test_render_launchd_plist_includes_track_base_url_when_set(tmp_path: Path, monkeypatch):
+def test_render_launchd_plist_includes_track_base_url_when_set(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://example.fleetai.com")
     body = render_launchd_plist(_paths(tmp_path), flt_path="/usr/local/bin/flt")
@@ -70,7 +79,9 @@ def test_render_systemd_unit_has_required_directives(tmp_path: Path):
     assert SYSTEMD_SERVICE  # imported, sanity check
 
 
-def test_render_systemd_unit_excludes_track_base_url_when_unset(tmp_path: Path, monkeypatch):
+def test_render_systemd_unit_excludes_track_base_url_when_unset(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.delenv("FLEET_TRACK_BASE_URL", raising=False)
     body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
@@ -78,7 +89,9 @@ def test_render_systemd_unit_excludes_track_base_url_when_unset(tmp_path: Path, 
     assert "FLEET_API_KEY" not in body
 
 
-def test_render_systemd_unit_includes_track_base_url_when_set(tmp_path: Path, monkeypatch):
+def test_render_systemd_unit_includes_track_base_url_when_set(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.delenv("FLEET_API_KEY", raising=False)
     monkeypatch.setenv("FLEET_TRACK_BASE_URL", "https://dev.example.com")
     body = render_systemd_unit(_paths(tmp_path), flt_path="/usr/local/bin/flt")
@@ -130,6 +143,72 @@ def test_flt_executable_returns_a_string():
     exe = flt_executable()
     assert isinstance(exe, str)
     assert exe  # non-empty
+
+
+def test_install_launchd_relaunches_existing_service(tmp_path: Path, monkeypatch):
+    plist_path = tmp_path / "io.fleet.track.plist"
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("fleet.track.install._launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr("fleet.track.install.flt_executable", lambda: "/bin/flt")
+    monkeypatch.setattr("fleet.track.install.subprocess.run", fake_run)
+
+    _install_launchd(_paths(tmp_path))
+
+    assert plist_path.exists()
+    assert calls == [
+        ["launchctl", "bootout", _launchd_service_target()],
+        ["launchctl", "bootout", _launchd_user_domain(), str(plist_path)],
+        ["launchctl", "unload", str(plist_path)],
+        ["launchctl", "bootstrap", _launchd_user_domain(), str(plist_path)],
+        ["launchctl", "kickstart", "-k", _launchd_service_target()],
+    ]
+
+
+def test_install_launchd_falls_back_to_legacy_load(tmp_path: Path, monkeypatch):
+    plist_path = tmp_path / "io.fleet.track.plist"
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        returncode = 1 if args[:2] == ["launchctl", "bootstrap"] else 0
+        return subprocess.CompletedProcess(args, returncode)
+
+    monkeypatch.setattr("fleet.track.install._launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr("fleet.track.install.flt_executable", lambda: "/bin/flt")
+    monkeypatch.setattr("fleet.track.install.subprocess.run", fake_run)
+
+    _install_launchd(_paths(tmp_path))
+
+    assert ["launchctl", "load", str(plist_path)] in calls
+
+
+def test_install_systemd_restarts_service_after_reload(tmp_path: Path, monkeypatch):
+    service_path = tmp_path / "fleet-track.service"
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(
+        "fleet.track.install._systemd_service_path", lambda: service_path
+    )
+    monkeypatch.setattr("fleet.track.install.flt_executable", lambda: "/bin/flt")
+    monkeypatch.setattr("fleet.track.install.subprocess.run", fake_run)
+
+    _install_systemd(_paths(tmp_path))
+
+    assert service_path.exists()
+    assert calls == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", SYSTEMD_SERVICE],
+        ["systemctl", "--user", "restart", SYSTEMD_SERVICE],
+    ]
 
 
 def test_render_paths_use_paths_home(tmp_path: Path):


### PR DESCRIPTION
## Summary
- make flt track enable reinstall path restart existing daemon services instead of trusting the PID file
- relaunch macOS launchd jobs with bootout/bootstrap/kickstart, with legacy launchctl fallback
- reload, enable, and restart the Linux systemd user service after writing the updated unit
- preserve a newer daemon PID if an old daemon finishes shutdown after the replacement starts
- add installer and PID ownership tests for restart behavior

## Tests
- uv run --extra dev --extra cli pytest tests/track -q
- uv run --extra dev ruff check fleet/track/status.py tests/track/test_status.py fleet/track/install.py fleet/track/cli.py tests/track/test_install.py
- uv run --extra dev black --check fleet/track/status.py tests/track/test_status.py fleet/track/install.py fleet/track/cli.py tests/track/test_install.py
- git diff --check