### PR TITLE
fix: refresh stored flt login tokens

### DIFF
--- a/fleet/_auth_headers.py
+++ b/fleet/_auth_headers.py
@@ -20,12 +20,14 @@ class AuthenticatedWrapperMixin:
         team_id: Optional[str] = None,
         base_url: Optional[str],
     ) -> None:
+        self._uses_stored_login_auth = False
         if not api_key and not (jwt and team_id):
             from .auth import get_valid_token
 
             token_info = get_valid_token()
             if token_info:
                 jwt, team_id = token_info
+                self._uses_stored_login_auth = True
 
         if not api_key and not (jwt and team_id):
             raise ValueError("Provide api_key, provide jwt/team_id, or run `flt login`")
@@ -42,6 +44,15 @@ class AuthenticatedWrapperMixin:
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
         elif self.jwt and self.team_id:
+            if getattr(self, "_uses_stored_login_auth", False):
+                from .auth import get_valid_token
+
+                token_info = get_valid_token()
+                if not token_info:
+                    raise self._authentication_error_cls(
+                        "Stored login credentials are expired; run `flt login` again"
+                    )
+                self.jwt, self.team_id = token_info
             headers["X-JWT-Token"] = self.jwt
             headers["X-Team-ID"] = self.team_id
         else:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,14 @@ import base64
 import json
 import time
 
+import pytest
+
 from fleet import auth
+from fleet._auth_headers import AuthenticatedWrapperMixin
+
+
+class _Wrapper(AuthenticatedWrapperMixin):
+    pass
 
 
 def _jwt(exp: int) -> str:
@@ -61,6 +68,57 @@ def test_get_valid_token_refreshes_expired_token(tmp_path, monkeypatch):
     stored = auth.load_credentials()
     assert stored["access_token"] == new_token
     assert stored["refresh_token"] == "refresh-next"
+
+
+def test_stored_login_auth_refreshes_headers_per_request(monkeypatch):
+    tokens = iter(
+        [
+            ("initial-token", "team-1"),
+            ("refreshed-token", "team-1"),
+        ]
+    )
+
+    monkeypatch.setattr(auth, "get_valid_token", lambda: next(tokens))
+
+    wrapper = _Wrapper()
+    wrapper._init_auth(api_key=None, base_url=None)
+
+    headers = wrapper.get_headers()
+
+    assert headers["X-JWT-Token"] == "refreshed-token"
+    assert headers["X-Team-ID"] == "team-1"
+
+
+def test_explicit_jwt_auth_does_not_refresh_headers(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_valid_token",
+        lambda: pytest.fail("explicit JWT auth should not read stored login"),
+    )
+
+    wrapper = _Wrapper()
+    wrapper._init_auth(
+        api_key=None,
+        jwt="explicit-token",
+        team_id="team-1",
+        base_url=None,
+    )
+
+    headers = wrapper.get_headers()
+
+    assert headers["X-JWT-Token"] == "explicit-token"
+    assert headers["X-Team-ID"] == "team-1"
+
+
+def test_stored_login_auth_raises_when_refresh_fails(monkeypatch):
+    tokens = iter([("initial-token", "team-1"), None])
+    monkeypatch.setattr(auth, "get_valid_token", lambda: next(tokens))
+
+    wrapper = _Wrapper()
+    wrapper._init_auth(api_key=None, base_url=None)
+
+    with pytest.raises(RuntimeError, match="Stored login credentials are expired"):
+        wrapper.get_headers()
 
 
 def test_clear_credentials_removes_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- refresh stored browser-login credentials each time SDK request headers are built
- keep explicit JWT auth unchanged
- add focused tests for stored flt login refresh behavior

## Testing
- ./.venv/bin/pytest tests/test_auth.py
- ./.venv/bin/ruff check fleet/_auth_headers.py tests/test_auth.py

Depends on fleet-ai/theseus PR for /v1/auth/refresh availability.