### PR TITLE
perf(track): bulk metadata upserts + drain pacing + single-pass scrub

### DIFF
--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -101,6 +101,26 @@ class TrackAPIError(Exception):
         self.detail = detail
 
 
+class BulkUpsertPartialFailure(TrackAPIError):
+    """Raised when one chunk of `upsert_sessions_bulk` fails after earlier
+    chunks succeeded. `unsent_items` is the failing chunk plus everything
+    after it; everything before it is already committed server-side. Lets
+    the caller re-enqueue only what hasn't been sent, avoiding repeat
+    sends of already-committed rows on the next flush.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        unsent_items: list["BulkSessionUpsert"],
+        status_code: Optional[int] = None,
+        detail: Any = None,
+    ) -> None:
+        super().__init__(message, status_code=status_code, detail=detail)
+        self.unsent_items = unsent_items
+
+
 def _default_auth_provider() -> Optional[AuthInfo]:
     """Production auth: prefer stored `flt login` creds, then FLEET_API_KEY.
 
@@ -252,6 +272,11 @@ class TrackAPIClient:
         path → s3_key conversion and validation behave identically. Empty
         list is a no-op. Chunks at SERVER_BULK_UPSERT_BATCH_CAP to match
         the server cap.
+
+        On partial failure (some chunk succeeds, a later one doesn't),
+        raises `BulkUpsertPartialFailure` carrying the unsent tail —
+        already-committed earlier chunks are left server-side and the
+        caller should only retry the unsent portion.
         """
         if not items:
             return
@@ -261,12 +286,29 @@ class TrackAPIClient:
                 "device_id": device_id,
                 "items": [_bulk_item_payload(item) for item in chunk],
             }
-            resp = self._client.post(
-                "/v1/track/sessions/bulk",
-                json=body,
-                headers=self._headers(),
-            )
-            _raise(resp)
+            try:
+                resp = self._client.post(
+                    "/v1/track/sessions/bulk",
+                    json=body,
+                    headers=self._headers(),
+                )
+                _raise(resp)
+            except TrackAPIError as e:
+                unsent = items[chunk_start:]
+                raise BulkUpsertPartialFailure(
+                    str(e),
+                    unsent_items=unsent,
+                    status_code=e.status_code,
+                    detail=e.detail,
+                ) from e
+            except Exception as e:
+                # Network errors etc. — same partial-failure semantics: this
+                # chunk and everything after it didn't reach the server.
+                unsent = items[chunk_start:]
+                raise BulkUpsertPartialFailure(
+                    str(e),
+                    unsent_items=unsent,
+                ) from e
 
     def list_sessions(
         self,

--- a/fleet/track/api.py
+++ b/fleet/track/api.py
@@ -34,6 +34,7 @@ log = logging.getLogger("fleet.track.api")
 
 DEFAULT_TIMEOUT = 30.0
 SERVER_UPLOAD_URL_BATCH_CAP = 100  # /v1/track/upload-urls returns 400 above this.
+SERVER_BULK_UPSERT_BATCH_CAP = 100  # /v1/track/sessions/bulk; chunk to match.
 
 
 AuthInfo = Union[str, Tuple[str, str]]
@@ -54,6 +55,22 @@ class TrackTextMatch:
     operator: TextMatchOperator = "all_tokens"
     field: str = "search_text"
     negate: bool = False
+
+
+@dataclass(frozen=True)
+class BulkSessionUpsert:
+    """One item in a /v1/track/sessions/bulk request.
+
+    Mirrors the per-arg shape of `upsert_session`. `content_codec`,
+    `raw_bytes`, `stored_bytes` are only sent when this row carries
+    a fresh upload (i.e. include_content_metadata=True equivalent).
+    """
+
+    path: str
+    session: Any
+    content_codec: Optional[str] = None
+    raw_bytes: Optional[int] = None
+    stored_bytes: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -222,6 +239,34 @@ class TrackAPIClient:
             headers=self._headers(),
         )
         _raise(resp)
+
+    def upsert_sessions_bulk(
+        self,
+        *,
+        device_id: str,
+        items: list["BulkSessionUpsert"],
+    ) -> None:
+        """Bulk-register metadata for many sessions in one request.
+
+        Server reuses the single-row upsert translation logic per item, so
+        path → s3_key conversion and validation behave identically. Empty
+        list is a no-op. Chunks at SERVER_BULK_UPSERT_BATCH_CAP to match
+        the server cap.
+        """
+        if not items:
+            return
+        for chunk_start in range(0, len(items), SERVER_BULK_UPSERT_BATCH_CAP):
+            chunk = items[chunk_start : chunk_start + SERVER_BULK_UPSERT_BATCH_CAP]
+            body = {
+                "device_id": device_id,
+                "items": [_bulk_item_payload(item) for item in chunk],
+            }
+            resp = self._client.post(
+                "/v1/track/sessions/bulk",
+                json=body,
+                headers=self._headers(),
+            )
+            _raise(resp)
 
     def list_sessions(
         self,
@@ -393,6 +438,20 @@ def _session_payload(session: Any) -> dict[str, Any]:
     if isinstance(session, Mapping):
         return dict(session)
     raise TypeError(f"Unsupported session payload type: {type(session)!r}")
+
+
+def _bulk_item_payload(item: "BulkSessionUpsert") -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "path": item.path,
+        "session": _session_payload(item.session),
+    }
+    if item.content_codec is not None:
+        out["content_codec"] = item.content_codec
+    if item.raw_bytes is not None:
+        out["raw_bytes"] = item.raw_bytes
+    if item.stored_bytes is not None:
+        out["stored_bytes"] = item.stored_bytes
+    return out
 
 
 def _json_body(body: Any) -> dict[str, Any]:

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -25,7 +25,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Optional
 
-from .api import TrackAPIClient, TrackAPIError
+from .api import BulkSessionUpsert, TrackAPIClient, TrackAPIError
 from .blocklist import TrackBlocklist
 from .drainer import QueueDrainer
 from .merkle import HashCache, MerkleTree
@@ -141,6 +141,11 @@ class Daemon:
         # in the orchestrator metadata index.
         self._metadata_indexed: dict[str, str] = {}
         self._metadata_lock = threading.Lock()
+        # Workers append confirmed uploads here; the main loop flushes via
+        # the bulk endpoint each iteration. Buffering halves orchestrator
+        # round trips and avoids workers blocking on per-file POSTs.
+        self._metadata_buffer: list[tuple[str, str, BulkSessionUpsert]] = []
+        self._metadata_buffer_lock = threading.Lock()
 
     # ------------------------------------------------------------------ #
     # Public entry points                                                  #
@@ -187,6 +192,7 @@ class Daemon:
 
         # Wait for in-flight uploads.
         self._pool.drain(timeout=60)
+        self._flush_metadata_buffer()
         if self._manifest_dirty:
             self._upload_manifest()
             self._manifest_dirty = False
@@ -248,6 +254,7 @@ class Daemon:
                 last_queue_reset = now
 
             self._drain_queue()
+            self._flush_metadata_buffer()
             # Persist manifest opportunistically when the queue is idle, but
             # also at least every MANIFEST_FLUSH_INTERVAL seconds so a daemon
             # that stays continuously busy still publishes progress. The
@@ -269,6 +276,7 @@ class Daemon:
         if self._pool:
             self._pool.drain(timeout=60)
             self._pool.shutdown()
+        self._flush_metadata_buffer()
         if self._manifest_dirty:
             self._upload_manifest()
         self._queue.close()
@@ -375,10 +383,18 @@ class Daemon:
     # ------------------------------------------------------------------ #
 
     def _drain_queue(self) -> None:
-        """Delegate to QueueDrainer; one pass."""
+        """Drain pending work into the upload pool until the queue is empty.
+
+        Tight-loops drain_once so dispatch isn't capped by the main loop's
+        10s sleep. The thread pool's worker count is the real concurrency
+        ceiling; this just keeps it fed.
+        """
         if self._drainer is None:
             return
-        self._drainer.drain_once(self._device_id)
+        while not self._stop.is_set():
+            result = self._drainer.drain_once(self._device_id)
+            if result.claimed == 0:
+                break
 
     # ------------------------------------------------------------------ #
     # Upload callbacks                                                     #
@@ -431,12 +447,13 @@ class Daemon:
         *,
         upload_payload: UploadPayload | None = None,
     ) -> None:
-        """Best-effort metadata index update for a confirmed S3 object.
+        """Buffer a metadata upsert for the next bulk flush.
 
-        The v1 syncer's correctness still comes from S3 bytes + manifest. The
-        metadata index is a read-side accelerator for listing/resume, so a
-        transient failure here should be retried on a later reconcile rather
-        than marking the file upload failed.
+        Workers call this synchronously from upload-completion callbacks;
+        the actual HTTP roundtrip happens later in `_flush_metadata_buffer`,
+        which the daemon main loop invokes after each drain pass and on
+        graceful shutdown. Buffering halves orchestrator round trips and
+        keeps workers off the network for metadata writes.
 
         `upload_payload` is only present immediately after this process uploads
         the file. For files merely confirmed by the remote manifest, omit
@@ -453,27 +470,53 @@ class Daemon:
         if session is None:
             return
 
-        kwargs = {"include_content_metadata": False}
         if upload_payload is not None:
-            kwargs = {
-                "content_codec": upload_payload.content_codec,
-                "raw_bytes": upload_payload.raw_bytes,
-                "stored_bytes": upload_payload.stored_bytes,
-            }
-
-        try:
-            self._api.upsert_session(
-                device_id=self._device_id,
+            item = BulkSessionUpsert(
                 path=rel_path,
                 session=session,
-                **kwargs,
+                content_codec=upload_payload.content_codec,
+                raw_bytes=upload_payload.raw_bytes,
+                stored_bytes=upload_payload.stored_bytes,
+            )
+        else:
+            item = BulkSessionUpsert(path=rel_path, session=session)
+
+        with self._metadata_buffer_lock:
+            # Drop any prior buffered entry for this path; the latest sha wins.
+            self._metadata_buffer = [
+                (p, s, i) for p, s, i in self._metadata_buffer if p != rel_path
+            ]
+            self._metadata_buffer.append((rel_path, sha256, item))
+
+    def _flush_metadata_buffer(self) -> None:
+        """Send buffered metadata upserts to the orchestrator in one bulk call.
+
+        Best-effort: a transient failure leaves entries in the buffer for
+        the next flush. If the daemon dies, the next reconcile re-queues
+        anything missing, so we tolerate buffer loss.
+        """
+        with self._metadata_buffer_lock:
+            if not self._metadata_buffer:
+                return
+            pending = self._metadata_buffer
+            self._metadata_buffer = []
+
+        try:
+            self._api.upsert_sessions_bulk(
+                device_id=self._device_id,
+                items=[item for _, _, item in pending],
             )
         except Exception as e:
-            log.warning("metadata upsert failed %s: %s", rel_path, e)
+            log.warning("bulk metadata upsert failed (%d items): %s", len(pending), e)
+            with self._metadata_buffer_lock:
+                # Put failed items back at the front so they're retried first;
+                # newer items appended during the flush stay in order.
+                self._metadata_buffer = pending + self._metadata_buffer
             return
 
         with self._metadata_lock:
-            self._metadata_indexed[rel_path] = sha256
+            for rel_path, sha256, _ in pending:
+                self._metadata_indexed[rel_path] = sha256
 
     # ------------------------------------------------------------------ #
     # Status                                                               #

--- a/fleet/track/daemon.py
+++ b/fleet/track/daemon.py
@@ -25,7 +25,12 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Optional
 
-from .api import BulkSessionUpsert, TrackAPIClient, TrackAPIError
+from .api import (
+    BulkSessionUpsert,
+    BulkUpsertPartialFailure,
+    TrackAPIClient,
+    TrackAPIError,
+)
 from .blocklist import TrackBlocklist
 from .drainer import QueueDrainer
 from .merkle import HashCache, MerkleTree
@@ -491,8 +496,11 @@ class Daemon:
     def _flush_metadata_buffer(self) -> None:
         """Send buffered metadata upserts to the orchestrator in one bulk call.
 
-        Best-effort: a transient failure leaves entries in the buffer for
-        the next flush. If the daemon dies, the next reconcile re-queues
+        Best-effort: a transient failure leaves only the unsent entries in
+        the buffer for the next flush. The bulk client raises
+        `BulkUpsertPartialFailure` when a later chunk fails after earlier
+        chunks succeeded — we use that to avoid re-sending items the server
+        already has. If the daemon dies, the next reconcile re-queues
         anything missing, so we tolerate buffer loss.
         """
         with self._metadata_buffer_lock:
@@ -506,17 +514,33 @@ class Daemon:
                 device_id=self._device_id,
                 items=[item for _, _, item in pending],
             )
+            sent = pending
+            unsent: list[tuple[str, str, BulkSessionUpsert]] = []
+        except BulkUpsertPartialFailure as e:
+            unsent_set = {id(it) for it in e.unsent_items}
+            sent = [t for t in pending if id(t[2]) not in unsent_set]
+            unsent = [t for t in pending if id(t[2]) in unsent_set]
+            log.warning(
+                "bulk metadata upsert partial failure: %d sent, %d unsent: %s",
+                len(sent),
+                len(unsent),
+                e,
+            )
         except Exception as e:
             log.warning("bulk metadata upsert failed (%d items): %s", len(pending), e)
-            with self._metadata_buffer_lock:
-                # Put failed items back at the front so they're retried first;
-                # newer items appended during the flush stay in order.
-                self._metadata_buffer = pending + self._metadata_buffer
-            return
+            sent = []
+            unsent = pending
 
-        with self._metadata_lock:
-            for rel_path, sha256, _ in pending:
-                self._metadata_indexed[rel_path] = sha256
+        if unsent:
+            with self._metadata_buffer_lock:
+                # Put unsent items back at the front so they're retried first;
+                # newer items appended during the flush stay in order.
+                self._metadata_buffer = unsent + self._metadata_buffer
+
+        if sent:
+            with self._metadata_lock:
+                for rel_path, sha256, _ in sent:
+                    self._metadata_indexed[rel_path] = sha256
 
     # ------------------------------------------------------------------ #
     # Status                                                               #

--- a/fleet/track/drainer.py
+++ b/fleet/track/drainer.py
@@ -26,7 +26,7 @@ log = logging.getLogger("fleet.track.drainer")
 
 # Server caps /v1/track/upload-urls at 100 paths per request. Match it
 # here to avoid a 400 if a single drain claims more.
-DEFAULT_BATCH_SIZE = 32
+DEFAULT_BATCH_SIZE = 100
 
 
 @dataclass(frozen=True)

--- a/fleet/track/scrubber.py
+++ b/fleet/track/scrubber.py
@@ -121,7 +121,8 @@ def scrub(text: str, rules: Iterable[Rule] = DEFAULT_RULES) -> ScrubResult:
 
     Hits are recorded against the *original* text's line numbers so that
     `flt track inspect` can point at the line the user can find in their
-    on-disk session file.
+    on-disk session file. The upload path uses `scrub_text` instead since
+    it doesn't need hits — see scrub_bytes.
     """
     rule_list: Sequence[Rule] = tuple(rules)
     hits: list[Hit] = []
@@ -133,14 +134,22 @@ def scrub(text: str, rules: Iterable[Rule] = DEFAULT_RULES) -> ScrubResult:
             line = text.count("\n", 0, m.start()) + 1
             hits.append(Hit(rule=rule.name, line=line, matched=m.group(0)))
 
-    # Second pass: actual substitution. We re-run regexes here rather than
-    # building offsets, because subs in earlier rules can change later
-    # rules' match positions (e.g. a long secret becoming "[REDACTED]"
-    # could expose a substring that looks like another secret).
-    for rule in rule_list:
-        text = rule.pattern.sub(rule.replacement, text)
+    return ScrubResult(text=scrub_text(text, rule_list), hits=tuple(hits))
 
-    return ScrubResult(text=text, hits=tuple(hits))
+
+def scrub_text(text: str, rules: Iterable[Rule] = DEFAULT_RULES) -> str:
+    """Apply substitution rules in order; return scrubbed text only.
+
+    Half the work of `scrub` — skips the hit-enumeration pass. Used by
+    the upload path, which discards hits anyway. Re-runs regexes for
+    substitution rather than building offsets, because subs in earlier
+    rules can change later rules' match positions (e.g. a long secret
+    becoming "[REDACTED]" could expose a substring that looks like
+    another secret).
+    """
+    for rule in rules:
+        text = rule.pattern.sub(rule.replacement, text)
+    return text
 
 
 def scrub_bytes(data: bytes, rules: Iterable[Rule] = DEFAULT_RULES) -> bytes:
@@ -148,6 +157,6 @@ def scrub_bytes(data: bytes, rules: Iterable[Rule] = DEFAULT_RULES) -> bytes:
     wrapper for the upload path that just wants the scrubbed payload."""
     try:
         text = data.decode("utf-8", errors="replace")
-        return scrub(text, rules).text.encode("utf-8")
+        return scrub_text(text, rules).encode("utf-8")
     except Exception:
         return data

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -11,6 +11,7 @@ import pytest
 
 from fleet.track.api import (
     BulkSessionUpsert,
+    BulkUpsertPartialFailure,
     SERVER_BULK_UPSERT_BATCH_CAP,
     SERVER_UPLOAD_URL_BATCH_CAP,
     TrackAPIClient,
@@ -264,6 +265,53 @@ def test_upsert_sessions_bulk_chunks_above_server_cap():
         SERVER_BULK_UPSERT_BATCH_CAP,
         7,
     ]
+
+
+def test_upsert_sessions_bulk_partial_failure_carries_unsent_tail():
+    """If chunk N fails after chunks 0..N-1 succeed, the raised exception
+    must expose only the unsent tail so the caller doesn't re-send items
+    the server already accepted."""
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return httpx.Response(204)  # first chunk succeeds
+        return httpx.Response(503, text="boom")  # second chunk fails
+
+    items = [
+        BulkSessionUpsert(path=f"{i}.jsonl", session={"id": f"s{i}"})
+        for i in range(SERVER_BULK_UPSERT_BATCH_CAP + 5)
+    ]
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    with pytest.raises(BulkUpsertPartialFailure) as exc:
+        api.upsert_sessions_bulk(device_id="dev1", items=items)
+
+    # The first SERVER_BULK_UPSERT_BATCH_CAP items were sent successfully;
+    # only the last 5 should be reported unsent.
+    assert len(exc.value.unsent_items) == 5
+    assert exc.value.unsent_items == items[SERVER_BULK_UPSERT_BATCH_CAP:]
+    assert exc.value.status_code == 503
+
+
+def test_upsert_sessions_bulk_first_chunk_failure_marks_all_unsent():
+    """If the very first chunk fails, every item is unsent — no work was
+    committed server-side."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="boom")
+
+    items = [
+        BulkSessionUpsert(path=f"{i}.jsonl", session={"id": f"s{i}"})
+        for i in range(10)
+    ]
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    with pytest.raises(BulkUpsertPartialFailure) as exc:
+        api.upsert_sessions_bulk(device_id="dev1", items=items)
+
+    assert exc.value.unsent_items == items
 
 
 def test_upsert_session_can_omit_content_metadata():

--- a/tests/track/test_api.py
+++ b/tests/track/test_api.py
@@ -10,6 +10,8 @@ import httpx
 import pytest
 
 from fleet.track.api import (
+    BulkSessionUpsert,
+    SERVER_BULK_UPSERT_BATCH_CAP,
     SERVER_UPLOAD_URL_BATCH_CAP,
     TrackAPIClient,
     TrackAPIError,
@@ -184,6 +186,84 @@ def test_upsert_session_posts_relative_path_and_session_payload():
     assert captured["body"]["content_codec"] == "gzip"
     assert captured["body"]["raw_bytes"] == 1000
     assert captured["body"]["stored_bytes"] == 200
+
+
+def test_upsert_sessions_bulk_posts_items_to_bulk_endpoint():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(204)
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    api.upsert_sessions_bulk(
+        device_id="dev1",
+        items=[
+            BulkSessionUpsert(
+                path=".codex/sessions/a.jsonl",
+                session={"id": "sa", "tool": "codex"},
+                content_codec="gzip",
+                raw_bytes=1000,
+                stored_bytes=200,
+            ),
+            BulkSessionUpsert(
+                path=".cursor/projects/b.jsonl",
+                session={"id": "sb", "tool": "cursor"},
+            ),
+        ],
+    )
+
+    assert captured["url"] == "http://test/v1/track/sessions/bulk"
+    assert captured["body"]["device_id"] == "dev1"
+    items = captured["body"]["items"]
+    assert len(items) == 2
+    assert items[0]["path"] == ".codex/sessions/a.jsonl"
+    assert items[0]["session"]["tool"] == "codex"
+    assert items[0]["content_codec"] == "gzip"
+    assert items[0]["raw_bytes"] == 1000
+    assert items[0]["stored_bytes"] == 200
+    # Item 2 omitted content metadata; bulk payload must too.
+    assert items[1]["path"] == ".cursor/projects/b.jsonl"
+    assert "content_codec" not in items[1]
+    assert "raw_bytes" not in items[1]
+    assert "stored_bytes" not in items[1]
+
+
+def test_upsert_sessions_bulk_empty_list_skips_request():
+    called = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["n"] += 1
+        return httpx.Response(204)
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    api.upsert_sessions_bulk(device_id="dev1", items=[])
+    assert called["n"] == 0
+
+
+def test_upsert_sessions_bulk_chunks_above_server_cap():
+    """Caller may pass more than the server cap; client splits into multiple POSTs."""
+    sizes_received: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        sizes_received.append(len(body["items"]))
+        return httpx.Response(204)
+
+    items = [
+        BulkSessionUpsert(path=f"{i}.jsonl", session={"id": f"s{i}"})
+        for i in range(SERVER_BULK_UPSERT_BATCH_CAP * 2 + 7)
+    ]
+
+    api = TrackAPIClient(client=_client_with_handler(handler), auth_provider=_auth)
+    api.upsert_sessions_bulk(device_id="dev1", items=items)
+
+    assert sizes_received == [
+        SERVER_BULK_UPSERT_BATCH_CAP,
+        SERVER_BULK_UPSERT_BATCH_CAP,
+        7,
+    ]
 
 
 def test_upsert_session_can_omit_content_metadata():

--- a/tests/track/test_daemon.py
+++ b/tests/track/test_daemon.py
@@ -20,6 +20,14 @@ def _auth() -> str:
     return "test-api-key"
 
 
+def _expand_bulk_upsert(body: dict) -> list[dict]:
+    """Flatten a /v1/track/sessions/bulk request body into per-row upsert dicts
+    that match the old per-row endpoint shape. Tests use this so the existing
+    per-row assertions continue to work after the daemon switched to bulk."""
+    device_id = body["device_id"]
+    return [{"device_id": device_id, **item} for item in body["items"]]
+
+
 class RecordingTransport:
     def __init__(self) -> None:
         self.calls: list[tuple[str, bytes]] = []
@@ -58,8 +66,8 @@ def test_run_once_reconciles_uploads_file_and_manifest(tmp_path: Path):
                 200,
                 json={"urls": {p: f"https://s3.test/{p}" for p in body["paths"]}},
             )
-        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
-            metadata_upserts.append(json.loads(req.content))
+        if req.method == "POST" and req.url.path.endswith("/v1/track/sessions/bulk"):
+            metadata_upserts.extend(_expand_bulk_upsert(json.loads(req.content)))
             return httpx.Response(204)
         raise AssertionError(f"unexpected request: {req.method} {req.url}")
 
@@ -144,8 +152,8 @@ def test_run_once_uploads_cursor_transcript_and_indexes_artifact(tmp_path: Path)
                 200,
                 json={"urls": {p: f"https://s3.test/{p}" for p in body["paths"]}},
             )
