### PR TITLE
v0.2.128

### DIFF
--- a/fleet/__init__.py
+++ b/fleet/__init__.py
@@ -76,7 +76,7 @@ from . import env
 from . import global_client as _global_client
 from ._async import global_client as _async_global_client
 
-__version__ = "0.2.125"
+__version__ = "0.2.128"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/__init__.py
+++ b/fleet/_async/__init__.py
@@ -44,7 +44,7 @@ from ..types import VerifierFunction
 from .. import env
 from . import global_client as _async_global_client
 
-__version__ = "0.2.125"
+__version__ = "0.2.128"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -26,7 +26,7 @@ from .exceptions import (
 try:
     from .. import __version__
 except ImportError:
-    __version__ = "0.2.125"
+    __version__ = "0.2.128"
 
 logger = logging.getLogger(__name__)
 

--- a/fleet/_async/client.py
+++ b/fleet/_async/client.py
@@ -482,6 +482,8 @@ class AsyncEnv(EnvironmentBase):
         timeout: Optional[int] = 30,
         needs_upload: bool = True,
         verifier_runtime_version: Optional[str] = None,
+        async_: bool = False,
+        poll_interval: float = 5.0,
     ) -> VerifiersExecuteResponse:
         return await _execute_verifier_remote(
             self._load_client,
@@ -495,6 +497,8 @@ class AsyncEnv(EnvironmentBase):
             timeout,
             needs_upload,
             verifier_runtime_version,
+            async_=async_,
+            poll_interval=poll_interval,
         )
 
     def __getstate__(self):
@@ -1725,6 +1729,8 @@ async def _execute_verifier_remote(
     timeout: Optional[int] = 30,
     needs_upload: bool = True,
     verifier_runtime_version: Optional[str] = None,
+    async_: bool = False,
+    poll_interval: float = 5.0,
 ) -> VerifiersExecuteResponse:
     # Pickle args and kwargs together
     # The first arg should be None as a placeholder for env
