### PR TITLE
Add FleetCode Fabric MCP tools

### DIFF
--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -260,6 +260,26 @@ class TrackAPIClient:
         _raise(resp)
         return resp.json()
 
+    def search_fabric(self, body: Mapping[str, Any]) -> dict:
+        """Run structured Fabric entry search."""
+        resp = self._client.post(
+            "/v1/fabric/entries/search",
+            json=dict(body),
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
+    def aggregate_fabric(self, body: Mapping[str, Any]) -> dict:
+        """Run structured Fabric entry aggregates."""
+        resp = self._client.post(
+            "/v1/fabric/entries/aggregate",
+            json=dict(body),
+            headers=self._headers(),
+        )
+        _raise(resp)
+        return resp.json()
+
     def get_session(self, session_id: str) -> dict:
         resp = self._client.get(
             f"/v1/track/sessions/{session_id}",

--- a/fleet/track/mcp_server.py
+++ b/fleet/track/mcp_server.py
@@ -28,6 +28,21 @@ FILTER_OPERATORS = list(SEARCH_FILTER_OPERATORS)
 LOGICAL_OPERATORS = list(SEARCH_LOGICAL_OPERATORS)
 SEARCH_MODES = ["hybrid", "keyword", "semantic", "recent"]
 TIME_FIELDS = list(SEARCH_TIME_FIELDS)
+FABRIC_SOURCES = ["slack", "linear", "github"]
+FABRIC_GROUP_BY = [
+    "source",
+    "day",
+    "hour",
+    "channel",
+    "author",
+    "identifier",
+    "state",
+    "linear_team",
+    "linear_project",
+    "linear_state_type",
+    "github_repo",
+    "github_author",
+]
 
 
 def fleetcode_query_guide() -> dict[str, Any]:
@@ -56,6 +71,30 @@ def fleetcode_query_guide() -> dict[str, Any]:
                     "time_bucket": "Optional bucket: {'field':'last_active','interval':'day'}.",
                     "order_by": "Metric/key ordering, e.g. [{'field':'count','direction':'desc'}].",
                     "having": "Metric filters after grouping, e.g. {'count': {'$gte': 5}}.",
+                    "limit": "Maximum number of groups. Defaults server-side.",
+                },
+            },
+            "fleetcode_search_fabric": {
+                "purpose": "Search FleetCode Fabric activity across Slack, Linear, and GitHub.",
+                "backend": "Postgres Fabric tables via orchestrator",
+                "body_fields": {
+                    "q": "Natural-language search text.",
+                    "sources": FABRIC_SOURCES,
+                    "time": "Fabric time filter, e.g. {'since':'7d'} or {'gte':'2026-05-01T00:00:00Z'}.",
+                    "limit": "Maximum result count. Defaults server-side.",
+                    "cursor": "Opaque pagination cursor returned as next_cursor.",
+                },
+            },
+            "fleetcode_aggregate_fabric": {
+                "purpose": "Summarize FleetCode Fabric activity by source, time, and source-specific fields.",
+                "backend": "Postgres Fabric tables via orchestrator",
+                "body_fields": {
+                    "q": "Optional natural-language search text to constrain aggregated entries.",
+                    "sources": FABRIC_SOURCES,
+                    "time": "Same Fabric time filter as search.",
+                    "group_by": FABRIC_GROUP_BY,
+                    "metrics": ["count"],
+                    "order_by": "Metric/key ordering, e.g. [{'field':'count','direction':'desc'}].",
                     "limit": "Maximum number of groups. Defaults server-side.",
                 },
             },
@@ -104,6 +143,21 @@ def fleetcode_query_guide() -> dict[str, Any]:
                 "having": {"count": {"$gte": 5}},
                 "order_by": [{"field": "count", "direction": "desc"}],
             },
+            "fabric_search": {
+                "q": "deployment incident",
+                "sources": ["slack", "github"],
+                "time": {"since": "14d"},
+                "limit": 25,
+            },
+            "fabric_aggregate": {
+                "q": "deployment incident",
+                "sources": ["linear", "github"],
+                "group_by": ["source", "day", "state"],
+                "metrics": ["count"],
+                "time": {"since": "30d"},
+                "order_by": [{"field": "count", "direction": "desc"}],
+                "limit": 50,
+            },
         },
     }
 
