### PR TITLE
Expose Track text-match search in SDK

### DIFF
--- a/docs/fleet-track/README.md
+++ b/docs/fleet-track/README.md
@@ -126,6 +126,7 @@ stdin:
 ```bash
 flt track search '{"query":"bugbot local index","limit":20}'
 flt track search '{"mode":"keyword","query":"schema error","filters":{"tool":"codex"}}'
+flt track search '{"text_match":{"query":"database schema","operator":"phrase"},"limit":10}'
 flt track search @search.json
 flt track search -
 flt track search --filters
@@ -136,6 +137,8 @@ The JSON body supports:
 ```text
 query    string   Natural-language search text.
 mode     string   hybrid (default), keyword, semantic, or recent.
+last_as_prefix boolean  Treat the final BM25 query token as a prefix.
+text_match object Full-text filter over indexed session text.
 limit    integer  Maximum ranked results to return. Defaults to 50.
 filters  object   Mongo-style exact/range/boolean filters.
 time     object   Shared time filter, e.g. {"field":"last_active","since":"7d"}.
@@ -149,7 +152,7 @@ Filterable attributes are:
 
 ```text
 session_id, user_id, device_id, tool, cwd, repo_url, git_branch, model,
-forked_from, event_count, started_at, last_active
+forked_from, event_count, started_at, last_active, search_text
 ```
 
 `team_id` is always injected by orchestrator. Filters support direct equality,
@@ -158,13 +161,17 @@ Mongo-style field operators, and boolean operators:
 ```json
 {"tool": "codex"}
 {"event_count": {"$gte": 1000}}
+{"search_text": {"$prefix": "database migr"}}
 {"$or": [{"repo_url": {"$contains": "theseus"}}, {"repo_url": {"$contains": "fleet-sdk"}}]}
 ```
 
 Supported field operators are `eq/$eq`, `ne/$ne`, `in/$in`, `nin/$nin`,
 `gt/$gt`, `gte/$gte`, `lt/$lt`, `lte/$lte`, `contains/$contains`,
-`glob/$glob`, and `regex/$regex`. Supported boolean operators are `$and`,
-`$or`, `$not`, and `$nor`.
+`glob/$glob`, `iglob/$iglob`, and `regex/$regex`. `search_text` additionally
+supports `$all_tokens`, `$any_token`, `$phrase`, and `$prefix`. The top-level
+`text_match` helper supports `all_tokens`, `any_token`, `phrase`, `prefix`,
+`glob`, `iglob`, and `regex`. Supported boolean operators are `$and`, `$or`,
+`$not`, and `$nor`.
 
 Example body:
 