@@ -1752,6 +1758,11 @@ async def _execute_verifier_remote(
     if verifier_runtime_version:
         request_data["verifier_runtime_version"] = verifier_runtime_version
 
+    # Async submit-and-poll path. When async_ is False the behavior below is
+    # identical to the original synchronous request.
+    if async_:
+        request_data["async"] = True
+
     # Debug logging
     # logger.debug(
     #     f"Sending verifier execute request: key={key}, sha256={bundle_sha[:8]}..., function_name={function_name}"
@@ -1773,4 +1784,21 @@ async def _execute_verifier_remote(
     response_json = response.json()
     # logger.debug(f"Verifier execute response: {response_json}")
 
-    return VerifiersExecuteResponse(**response_json)
+    if not async_:
+        return VerifiersExecuteResponse(**response_json)
+
+    # Async: the submit returns a job handle; poll until the job reaches a
+    # terminal state (completed/failed). Branch on `status`, never `success`.
+    job_id = response_json.get("job_id")
+    if not job_id:
+        # No job handle returned (e.g. server ran it inline) - surface as-is.
+        return VerifiersExecuteResponse(**response_json)
+
+    while True:
+        poll_response = await client.request(
+            "GET", f"/v1/verifiers/jobs/{job_id}"
+        )
+        poll_json = poll_response.json()
+        if poll_json.get("status") in ("completed", "failed"):
+            return VerifiersExecuteResponse(**poll_json)
+        await asyncio.sleep(poll_interval)

--- a/fleet/_async/models.py
+++ b/fleet/_async/models.py
@@ -258,6 +258,12 @@ class VerifiersExecuteRequest(BaseModel):
     display_src: Optional[str] = Field(
         None, description="Display source code", title="Display Src"
     )
+    async_: Optional[bool] = Field(
+        None,
+        alias="async",
+        description="Submit asynchronously and return a job handle instead of waiting",
+        title="Async",
+    )
 
 
 class VerifiersExecuteResponse(BaseModel):
@@ -301,6 +307,16 @@ class VerifiersExecuteResponse(BaseModel):
     )
     stdout: Optional[str] = Field(
         None, description="Captured stdout from execution", title="Stdout"
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Job status for async execution (pending/running/completed/failed)",
+        title="Status",
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description="Job handle for async execution; poll GET /v1/verifiers/jobs/{job_id}",
+        title="Job Id",
     )
 
 

--- a/fleet/_async/tasks.py
+++ b/fleet/_async/tasks.py
@@ -81,11 +81,23 @@ class Task(BaseModel):
         # Allow arbitrary types for the verifier field
         arbitrary_types_allowed = True
 
-    def verify(self, env, *args, **kwargs) -> float:
+    def verify(
+        self,
+        env,
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
+    ) -> float:
         """Verify the task using the verifier function (sync version).
 
         For sync environments, calls the sync verifier directly.
         For async verifiers, automatically runs them with asyncio.run().
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
@@ -95,7 +107,9 @@ class Task(BaseModel):
             import asyncio
             import inspect
 
-            result = self.verifier.remote(env, *args, **kwargs)
+            result = self.verifier.remote(
+                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
 
             # If the result is a coroutine, we need to run it
             if inspect.iscoroutine(result):
@@ -115,18 +129,27 @@ class Task(BaseModel):
         else:
             raise ValueError("No verifier function found for this task")
 
-    async def verify_async(self, *args, **kwargs) -> float:
+    async def verify_async(
+        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+    ) -> float:
         """Verify the task using the verifier function (async version).
 
         For async environments, awaits the async verifier.
         Works with both sync and async verifiers in async contexts.
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
             self._rebuild_verifier()
 
         if self.verifier:
-            result = self.verifier.remote(*args, **kwargs)
+            result = self.verifier.remote(
+                *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
             # If it's a coroutine, await it
             import inspect
 
@@ -138,19 +161,26 @@ class Task(BaseModel):
             raise ValueError("No verifier function found for this task")
 
     async def verify_detailed_async(
-        self, *args, **kwargs
+        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
     ) -> "VerifiersExecuteResponse":
         """Verify the task and return the full execute response model.
 
         For async environments, awaits the async verifier.
         Works with both sync and async verifiers in async contexts.
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
             self._rebuild_verifier()
 
         if self.verifier:
-            result = self.verifier.remote_with_response(*args, **kwargs)
+            result = self.verifier.remote_with_response(
+                *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
             # If it's a coroutine, await it
             import inspect
 
@@ -161,11 +191,23 @@ class Task(BaseModel):
         else:
             raise ValueError("No verifier function found for this task")
 
-    def verify_detailed(self, env, *args, **kwargs) -> "VerifiersExecuteResponse":
+    def verify_detailed(
+        self,
+        env,
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
+    ) -> "VerifiersExecuteResponse":
         """Verify the task and return the full execute response model (sync version).
 
         For sync environments, calls the sync verifier directly.
         For async verifiers, automatically runs them with asyncio.run().
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
@@ -176,7 +218,9 @@ class Task(BaseModel):
             import inspect
 
             # Check if verifier has remote_with_response method (for decorated verifiers)
-            result = self.verifier.remote_with_response(env, *args, **kwargs)
+            result = self.verifier.remote_with_response(
+                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
 
             # If the result is a coroutine, we need to run it
             if inspect.iscoroutine(result):

--- a/fleet/_async/verifiers/verifier.py
+++ b/fleet/_async/verifiers/verifier.py
@@ -154,9 +154,25 @@ class AsyncVerifierFunction:
             # Return error score 0
             return 0.0
 
-    async def remote(self, env: AsyncEnv, *args, **kwargs) -> float:
-        """Remote execution of the verifier function with SHA-based bundle caching."""
-        response = await self.remote_with_response(env, *args, **kwargs)
+    async def remote(
+        self,
+        env: AsyncEnv,
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
+    ) -> float:
+        """Remote execution of the verifier function with SHA-based bundle caching.
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and the result is polled (every ``poll_interval`` seconds)
+        until it completes — this avoids HTTP/edge idle timeouts for
+        long-running verifiers. When False the behavior is unchanged (the
+        request blocks until the verifier finishes).
+        """
+        response = await self.remote_with_response(
+            env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+        )
 
         # Handle response
         if response.stdout:
@@ -228,9 +244,20 @@ Remote traceback:
         )
 
     async def remote_with_response(
-        self, env: "AsyncEnv", *args, **kwargs
+        self,
+        env: "AsyncEnv",
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
     ) -> "VerifiersExecuteResponse":
-        """Remote execution of the verifier function that returns the full response model."""
+        """Remote execution of the verifier function that returns the full response model.
+
+        When ``async_`` is True the verifier is submitted asynchronously and
+        polled (every ``poll_interval`` seconds) until it reaches a terminal
+        state; the returned response is the completed/failed job result. When
+        False the request blocks until the verifier finishes (unchanged).
+        """
         args_array = list(args)
         args_array.append({"env": env.instance_id})
         args = tuple(args_array)
@@ -254,6 +281,8 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    async_=async_,
+                    poll_interval=poll_interval,
                 )
 
                 # logger.debug(f"Bundle {bundle_sha[:8]}... uploaded successfully")
@@ -271,6 +300,8 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=False,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    async_=async_,
+                    poll_interval=poll_interval,
                 )
 
             return response