-        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
-            metadata_upserts.append(json.loads(req.content))
+        if req.method == "POST" and req.url.path.endswith("/v1/track/sessions/bulk"):
+            metadata_upserts.extend(_expand_bulk_upsert(json.loads(req.content)))
             return httpx.Response(204)
         raise AssertionError(f"unexpected request: {req.method} {req.url}")
 
@@ -316,8 +324,8 @@ def test_upload_done_upserts_exact_uploaded_payload_metadata(tmp_path: Path):
     metadata_upserts: list[dict] = []
 
     def handler(req: httpx.Request) -> httpx.Response:
-        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
-            metadata_upserts.append(json.loads(req.content))
+        if req.method == "POST" and req.url.path.endswith("/v1/track/sessions/bulk"):
+            metadata_upserts.extend(_expand_bulk_upsert(json.loads(req.content)))
             return httpx.Response(204)
         raise AssertionError(f"unexpected request: {req.method} {req.url}")
 
@@ -339,6 +347,7 @@ def test_upload_done_upserts_exact_uploaded_payload_metadata(tmp_path: Path):
     )
 
     daemon._on_upload_done(rel_path, "fresh-digest", payload)
+    daemon._flush_metadata_buffer()
 
     assert len(metadata_upserts) == 1
     upsert = metadata_upserts[0]