@@ -144,6 +198,26 @@ def fleetcode_aggregate_sessions(
     """Run structured FleetCode aggregate session query."""
     payload = _body_dict(body)
     return _with_api(api, lambda client: client.aggregate_sessions(payload))
+
+
+def fleetcode_search_fabric(
+    body: Mapping[str, Any],
+    *,
+    api: Optional[TrackAPIClient] = None,
+) -> dict[str, Any]:
+    """Run structured FleetCode Fabric search."""
+    payload = _body_dict(body)
+    return _with_api(api, lambda client: client.search_fabric(payload))
+
+
+def fleetcode_aggregate_fabric(
+    body: Mapping[str, Any],
+    *,
+    api: Optional[TrackAPIClient] = None,
+) -> dict[str, Any]:
+    """Run structured FleetCode Fabric aggregate query."""
+    payload = _body_dict(body)
+    return _with_api(api, lambda client: client.aggregate_fabric(payload))
 
 
 def fleetcode_download_session(
@@ -198,6 +272,8 @@ def create_mcp():
     mcp = FastMCP("fleetcode")
     search_impl = globals()["fleetcode_search_sessions"]
     aggregate_impl = globals()["fleetcode_aggregate_sessions"]
+    fabric_search_impl = globals()["fleetcode_search_fabric"]
+    fabric_aggregate_impl = globals()["fleetcode_aggregate_fabric"]
     download_impl = globals()["fleetcode_download_session"]
 
     @mcp.tool()
@@ -225,6 +301,26 @@ def create_mcp():
         distinct user/device/repo/model counts. No raw SQL is accepted.
         """
         return aggregate_impl(body)
+
+    @mcp.tool()
+    def fleetcode_search_fabric(body: dict[str, Any]) -> dict[str, Any]:
+        """Search FleetCode Fabric activity.
+
+        Body fields: q, sources, time, limit, and cursor. Sources are slack,
+        linear, and github. No raw SQL is accepted.
+        """
+        return fabric_search_impl(body)
+
+    @mcp.tool()
+    def fleetcode_aggregate_fabric(body: dict[str, Any]) -> dict[str, Any]:
+        """Aggregate FleetCode Fabric activity.
+
+        Body fields: q, sources, time, group_by, metrics, order_by, and limit.
+        Metrics currently support count. Group by source, day, hour, channel,
+        author, identifier, state, and source-specific Linear or GitHub fields.
+        No raw SQL is accepted.
+        """
+        return fabric_aggregate_impl(body)
 
     @mcp.tool()
     def fleetcode_download_session(

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -332,6 +332,74 @@ def test_aggregate_sessions_posts_body_and_returns_json():
     assert out["groups"][0]["count"] == 2
 
 
+def test_search_fabric_posts_body_headers_and_returns_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "items": [{"id": "entry-1", "kind": "note"}],
+                "next_cursor": None,
+            },
+        )
+
+    body = {
+        "q": "deployment plan",
+        "sources": ["slack", "github"],
+        "time": {"field": "occurred_at", "since": "7d"},
+        "limit": 5,
+    }
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.search_fabric(body)
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://test/v1/fabric/entries/search"
+    assert captured["headers"]["authorization"] == "Bearer test-api-key"
+    assert captured["body"] == body
+    assert out["items"][0]["id"] == "entry-1"
+
+
+def test_aggregate_fabric_posts_body_headers_and_returns_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "backend": "postgres",
+                "groups": [{"key": {"kind": "note"}, "count": 3}],
+                "row_count": 3,
+                "total_groups": 1,
+                "truncated": False,
+            },
+        )
+
+    body = {
+        "q": "deployment plan",
+        "sources": ["linear", "github"],
+        "time": {"field": "occurred_at", "since": "14d"},
+        "group_by": ["source", "day"],
+        "metrics": ["count"],
+    }
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    out = api.aggregate_fabric(body)
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://test/v1/fabric/entries/aggregate"
+    assert captured["headers"]["authorization"] == "Bearer test-api-key"
+    assert captured["body"] == body
+    assert out["groups"][0]["count"] == 3
+
+
 def test_download_session_content_uses_presigned_url_without_auth_headers():
     seen: list[tuple[str, str | None]] = []
 

--- a/tests/track/test_mcp_server.py
+++ b/tests/track/test_mcp_server.py
@@ -11,6 +11,8 @@ class FakeAPI:
     def __init__(self):
         self.search_bodies = []
         self.aggregate_bodies = []
+        self.fabric_search_bodies = []
+        self.fabric_aggregate_bodies = []
 
     def search_sessions(self, body):
         self.search_bodies.append(body)
@@ -19,6 +21,14 @@ class FakeAPI:
     def aggregate_sessions(self, body):
         self.aggregate_bodies.append(body)
         return {"groups": [{"key": {"tool": "codex"}, "count": 1}]}
+
+    def search_fabric(self, body):
+        self.fabric_search_bodies.append(body)
+        return {"items": [{"source": "slack", "identifier": "C123"}]}
+
+    def aggregate_fabric(self, body):
+        self.fabric_aggregate_bodies.append(body)
+        return {"groups": [{"key": {"source": "github"}, "count": 2}]}
 
 
 @dataclass(frozen=True)
@@ -53,6 +63,26 @@ def test_fleetcode_query_guide_describes_query_contract():
         in guide["tools"]["fleetcode_aggregate_sessions"]["body_fields"]["metrics"]
     )
     assert "time_bucket" in guide["tools"]["fleetcode_aggregate_sessions"]["body_fields"]
+    assert "fleetcode_search_fabric" in guide["tools"]
+    assert "fleetcode_aggregate_fabric" in guide["tools"]
+    assert (
+        "github"
+        in guide["tools"]["fleetcode_search_fabric"]["body_fields"]["sources"]
+    )
+    assert (
+        "linear_team"
+        in guide["tools"]["fleetcode_aggregate_fabric"]["body_fields"]["group_by"]
+    )
+    assert "q" in guide["tools"]["fleetcode_search_fabric"]["body_fields"]
+    assert "filters" not in guide["tools"]["fleetcode_search_fabric"]["body_fields"]
+    assert "q" in guide["tools"]["fleetcode_aggregate_fabric"]["body_fields"]
+    assert "filters" not in guide["tools"]["fleetcode_aggregate_fabric"]["body_fields"]
+    assert "fabric_search" in guide["examples"]
+    assert "fabric_aggregate" in guide["examples"]
+    assert "q" in guide["examples"]["fabric_search"]
+    assert "filters" not in guide["examples"]["fabric_search"]
+    assert "q" in guide["examples"]["fabric_aggregate"]
+    assert "filters" not in guide["examples"]["fabric_aggregate"]
 
 
 def test_fleetcode_search_sessions_defaults_limit_and_calls_api():
@@ -80,6 +110,30 @@ def test_fleetcode_aggregate_sessions_calls_api():
 
     assert out["groups"][0]["count"] == 1
     assert api.aggregate_bodies == [body]
+
+
+def test_fleetcode_search_fabric_calls_api():
+    api = FakeAPI()
+    body = {"q": "deployment", "sources": ["slack"], "limit": 5}
+
+    out = mcp_server.fleetcode_search_fabric(body, api=api)
+
+    assert out["items"][0]["source"] == "slack"
+    assert api.fabric_search_bodies == [body]
+
+
+def test_fleetcode_aggregate_fabric_calls_api():
+    api = FakeAPI()
+    body = {
+        "q": "deployment",
+        "sources": ["github"],
+        "group_by": ["source", "github_repo"],
+    }
+
+    out = mcp_server.fleetcode_aggregate_fabric(body, api=api)
+
+    assert out["groups"][0]["count"] == 2
+    assert api.fabric_aggregate_bodies == [body]
 
 
 def test_fleetcode_download_session_returns_path_and_local_guidance(monkeypatch):
@@ -114,6 +168,15 @@ def test_fleetcode_download_session_returns_path_and_local_guidance(monkeypatch)
 def test_fleetcode_tools_reject_non_object_body():
     with pytest.raises(TypeError, match="body must be a JSON object"):
         mcp_server.fleetcode_search_sessions(["not", "an", "object"])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [mcp_server.fleetcode_search_fabric, mcp_server.fleetcode_aggregate_fabric],
+)
+def test_fleetcode_fabric_tools_reject_non_object_body(tool):
+    with pytest.raises(TypeError, match="body must be a JSON object"):
+        tool(["not", "an", "object"])  # type: ignore[arg-type]
 
 
 def test_mcp_install_error_mentions_python_requirement(monkeypatch):


### PR DESCRIPTION
## Summary
- Add FleetCode SDK client methods for the Fabric search and aggregate endpoints.
- Register `fleetcode_search_fabric` and `fleetcode_aggregate_fabric` MCP tools with query-guide examples matching the Fabric API contract.
- Add focused API and MCP unit coverage for endpoint paths, auth headers, body pass-through, guide fields, and body validation.

## Test plan
- `uv --directory "/Users/jonathanyin/fleet/fleet-sdk" run pytest tests/track/test_api.py tests/track/test_mcp_server.py`
- `uv --directory "/Users/jonathanyin/fleet/fleet-sdk" run ruff check fleet/track/api.py fleet/track/mcp_server.py tests/track/test_api.py tests/track/test_mcp_server.py`


Made with [Cursor](https://cursor.com)