@@ -292,6 +323,8 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    async_=async_,
+                    poll_interval=poll_interval,
                 )
                 return response
             else:

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -27,7 +27,7 @@ from .exceptions import (
 try:
     from . import __version__
 except ImportError:
-    __version__ = "0.2.125"
+    __version__ = "0.2.128"
 
 logger = logging.getLogger(__name__)
 

--- a/fleet/client.py
+++ b/fleet/client.py
@@ -22,6 +22,7 @@ import httpx
 import json
 import logging
 import os
+import time
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -494,6 +495,8 @@ class SyncEnv(EnvironmentBase):
         timeout: Optional[int] = 30,
         needs_upload: bool = True,
         verifier_runtime_version: Optional[str] = None,
+        async_: bool = False,
+        poll_interval: float = 5.0,
     ) -> VerifiersExecuteResponse:
         return _execute_verifier_remote(
             self._load_client,
@@ -507,6 +510,8 @@ class SyncEnv(EnvironmentBase):
             timeout,
             needs_upload,
             verifier_runtime_version,
+            async_=async_,
+            poll_interval=poll_interval,
         )
 
     def __getstate__(self):
@@ -1839,6 +1844,8 @@ def _execute_verifier_remote(
     timeout: Optional[int] = 30,
     needs_upload: bool = True,
     verifier_runtime_version: Optional[str] = None,
+    async_: bool = False,
+    poll_interval: float = 5.0,
 ) -> VerifiersExecuteResponse:
     # Pickle args and kwargs together
     # The first arg should be None as a placeholder for env