@@ -367,8 +376,8 @@ def test_confirmed_existing_metadata_upsert_omits_content_metadata(tmp_path: Pat
     metadata_upserts: list[dict] = []
 
     def handler(req: httpx.Request) -> httpx.Response:
-        if req.method == "POST" and "/v1/track/sessions/" in req.url.path:
-            metadata_upserts.append(json.loads(req.content))
+        if req.method == "POST" and req.url.path.endswith("/v1/track/sessions/bulk"):
+            metadata_upserts.extend(_expand_bulk_upsert(json.loads(req.content)))
             return httpx.Response(204)
         raise AssertionError(f"unexpected request: {req.method} {req.url}")
 
@@ -384,12 +393,155 @@ def test_confirmed_existing_metadata_upsert_omits_content_metadata(tmp_path: Pat
     daemon = Daemon(paths, queue=queue, cache=cache, tree=tree, api=api)
 
     daemon._upsert_metadata_for_paths({rel_path: "existing-digest"})
+    daemon._flush_metadata_buffer()
 
     assert len(metadata_upserts) == 1
     upsert = metadata_upserts[0]
     assert "content_codec" not in upsert
     assert "raw_bytes" not in upsert
     assert "stored_bytes" not in upsert
+
+    queue.close()
+    cache.close()
+
+
+def test_metadata_buffer_coalesces_many_uploads_into_one_bulk_request(tmp_path: Path):
+    """Workers append per upload; one main-loop flush should batch them all."""
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    rel_paths = [
+        ".codex/sessions/"
+        f"rollout-2026-05-05T00-00-00-eeeeeeee-eeee-eeee-eeee-eeeeeeeeee{i:02d}.jsonl"
+        for i in range(3)
+    ]
+    for rel in rel_paths:
+        f = tmp_path / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text('{"type":"session_meta","payload":{"id":"s","cwd":"/tmp"}}\n')
+
+    bulk_calls: list[dict] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and req.url.path.endswith("/v1/track/sessions/bulk"):
+            bulk_calls.append(json.loads(req.content))
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree, api=api)
+    daemon._device_id = "dev1"
+
+    for i, rel in enumerate(rel_paths):
+        daemon._on_upload_done(rel, f"sha-{i}", UploadPayload(b"x", "raw", 1, 1))
+
+    # Workers haven't done HTTP yet — only after the flush.
+    assert bulk_calls == []
+
+    daemon._flush_metadata_buffer()
+
+    assert len(bulk_calls) == 1
+    items = bulk_calls[0]["items"]
+    assert {it["path"] for it in items} == set(rel_paths)
+
+    queue.close()
+    cache.close()
+
+
+def test_metadata_buffer_retains_items_when_flush_fails(tmp_path: Path):
+    """A 5xx on bulk upsert must leave items buffered for the next flush."""
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+
+    rel_path = (
+        ".codex/sessions/"
+        "rollout-2026-05-05T00-00-00-ffffffff-ffff-ffff-ffff-ffffffffff01.jsonl"
+    )
+    session_file = tmp_path / rel_path
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        '{"type":"session_meta","payload":{"id":"s","cwd":"/tmp"}}\n'
+    )
+
+    attempts = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and req.url.path.endswith("/v1/track/sessions/bulk"):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(503, text="boom")
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {req.method} {req.url}")
+
+    api = TrackAPIClient(
+        client=httpx.Client(
+            transport=httpx.MockTransport(handler), base_url="http://test"
+        ),
+        auth_provider=_auth,
+    )
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree, api=api)
+    daemon._device_id = "dev1"
+
+    daemon._on_upload_done(rel_path, "fresh-sha", UploadPayload(b"x", "raw", 1, 1))
+    daemon._flush_metadata_buffer()  # first attempt 503s
+
+    assert attempts["n"] == 1
+    assert len(daemon._metadata_buffer) == 1  # item retained for retry
+    assert daemon._metadata_indexed.get(rel_path) is None  # not yet marked
+
+    daemon._flush_metadata_buffer()  # second attempt succeeds
+
+    assert attempts["n"] == 2
+    assert daemon._metadata_buffer == []
+    assert daemon._metadata_indexed.get(rel_path) == "fresh-sha"
+
+    queue.close()
+    cache.close()
+
+
+def test_drain_queue_tight_loops_until_drainer_empty(tmp_path: Path):
+    """`_drain_queue` must call `drain_once` until claimed=0 in one main-loop
+    iteration, instead of one drain per 10s sleep. This is the dispatch-throughput
+    fix — without it, a 1000-file backlog needed ~30 main-loop sleeps to dispatch."""
+    paths = TrackPaths.under(tmp_path)
+    paths.ensure_track_dir()
+    queue = UploadQueue(paths)
+    cache = HashCache(paths)
+    tree = MerkleTree(cache, file_iter=[])
+    daemon = Daemon(paths, queue=queue, cache=cache, tree=tree)
+    daemon._device_id = "dev1"
+
+    class CountingDrainer:
+        """Returns claimed=N for the first 3 calls, then 0. Records each call."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def drain_once(self, device_id: str):
+            from fleet.track.drainer import DrainResult
+
+            self.calls += 1
+            if self.calls <= 3:
+                return DrainResult(claimed=10, submitted=10, failed=0)
+            return DrainResult(claimed=0, submitted=0, failed=0)
+
+    counter = CountingDrainer()
+    daemon._drainer = counter  # type: ignore[assignment]
+
+    daemon._drain_queue()
+
+    assert counter.calls == 4, "drain should loop until claimed=0, then stop"
 
     queue.close()
     cache.close()

--- a/tests/track/test_scrubber.py
+++ b/tests/track/test_scrubber.py
@@ -10,6 +10,7 @@ from fleet.track.scrubber import (
     Rule,
     scrub,
     scrub_bytes,
+    scrub_text,
 )
 
 
@@ -164,3 +165,26 @@ def test_scrub_bytes_handles_invalid_utf8():
     bad = b"\xff\xfe AKIAIOSFODNN7EXAMPLE \x80"
     out = scrub_bytes(bad)
     assert b"AKIA" not in out
+
+
+# ------------------------------------------------------------------ #
+# scrub_text — single-pass equivalence to scrub().text                 #
+# ------------------------------------------------------------------ #
+
+
+def test_scrub_text_matches_scrub_result_text_for_diverse_inputs():
+    """Upload path uses scrub_text (skips hits enumeration). Result must be
+    identical to scrub(text).text — same substitutions in same order."""
+    samples = [
+        '{"k": "AKIAIOSFODNN7EXAMPLE", "key": "sk-abcdef0123456789ABCDEF0123456789"}',
+        "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 and /Users/alice/x",
+        "postgres://user:pass@host/db\nMY_VAR=longvalueXXXXXXXXXXXXXXXXXXXXX\n",
+        '{"hello": "world"}\n',  # no matches → must be unchanged
+    ]
+    for text in samples:
+        assert scrub_text(text) == scrub(text).text
+
+
+def test_scrub_text_returns_input_unchanged_when_no_rules_fire():
+    text = '{"hello": "world"}\n'
+    assert scrub_text(text) == text


### PR DESCRIPTION
## Summary

Three SDK-side changes that together remove the dispatch ceiling on `flt track` uploads. The companion orchestrator PR adds the `POST /v1/track/sessions/bulk` endpoint this client targets.

- **Drain pacing**: daemon main loop now tight-loops `drain_once` until the queue is empty rather than doing one drain per 10s sleep. The 8-thread upload pool is now actually saturable.
- **Drainer batch size**: 32 → 100 to match the server's `/v1/track/upload-urls` cap (which the existing comment already acknowledged).
- **Bulk metadata upserts**: workers buffer per-upload metadata; the main loop flushes via a new `POST /v1/track/sessions/bulk` each iteration and on graceful shutdown. Halves per-file network round trips.
- **Scrubber single-pass for uploads**: `scrub_bytes` now uses a new `scrub_text` that skips the hits-enumeration pass (which the upload path discarded anyway). `scrub()` retains the full API for `flt track inspect`-style callers.

Failure semantics:
- Failed bulk flush leaves items in the buffer for the next flush; reconcile re-queues anything lost on crash.
- Daemon uses the bulk endpoint exclusively for new metadata writes — needs the orchestrator side merged first.

## Test plan

- [x] All 525 track tests pass (`pytest tests/track`)
- [x] Full SDK suite passes (`pytest`) — 735 passed, 11 skipped
- [x] Added tests: bulk client serializes + chunks per server cap; daemon coalesces many uploads into one bulk request; daemon retains items on flush failure and retries successfully; scrub_text matches scrub().text on diverse inputs; _drain_queue tight-loops until claimed=0
- [ ] Smoke-test against staging orchestrator once the bulk endpoint lands