@@ -180,6 +187,11 @@ Example body:
   "limit": 25
 }
 ```
+
+Search results may include `content_endpoint` and `search_match` on each item.
+`content_endpoint` points at the API route used by `flt track download`, and
+`search_match` identifies matched text fields and ranking sources such as
+`bm25:search_text`, `bm25:user_messages_text`, `vector`, or `last_active`.
 
 ### Aggregate
 

--- a/fleet/track/__init__.py
+++ b/fleet/track/__init__.py
@@ -17,6 +17,8 @@ re-exported here.
 
 from __future__ import annotations
 
+from .api import TrackSessionSearchRequest, TrackTextMatch
+
 # --- Unified event model + format conversion --- #
 from .compactor import (
     Compactor,
@@ -78,6 +80,8 @@ from .unified import (
 __all__ = [
     # Paths
     "TrackPaths",
+    "TrackSessionSearchRequest",
+    "TrackTextMatch",
     # Unified format
     "Event",
     "SessionStart",

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -23,7 +23,7 @@ import os
 import platform
 import socket
 import gzip
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, Callable, Mapping, Optional, Tuple, Union
 
 import httpx
@@ -38,6 +38,37 @@ SERVER_UPLOAD_URL_BATCH_CAP = 100  # /v1/track/upload-urls returns 400 above thi
 
 AuthInfo = Union[str, Tuple[str, str]]
 AuthProvider = Callable[[], Optional[AuthInfo]]
+SearchMode = str
+TextMatchOperator = str
+
+
+@dataclass(frozen=True)
+class TrackTextMatch:
+    """Full-text match filter for indexed FleetCode session text.
+
+    Operators mirror orchestrator's Turbopuffer-backed search API:
+    `all_tokens`, `any_token`, `phrase`, `prefix`, `glob`, `iglob`, and `regex`.
+    """
+
+    query: str
+    operator: TextMatchOperator = "all_tokens"
+    field: str = "search_text"
+    negate: bool = False
+
+
+@dataclass(frozen=True)
+class TrackSessionSearchRequest:
+    """Structured body for `POST /v1/track/sessions/search`."""
+
+    query: Optional[str] = None
+    mode: SearchMode = "hybrid"
+    last_as_prefix: bool = False
+    text_match: Optional[TrackTextMatch] = None
+    rank_by: Optional[list[Any]] = None
+    filters: Optional[Any] = None
+    time: Optional[Mapping[str, Any]] = None
+    limit: Optional[int] = None
+    top_k: int = 50
 
 
 class TrackAPIError(Exception):
@@ -220,16 +251,16 @@ class TrackAPIClient:
         _raise(resp)
         return resp.json()
 
-    def _post_session_search(self, body: Mapping[str, Any]) -> dict:
+    def _post_session_search(self, body: Any) -> dict:
         resp = self._client.post(
             "/v1/track/sessions/search",
-            json=dict(body),
+            json=_json_body(body),
             headers=self._headers(),
         )
         _raise(resp)
         return resp.json()
 
-    def search_sessions_raw(self, body: Mapping[str, Any]) -> dict:
+    def search_sessions_raw(self, body: Any) -> dict:
         """Run legacy/debug raw Turbopuffer-shaped session search.
 
         The body is forwarded to orchestrator's
@@ -240,13 +271,14 @@ class TrackAPIClient:
         """
         return self._post_session_search(body)
 
-    def search_sessions(self, body: Mapping[str, Any]) -> dict:
+    def search_sessions(self, body: Any) -> dict:
         """Run structured session search.
 
         This posts the stable Fleet search shape to the same orchestrator route
         as the legacy raw Turbopuffer body. Prefer this for agents and CLI use:
-        filters are objects, `time` is shared with aggregate queries, and the
-        server compiles the request to Turbopuffer.
+        filters are objects, `time` is shared with aggregate queries,
+        `text_match` exposes Turbopuffer token/phrase/prefix/glob/regex
+        filtering, and the server compiles the request to Turbopuffer.
         """
         return self._post_session_search(body)
 
@@ -341,6 +373,14 @@ def _session_payload(session: Any) -> dict[str, Any]:
     if isinstance(session, Mapping):
         return dict(session)
     raise TypeError(f"Unsupported session payload type: {type(session)!r}")
+
+
+def _json_body(body: Any) -> dict[str, Any]:
+    if is_dataclass(body):
+        return asdict(body)
+    if isinstance(body, Mapping):
+        return dict(body)
+    raise TypeError(f"Unsupported JSON body type: {type(body)!r}")
 
 
 def _session_id(session: Any) -> str:

--- a/fleet/track/mcp_server.py
+++ b/fleet/track/mcp_server.py
@@ -20,13 +20,19 @@ from .query_schema import (
     SEARCH_FILTER_FIELDS,
     SEARCH_FILTER_OPERATORS,
     SEARCH_LOGICAL_OPERATORS,
+    SEARCH_TEXT_FILTER_OPERATORS,
+    SEARCH_TEXT_FIELD,
     SEARCH_TIME_FIELDS,
+    TEXT_MATCH_OPERATORS,
 )
 
 FILTERABLE_ATTRIBUTES = [field["name"] for field in SEARCH_FILTER_FIELDS]
+SEARCH_FILTERABLE_ATTRIBUTES = FILTERABLE_ATTRIBUTES + [SEARCH_TEXT_FIELD["name"]]
 FILTER_OPERATORS = list(SEARCH_FILTER_OPERATORS)
 LOGICAL_OPERATORS = list(SEARCH_LOGICAL_OPERATORS)
 SEARCH_MODES = ["hybrid", "keyword", "semantic", "recent"]
+SEARCH_TEXT_OPERATORS = list(SEARCH_TEXT_FILTER_OPERATORS)
+TEXT_MATCH_OPERATORS_LIST = list(TEXT_MATCH_OPERATORS)
 TIME_FIELDS = list(SEARCH_TIME_FIELDS)
 
 
@@ -40,9 +46,24 @@ def fleetcode_query_guide() -> dict[str, Any]:
                 "body_fields": {
                     "query": "Natural-language search text.",
                     "mode": SEARCH_MODES,
+                    "last_as_prefix": "Treat the final BM25 query token as a prefix.",
+                    "text_match": {
+                        "purpose": "Full-text filter over indexed session text.",
+                        "operators": TEXT_MATCH_OPERATORS_LIST,
+                        "shape": {
+                            "query": "Text to match.",
+                            "operator": "Defaults to all_tokens.",
+                            "field": "search_text",
+                            "negate": False,
+                        },
+                    },
                     "limit": "Maximum result count. Defaults to 50.",
-                    "filters": "Mongo-style filters over filterable attributes.",
+                    "filters": "Mongo-style filters over search_filter_attributes.",
                     "time": "Shared time filter, e.g. {'field':'last_active','since':'7d'}.",
+                },
+                "response_fields": {
+                    "items[].content_endpoint": "Relative content URL endpoint for the download tool/API.",
+                    "items[].search_match": "Diagnostics: matched_fields, filter_fields, rank_sources, query, mode, and text_match.",
                 },
             },
             "fleetcode_aggregate_sessions": {
@@ -66,11 +87,15 @@ def fleetcode_query_guide() -> dict[str, Any]:
         },
         "filters": {
             "attributes": FILTERABLE_ATTRIBUTES,
+            "search_filter_attributes": SEARCH_FILTERABLE_ATTRIBUTES,
+            "search_text_field": dict(SEARCH_TEXT_FIELD),
             "operators": FILTER_OPERATORS,
+            "search_text_operators": SEARCH_TEXT_OPERATORS,
             "logical_operators": LOGICAL_OPERATORS,
             "examples": [
                 {"tool": "codex"},
                 {"event_count": {"$gte": 1000}},
+                {"search_text": {"$prefix": "database migr"}},
                 {"repo_url": "github.com/fleet-ai/theseus", "tool": "codex"},
                 {
                     "$or": [
@@ -95,6 +120,11 @@ def fleetcode_query_guide() -> dict[str, Any]:
                 "filters": {"repo_url": {"$contains": "theseus"}},
                 "time": {"field": "last_active", "since": "30d"},
                 "limit": 25,
+            },
+            "text_match": {
+                "text_match": {"query": "database schema", "operator": "phrase"},
+                "filters": {"tool": "codex"},
+                "limit": 10,
             },
             "aggregate": {
                 "group_by": ["repo_url", "tool"],
@@ -209,10 +239,11 @@ def create_mcp():
     def fleetcode_search_sessions(body: dict[str, Any]) -> dict[str, Any]:
         """Find relevant sessions using structured FleetCode search.
 
-        Body fields: query, mode, limit, filters, and time. Modes are hybrid,
-        keyword, semantic, and recent. Filters use Mongo-style `$and`, `$or`,
-        `$not`, field operators such as `$in` and `$gte`, and the documented
-        session metadata fields.
+        Body fields: query, mode, last_as_prefix, text_match, limit, filters,
+        and time. Modes are hybrid, keyword, semantic, and recent. `text_match`
+        supports all_tokens, any_token, phrase, prefix, glob, iglob, and regex
+        over search_text. Results include content_endpoint and search_match
+        when the server returns match diagnostics.
         """
         return search_impl(body)
 

--- a/fleet/track/query_schema.py
+++ b/fleet/track/query_schema.py
@@ -64,6 +64,14 @@ SEARCH_FILTER_FIELDS = (
         "description": "Most recent session activity timestamp in ISO-8601 format.",
     },
 )
+SEARCH_TEXT_FIELD = {
+    "name": "search_text",
+    "type": "full-text string",
+    "description": (
+        "Indexed session text for search only. Use with text operators such as "
+        "$all_tokens, $any_token, $phrase, $prefix, $glob, $iglob, or $regex."
+    ),
+}
 
 SEARCH_FILTER_OPERATORS = (
     "eq/$eq",
@@ -76,7 +84,26 @@ SEARCH_FILTER_OPERATORS = (
     "lte/$lte",
     "contains/$contains",
     "glob/$glob",
+    "iglob/$iglob",
     "regex/$regex",
+)
+SEARCH_TEXT_FILTER_OPERATORS = (
+    "all_tokens/$all_tokens",
+    "any_token/$any_token",
+    "phrase/$phrase",
+    "prefix/$prefix",
+    "glob/$glob",
+    "iglob/$iglob",
+    "regex/$regex",
+)
+TEXT_MATCH_OPERATORS = (
+    "all_tokens",
+    "any_token",
+    "phrase",
+    "prefix",
+    "glob",
+    "iglob",
+    "regex",
 )
 
 SEARCH_LOGICAL_OPERATORS = ("$and", "$or", "$not", "$nor")
@@ -100,11 +127,38 @@ def search_filter_catalog() -> dict:
     return {
         "description": "Structured Fleet session filters. Orchestrator compiles these to Postgres or Turbopuffer as needed.",
         "filterable_attributes": list(SEARCH_FILTER_FIELDS),
+        "search_text_field": dict(SEARCH_TEXT_FIELD),
         "operators": list(SEARCH_FILTER_OPERATORS),
+        "search_text_operators": list(SEARCH_TEXT_FILTER_OPERATORS),
+        "text_match_operators": list(TEXT_MATCH_OPERATORS),
         "logical_operators": list(SEARCH_LOGICAL_OPERATORS),
         "time_fields": list(SEARCH_TIME_FIELDS),
         "aggregate_metrics": list(AGGREGATE_METRICS),
         "aggregate_features": list(AGGREGATE_FEATURES),
+        "search_body_fields": {
+            "query": "Natural-language ranked query.",
+            "mode": ["hybrid", "keyword", "semantic", "recent"],
+            "last_as_prefix": (
+                "For BM25 keyword/hybrid query ranking, treat the final query "
+                "token as a prefix."
+            ),
+            "text_match": (
+                "Full-text filter: {'query': str, 'operator': one of "
+                "text_match_operators, 'field': 'search_text', 'negate': bool}."
+            ),
+            "filters": "Mongo-style filters over metadata fields plus search_text.",
+            "time": "Shared time filter, e.g. {'field': 'last_active', 'since': '7d'}.",
+            "limit": "Maximum result count.",
+        },
+        "response_fields": {
+            "content_endpoint": (
+                "Relative API path for retrieving the session content URL."
+            ),
+            "search_match": (
+                "Search diagnostics with matched_fields, filter_fields, "
+                "rank_sources, query, mode, and text_match."
+            ),
+        },
         "examples": [
             {"filters": {"tool": "codex"}},
             {
@@ -117,6 +171,12 @@ def search_filter_catalog() -> dict:
                 }
             },
             {"time": {"field": "last_active", "since": "7d"}},
+            {"text_match": {"query": "shit", "operator": "all_tokens"}},
+            {
+                "query": "schema migr",
+                "last_as_prefix": True,
+                "filters": {"search_text": {"$prefix": "database schem"}},
+            },
             {
                 "filters": {
                     "repo_url": "github.com/fleet-ai/theseus",

--- a/fleet/track/store.py
+++ b/fleet/track/store.py
@@ -272,6 +272,11 @@ class Session:
     `metadata` — open-ended bag conforming to `SessionMetadata`.
         Validated lazily via `metadata_typed()`; stored as dict so
         callers can read/write known keys directly.
+
+    `content_endpoint` / `search_match` — server-returned read-side metadata.
+        `content_endpoint` is the relative API path for content download.
+        `search_match` is present on search results and identifies the indexed
+        fields and rank sources that matched the query.
     """
 
     id: str
@@ -283,6 +288,8 @@ class Session:
     forked_from: Optional[str] = None
     fork_point: Optional[int] = None
     origin_device: Optional[str] = None
+    content_endpoint: Optional[str] = None
+    search_match: Optional[dict] = None
     metadata: dict = field(default_factory=dict)
 
     def metadata_typed(self) -> SessionMetadata:

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -13,6 +13,8 @@ from fleet.track.api import (
     SERVER_UPLOAD_URL_BATCH_CAP,
     TrackAPIClient,
     TrackAPIError,
+    TrackSessionSearchRequest,
+    TrackTextMatch,
 )
 
 
@@ -305,6 +307,40 @@ def test_search_sessions_posts_structured_body_and_returns_json():
     assert captured["url"] == "http://test/v1/track/sessions/search"
     assert captured["body"]["filters"] == {"tool": "codex"}
     assert out["items"] == []
+
+
+def test_search_sessions_accepts_typed_text_match_request():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"items": [], "next_cursor": None})
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    api.search_sessions(
+        TrackSessionSearchRequest(
+            query="schema migr",
+            mode="keyword",
+            last_as_prefix=True,
+            text_match=TrackTextMatch(query="database schema", operator="phrase"),
+            filters={"search_text": {"$prefix": "database schem"}},
+            limit=5,
+        )
+    )
+
+    assert captured["url"] == "http://test/v1/track/sessions/search"
+    assert captured["body"]["mode"] == "keyword"
+    assert captured["body"]["last_as_prefix"] is True
+    assert captured["body"]["text_match"] == {
+        "query": "database schema",
+        "operator": "phrase",
+        "field": "search_text",
+        "negate": False,
+    }
+    assert captured["body"]["filters"] == {
+        "search_text": {"$prefix": "database schem"}
+    }
 
 
 def test_aggregate_sessions_posts_body_and_returns_json():

--- a/tests/track/test_mcp_server.py
+++ b/tests/track/test_mcp_server.py
@@ -46,7 +46,17 @@ def test_fleetcode_query_guide_describes_query_contract():
     assert "fleetcode_aggregate_sessions" in guide["tools"]
     assert "fleetcode_download_session" in guide["tools"]
     assert "repo_url" in guide["filters"]["attributes"]
+    assert "search_text" in guide["filters"]["search_filter_attributes"]
     assert "gte/$gte" in guide["filters"]["operators"]
+    assert "prefix/$prefix" in guide["filters"]["search_text_operators"]
+    assert (
+        "text_match"
+        in guide["tools"]["fleetcode_search_sessions"]["body_fields"]
+    )
+    assert (
+        "items[].search_match"
+        in guide["tools"]["fleetcode_search_sessions"]["response_fields"]
+    )
     assert "$or" in guide["filters"]["logical_operators"]
     assert (
         "avg_event_count"
@@ -70,6 +80,20 @@ def test_fleetcode_search_sessions_preserves_explicit_limit():
     mcp_server.fleetcode_search_sessions({"query": "deployment", "limit": 5}, api=api)
 
     assert api.search_bodies == [{"query": "deployment", "limit": 5}]
+
+
+def test_fleetcode_search_sessions_preserves_text_match_fields():
+    api = FakeAPI()
+    body = {
+        "text_match": {"query": "database schema", "operator": "phrase"},
+        "last_as_prefix": True,
+        "filters": {"search_text": {"$prefix": "database schem"}},
+        "limit": 10,
+    }
+
+    mcp_server.fleetcode_search_sessions(body, api=api)
+
+    assert api.search_bodies == [body]
 
 
 def test_fleetcode_aggregate_sessions_calls_api():

--- a/tests/track/test_store.py
+++ b/tests/track/test_store.py
@@ -854,6 +854,14 @@ def test_remote_store_pages_with_query_and_origin_device():
                         "last_active": "2026-05-05T00:00:00Z",
                         "event_count": 7,
                         "device_id": "laptop-abc12345",
+                        "content_endpoint": "/v1/track/sessions/s1/content",
+                        "search_match": {
+                            "query": "fleet",
+                            "mode": "hybrid",
+                            "matched_fields": ["search_text"],
+                            "filter_fields": [],
+                            "rank_sources": ["bm25:search_text"],
+                        },
                         "metadata": {"title": "FleetTrack"},
                     }
                 ],
@@ -868,6 +876,14 @@ def test_remote_store_pages_with_query_and_origin_device():
     assert captured["params"]["limit"] == "10"
     assert cursor == "next"
     assert items[0].origin_device == "laptop-abc12345"
+    assert items[0].content_endpoint == "/v1/track/sessions/s1/content"
+    assert items[0].search_match == {
+        "query": "fleet",
+        "mode": "hybrid",
+        "matched_fields": ["search_text"],
+        "filter_fields": [],
+        "rank_sources": ["bm25:search_text"],
+    }
     assert items[0].metadata["title"] == "FleetTrack"
 
 


### PR DESCRIPTION
## Summary
- add typed Track text-match search request helpers
- preserve content_endpoint and search_match on returned sessions
- update FleetCode MCP query guide and docs for text_match/search_text operators

## Tests
- uv run --extra dev ruff check fleet/track/api.py fleet/track/store.py fleet/track/query_schema.py fleet/track/mcp_server.py fleet/track/__init__.py tests/track/test_api.py tests/track/test_store.py tests/track/test_mcp_server.py
- uv run --extra dev pytest tests/track/test_api.py tests/track/test_store.py tests/track/test_mcp_server.py tests/track/test_cli.py -q
- git diff --check