@@ -1866,6 +1873,11 @@ def _execute_verifier_remote(
     if verifier_runtime_version:
         request_data["verifier_runtime_version"] = verifier_runtime_version
 
+    # Async submit-and-poll path. When async_ is False the behavior below is
+    # identical to the original synchronous request.
+    if async_:
+        request_data["async"] = True
+
     # Debug logging
     # logger.debug(
     #     f"Sending verifier execute request: key={key}, sha256={bundle_sha[:8]}..., function_name={function_name}"
@@ -1887,4 +1899,19 @@ def _execute_verifier_remote(
     response_json = response.json()
     # logger.debug(f"Verifier execute response: {response_json}")
 
-    return VerifiersExecuteResponse(**response_json)
+    if not async_:
+        return VerifiersExecuteResponse(**response_json)
+
+    # Async: the submit returns a job handle; poll until the job reaches a
+    # terminal state (completed/failed). Branch on `status`, never `success`.
+    job_id = response_json.get("job_id")
+    if not job_id:
+        # No job handle returned (e.g. server ran it inline) - surface as-is.
+        return VerifiersExecuteResponse(**response_json)
+
+    while True:
+        poll_response = client.request("GET", f"/v1/verifiers/jobs/{job_id}")
+        poll_json = poll_response.json()
+        if poll_json.get("status") in ("completed", "failed"):
+            return VerifiersExecuteResponse(**poll_json)
+        time.sleep(poll_interval)

--- a/fleet/models.py
+++ b/fleet/models.py
@@ -266,6 +266,12 @@ class VerifiersExecuteRequest(BaseModel):
     display_src: Optional[str] = Field(
         None, description="Display source code", title="Display Src"
     )
+    async_: Optional[bool] = Field(
+        None,
+        alias="async",
+        description="Submit asynchronously and return a job handle instead of waiting",
+        title="Async",
+    )
 
 
 class VerifiersExecuteResponse(BaseModel):
@@ -309,6 +315,16 @@ class VerifiersExecuteResponse(BaseModel):
     )
     stdout: Optional[str] = Field(
         None, description="Captured stdout from execution", title="Stdout"
+    )
+    status: Optional[str] = Field(
+        None,
+        description="Job status for async execution (pending/running/completed/failed)",
+        title="Status",
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description="Job handle for async execution; poll GET /v1/verifiers/jobs/{job_id}",
+        title="Job Id",
     )
 
 

--- a/fleet/tasks.py
+++ b/fleet/tasks.py
@@ -83,11 +83,23 @@ class Task(BaseModel):
         # Allow arbitrary types for the verifier field
         arbitrary_types_allowed = True
 
-    def verify(self, env, *args, **kwargs) -> float:
+    def verify(
+        self,
+        env,
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
+    ) -> float:
         """Verify the task using the verifier function (sync version).
 
         For sync environments, calls the sync verifier directly.
         For async verifiers, automatically runs them with asyncio.run().
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
@@ -97,7 +109,9 @@ class Task(BaseModel):
             import inspect
 
             # Check if verifier has remote method (for decorated verifiers)
-            result = self.verifier.remote(env, *args, **kwargs)
+            result = self.verifier.remote(
+                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
 
             # If the result is a coroutine, we need to run it
             if inspect.iscoroutine(result):
@@ -117,18 +131,27 @@ class Task(BaseModel):
         else:
             raise ValueError("No verifier function found for this task")
 
-    def verify_async(self, *args, **kwargs) -> float:
+    def verify_async(
+        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+    ) -> float:
         """Verify the task using the verifier function (async version).
 
         For async environments, awaits the async verifier.
         Works with both sync and async verifiers in async contexts.
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
             self._rebuild_verifier()
 
         if self.verifier:
-            result = self.verifier.remote(*args, **kwargs)
+            result = self.verifier.remote(
+                *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
             # If it's a coroutine, await it
             import inspect
 
@@ -139,11 +162,23 @@ class Task(BaseModel):
         else:
             raise ValueError("No verifier function found for this task")
 
-    def verify_detailed(self, env, *args, **kwargs) -> "VerifiersExecuteResponse":
+    def verify_detailed(
+        self,
+        env,
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
+    ) -> "VerifiersExecuteResponse":
         """Verify the task and return the full execute response model.
 
         For sync environments, calls the sync verifier directly.
         For async verifiers, automatically runs them with asyncio.run().
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
@@ -153,7 +188,9 @@ class Task(BaseModel):
             import inspect
 
             # Check if verifier has remote_with_response method (for decorated verifiers)
-            result = self.verifier.remote_with_response(env, *args, **kwargs)
+            result = self.verifier.remote_with_response(
+                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
 
             # If the result is a coroutine, we need to run it
             if inspect.iscoroutine(result):
@@ -173,18 +210,27 @@ class Task(BaseModel):
         else:
             raise ValueError("No verifier function found for this task")
 
-    def verify_detailed_async(self, *args, **kwargs) -> "VerifiersExecuteResponse":
+    def verify_detailed_async(
+        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+    ) -> "VerifiersExecuteResponse":
         """Verify the task and return the full execute response model (async version).
 
         For async environments, returns a coroutine that when awaited returns the response.
         Works with both sync and async verifiers in async contexts.
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and polled (every ``poll_interval`` seconds) until it
+        completes, avoiding HTTP/edge idle timeouts for long-running
+        verifiers. When False the behavior is unchanged.
         """
         # If verifier doesn't exist but verifier_func does, rebuild it
         if not self.verifier and self.verifier_func:
             self._rebuild_verifier()
 
         if self.verifier:
-            result = self.verifier.remote_with_response(*args, **kwargs)
+            result = self.verifier.remote_with_response(
+                *args, async_=async_, poll_interval=poll_interval, **kwargs
+            )
             # Return the result (could be a coroutine or a value)
             return result
         else:

--- a/fleet/verifiers/verifier.py
+++ b/fleet/verifiers/verifier.py
@@ -165,9 +165,25 @@ class SyncVerifierFunction:
             # Return error score 0
             return 0.0
 
-    def remote(self, env: "SyncEnv", *args, **kwargs) -> float:
-        """Remote execution of the verifier function with SHA-based bundle caching."""
-        response = self.remote_with_response(env, *args, **kwargs)
+    def remote(
+        self,
+        env: "SyncEnv",
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
+    ) -> float:
+        """Remote execution of the verifier function with SHA-based bundle caching.
+
+        When ``async_`` is True the verifier is submitted to run in the
+        background and the result is polled (every ``poll_interval`` seconds)
+        until it completes — this avoids HTTP/edge idle timeouts for
+        long-running verifiers. When False the behavior is unchanged (the
+        request blocks until the verifier finishes).
+        """
+        response = self.remote_with_response(
+            env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+        )
 
         # Handle response
         if response.stdout:
@@ -239,9 +255,20 @@ Remote traceback:
         )
 
     def remote_with_response(
-        self, env: "SyncEnv", *args, **kwargs
+        self,
+        env: "SyncEnv",
+        *args,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
     ) -> "VerifiersExecuteResponse":
-        """Remote execution of the verifier function that returns the full response model."""
+        """Remote execution of the verifier function that returns the full response model.
+
+        When ``async_`` is True the verifier is submitted asynchronously and
+        polled (every ``poll_interval`` seconds) until it reaches a terminal
+        state; the returned response is the completed/failed job result. When
+        False the request blocks until the verifier finishes (unchanged).
+        """
         args_array = list(args)
         args_array.append({"env": env.instance_id})
         args = tuple(args_array)
@@ -265,6 +292,8 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    async_=async_,
+                    poll_interval=poll_interval,
                 )
 
                 # logger.debug(f"Bundle {bundle_sha[:8]}... uploaded successfully")
@@ -283,6 +312,8 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=False,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    async_=async_,
+                    poll_interval=poll_interval,
                 )
                 return response
 
@@ -303,6 +334,8 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    async_=async_,
+                    poll_interval=poll_interval,
                 )
                 return response
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fleet-python"
 
-version = "0.2.125"
+version = "0.2.128"
 description = "Python SDK for Fleet environments"
 authors = [
     {name = "Fleet AI", email = "nic@fleet.so"},

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "fleet-python"
-version = "0.2.125"
+version = "0.2.128"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Add an opt-in async_ flag to the verifier execute path. When async_=True, the SDK submits with "async": true, receives a job handle, and polls GET /v1/verifiers/jobs/{job_id} until the job reaches a terminal state (completed/failed). When async_ is False (default), behavior is unchanged.

Threaded through task.verify/verify_async/verify_detailed/verify_detailed_async, SyncVerifierFunction/AsyncVerifierFunction remote()/remote_with_response(), and env.execute_verifier_remote(). Added status/job_id to VerifiersExecuteResponse and async_ (alias "async") to VerifiersExecuteRequest.