### PR TITLE
PLAT-399 Respect cost_team_id in verifier execution

### DIFF
--- a/fleet/__init__.py
+++ b/fleet/__init__.py
@@ -78,7 +78,7 @@ from . import env
 from . import global_client as _global_client
 from ._async import global_client as _async_global_client
 
-__version__ = "0.2.129"
+__version__ = "0.2.130"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/__init__.py
+++ b/fleet/_async/__init__.py
@@ -44,7 +44,7 @@ from ..types import VerifierFunction
 from .. import env
 from . import global_client as _async_global_client
 
-__version__ = "0.2.129"
+__version__ = "0.2.130"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -26,7 +26,7 @@ from .exceptions import (
 try:
     from .. import __version__
 except ImportError:
-    __version__ = "0.2.129"
+    __version__ = "0.2.130"
 
 logger = logging.getLogger(__name__)
 

--- a/fleet/_async/client.py
+++ b/fleet/_async/client.py
@@ -532,6 +532,7 @@ class AsyncEnv(EnvironmentBase):
         verifier_runtime_version: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
+        cost_team_id: Optional[str] = None,
     ) -> VerifiersExecuteResponse:
         return await _execute_verifier_remote(
             self._load_client,
@@ -547,6 +548,7 @@ class AsyncEnv(EnvironmentBase):
             verifier_runtime_version,
             async_=async_,
             poll_interval=poll_interval,
+            cost_team_id=cost_team_id,
         )
 
     def __getstate__(self):
@@ -1820,6 +1822,7 @@ async def _execute_verifier_remote(
     verifier_runtime_version: Optional[str] = None,
     async_: bool = False,
     poll_interval: float = 5.0,
+    cost_team_id: Optional[str] = None,
 ) -> VerifiersExecuteResponse:
     # Pickle args and kwargs together
     # The first arg should be None as a placeholder for env
@@ -1846,6 +1849,9 @@ async def _execute_verifier_remote(
     # Add verifier_runtime_version if present
     if verifier_runtime_version:
         request_data["verifier_runtime_version"] = verifier_runtime_version
+
+    if cost_team_id is not None:
+        request_data["cost_team_id"] = cost_team_id
 
     # Async submit-and-poll path. When async_ is False the behavior below is
     # identical to the original synchronous request.

--- a/fleet/_async/models.py
+++ b/fleet/_async/models.py
@@ -222,6 +222,9 @@ class VerifiersCheckResponse(BaseModel):
 
 
 class VerifiersExecuteRequest(BaseModel):
+    cost_team_id: Optional[str] = Field(
+        None, description="Team to attribute verifier costs to", title="Cost Team Id"
+    )
     key: Optional[str] = Field(
         None, description="Key of the verifier artifact", title="Key"
     )

--- a/fleet/_async/tasks.py
+++ b/fleet/_async/tasks.py
@@ -85,6 +85,7 @@ class Task(BaseModel):
         self,
         env,
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -108,7 +109,12 @@ class Task(BaseModel):
             import inspect
 
             result = self.verifier.remote(
-                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+                env,
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
 
             # If the result is a coroutine, we need to run it
@@ -130,7 +136,12 @@ class Task(BaseModel):
             raise ValueError("No verifier function found for this task")
 
     async def verify_async(
-        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+        self,
+        *args,
+        cost_team_id: Optional[str] = None,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
     ) -> float:
         """Verify the task using the verifier function (async version).
 
@@ -148,7 +159,11 @@ class Task(BaseModel):
 
         if self.verifier:
             result = self.verifier.remote(
-                *args, async_=async_, poll_interval=poll_interval, **kwargs
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
             # If it's a coroutine, await it
             import inspect
@@ -161,7 +176,12 @@ class Task(BaseModel):
             raise ValueError("No verifier function found for this task")
 
     async def verify_detailed_async(
-        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+        self,
+        *args,
+        cost_team_id: Optional[str] = None,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
     ) -> "VerifiersExecuteResponse":
         """Verify the task and return the full execute response model.
 
@@ -179,7 +199,11 @@ class Task(BaseModel):
 
         if self.verifier:
             result = self.verifier.remote_with_response(
-                *args, async_=async_, poll_interval=poll_interval, **kwargs
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
             # If it's a coroutine, await it
             import inspect
@@ -195,6 +219,7 @@ class Task(BaseModel):
         self,
         env,
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -219,7 +244,12 @@ class Task(BaseModel):
 
             # Check if verifier has remote_with_response method (for decorated verifiers)
             result = self.verifier.remote_with_response(
-                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+                env,
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
 
             # If the result is a coroutine, we need to run it

--- a/fleet/_async/verifiers/verifier.py
+++ b/fleet/_async/verifiers/verifier.py
@@ -158,6 +158,7 @@ class AsyncVerifierFunction:
         self,
         env: AsyncEnv,
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -171,7 +172,12 @@ class AsyncVerifierFunction:
         request blocks until the verifier finishes).
         """
         response = await self.remote_with_response(
-            env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+            env,
+            *args,
+            cost_team_id=cost_team_id,
+            async_=async_,
+            poll_interval=poll_interval,
+            **kwargs,
         )
 
         # Handle response
@@ -247,6 +253,7 @@ Remote traceback:
         self,
         env: "AsyncEnv",
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -281,6 +288,7 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    cost_team_id=cost_team_id,
                     async_=async_,
                     poll_interval=poll_interval,
                 )
@@ -300,6 +308,7 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=False,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    cost_team_id=cost_team_id,
                     async_=async_,
                     poll_interval=poll_interval,
                 )
@@ -323,6 +332,7 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    cost_team_id=cost_team_id,
                     async_=async_,
                     poll_interval=poll_interval,
                 )

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -27,7 +27,7 @@ from .exceptions import (
 try:
     from . import __version__
 except ImportError:
-    __version__ = "0.2.129"
+    __version__ = "0.2.130"
 
 logger = logging.getLogger(__name__)
 

--- a/fleet/client.py
+++ b/fleet/client.py
@@ -545,6 +545,7 @@ class SyncEnv(EnvironmentBase):
         verifier_runtime_version: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
+        cost_team_id: Optional[str] = None,
     ) -> VerifiersExecuteResponse:
         return _execute_verifier_remote(
             self._load_client,
@@ -560,6 +561,7 @@ class SyncEnv(EnvironmentBase):
             verifier_runtime_version,
             async_=async_,
             poll_interval=poll_interval,
+            cost_team_id=cost_team_id,
         )
 
     def __getstate__(self):
@@ -1940,6 +1942,7 @@ def _execute_verifier_remote(
     verifier_runtime_version: Optional[str] = None,
     async_: bool = False,
     poll_interval: float = 5.0,
+    cost_team_id: Optional[str] = None,
 ) -> VerifiersExecuteResponse:
     # Pickle args and kwargs together
     # The first arg should be None as a placeholder for env
@@ -1966,6 +1969,9 @@ def _execute_verifier_remote(
     # Add verifier_runtime_version if present
     if verifier_runtime_version:
         request_data["verifier_runtime_version"] = verifier_runtime_version
+
+    if cost_team_id is not None:
+        request_data["cost_team_id"] = cost_team_id
 
     # Async submit-and-poll path. When async_ is False the behavior below is
     # identical to the original synchronous request.

--- a/fleet/models.py
+++ b/fleet/models.py
@@ -230,6 +230,9 @@ class VerifiersCheckResponse(BaseModel):
 
 
 class VerifiersExecuteRequest(BaseModel):
+    cost_team_id: Optional[str] = Field(
+        None, description="Team to attribute verifier costs to", title="Cost Team Id"
+    )
     key: Optional[str] = Field(
         None, description="Key of the verifier artifact", title="Key"
     )

--- a/fleet/tasks.py
+++ b/fleet/tasks.py
@@ -87,6 +87,7 @@ class Task(BaseModel):
         self,
         env,
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -110,7 +111,12 @@ class Task(BaseModel):
 
             # Check if verifier has remote method (for decorated verifiers)
             result = self.verifier.remote(
-                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+                env,
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
 
             # If the result is a coroutine, we need to run it
@@ -132,7 +138,12 @@ class Task(BaseModel):
             raise ValueError("No verifier function found for this task")
 
     def verify_async(
-        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+        self,
+        *args,
+        cost_team_id: Optional[str] = None,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
     ) -> float:
         """Verify the task using the verifier function (async version).
 
@@ -150,7 +161,11 @@ class Task(BaseModel):
 
         if self.verifier:
             result = self.verifier.remote(
-                *args, async_=async_, poll_interval=poll_interval, **kwargs
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
             # If it's a coroutine, await it
             import inspect
@@ -166,6 +181,7 @@ class Task(BaseModel):
         self,
         env,
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -189,7 +205,12 @@ class Task(BaseModel):
 
             # Check if verifier has remote_with_response method (for decorated verifiers)
             result = self.verifier.remote_with_response(
-                env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+                env,
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
 
             # If the result is a coroutine, we need to run it
@@ -211,7 +232,12 @@ class Task(BaseModel):
             raise ValueError("No verifier function found for this task")
 
     def verify_detailed_async(
-        self, *args, async_: bool = False, poll_interval: float = 5.0, **kwargs
+        self,
+        *args,
+        cost_team_id: Optional[str] = None,
+        async_: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs,
     ) -> "VerifiersExecuteResponse":
         """Verify the task and return the full execute response model (async version).
 
@@ -229,7 +255,11 @@ class Task(BaseModel):
 
         if self.verifier:
             result = self.verifier.remote_with_response(
-                *args, async_=async_, poll_interval=poll_interval, **kwargs
+                *args,
+                cost_team_id=cost_team_id,
+                async_=async_,
+                poll_interval=poll_interval,
+                **kwargs,
             )
             # Return the result (could be a coroutine or a value)
             return result

--- a/fleet/verifiers/verifier.py
+++ b/fleet/verifiers/verifier.py
@@ -169,6 +169,7 @@ class SyncVerifierFunction:
         self,
         env: "SyncEnv",
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -182,7 +183,12 @@ class SyncVerifierFunction:
         request blocks until the verifier finishes).
         """
         response = self.remote_with_response(
-            env, *args, async_=async_, poll_interval=poll_interval, **kwargs
+            env,
+            *args,
+            cost_team_id=cost_team_id,
+            async_=async_,
+            poll_interval=poll_interval,
+            **kwargs,
         )
 
         # Handle response
@@ -258,6 +264,7 @@ Remote traceback:
         self,
         env: "SyncEnv",
         *args,
+        cost_team_id: Optional[str] = None,
         async_: bool = False,
         poll_interval: float = 5.0,
         **kwargs,
@@ -292,6 +299,7 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    cost_team_id=cost_team_id,
                     async_=async_,
                     poll_interval=poll_interval,
                 )
@@ -312,6 +320,7 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=False,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    cost_team_id=cost_team_id,
                     async_=async_,
                     poll_interval=poll_interval,
                 )
@@ -334,6 +343,7 @@ Remote traceback:
                     kwargs=kwargs,
                     needs_upload=True,
                     verifier_runtime_version=self.verifier_runtime_version,
+                    cost_team_id=cost_team_id,
                     async_=async_,
                     poll_interval=poll_interval,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fleet-python"
 
-version = "0.2.129"
+version = "0.2.130"
 description = "Python SDK for Fleet environments"
 authors = [
     {name = "Fleet AI", email = "nic@fleet.so"},

--- a/tests/test_verifier_cost_team.py
+++ b/tests/test_verifier_cost_team.py
@@ -1,0 +1,198 @@
+from types import SimpleNamespace
+
+import pytest
+
+from fleet._async.client import _execute_verifier_remote as execute_async
+from fleet._async.verifiers.verifier import AsyncVerifierFunction
+from fleet.client import _execute_verifier_remote as execute_sync
+from fleet.verifiers.verifier import SyncVerifierFunction
+
+
+TEAM_ID = "11111111-2222-3333-4444-555555555555"
+EXECUTE_RESPONSE = {"success": True, "execution_time_ms": 1}
+
+
+class AsyncClientStub:
+    def __init__(self):
+        self.request_json = None
+
+    async def request(self, method, path, *, json):
+        assert (method, path) == ("POST", "/v1/verifiers/execute")
+        self.request_json = json
+        return SimpleNamespace(json=lambda: EXECUTE_RESPONSE)
+
+
+class SyncClientStub:
+    def __init__(self):
+        self.request_json = None
+
+    def request(self, method, path, *, json):
+        assert (method, path) == ("POST", "/v1/verifiers/execute")
+        self.request_json = json
+        return SimpleNamespace(json=lambda: EXECUTE_RESPONSE)
+
+
+@pytest.mark.asyncio
+async def test_async_execute_sends_cost_team_id_as_request_metadata():
+    client = AsyncClientStub()
+
+    await execute_async(
+        client,
+        bundle_data=b"",
+        bundle_sha="sha",
+        key="key",
+        function_name="verify",
+        args=(),
+        args_array=[],
+        kwargs={"final_answer": "done"},
+        needs_upload=False,
+        cost_team_id=TEAM_ID,
+    )
+
+    assert client.request_json["cost_team_id"] == TEAM_ID
+
+
+def test_sync_execute_sends_cost_team_id_as_request_metadata():
+    client = SyncClientStub()
+
+    execute_sync(
+        client,
+        bundle_data=b"",
+        bundle_sha="sha",
+        key="key",
+        function_name="verify",
+        args=(),
+        args_array=[],
+        kwargs={"final_answer": "done"},
+        needs_upload=False,
+        cost_team_id=TEAM_ID,
+    )
+
+    assert client.request_json["cost_team_id"] == TEAM_ID
+
+
+@pytest.mark.asyncio
+async def test_async_verifier_keeps_cost_team_id_out_of_function_kwargs(monkeypatch):
+    verifier = AsyncVerifierFunction(lambda env, **kwargs: 1.0, key="key")
+
+    async def bundle_status(_env):
+        return "sha", False
+
+    monkeypatch.setattr(verifier, "_check_bundle_status", bundle_status)
+    captured = {}
+
+    class EnvStub:
+        instance_id = "instance"
+
+        async def execute_verifier_remote(self, **kwargs):
+            captured.update(kwargs)
+            return EXECUTE_RESPONSE
+
+    await verifier.remote_with_response(
+        EnvStub(), final_answer="done", cost_team_id=TEAM_ID
+    )
+
+    assert captured["cost_team_id"] == TEAM_ID
+    assert captured["kwargs"] == {"final_answer": "done"}
+
+
+def test_sync_verifier_keeps_cost_team_id_out_of_function_kwargs(monkeypatch):
+    verifier = SyncVerifierFunction(lambda env, **kwargs: 1.0, key="key")
+    monkeypatch.setattr(verifier, "_check_bundle_status", lambda _env: ("sha", False))
+    captured = {}
+
+    class EnvStub:
+        instance_id = "instance"
+
+        def execute_verifier_remote(self, **kwargs):
+            captured.update(kwargs)
+            return EXECUTE_RESPONSE
+
+    verifier.remote_with_response(EnvStub(), final_answer="done", cost_team_id=TEAM_ID)
+
+    assert captured["cost_team_id"] == TEAM_ID
+    assert captured["kwargs"] == {"final_answer": "done"}
+
+
+@pytest.mark.asyncio
+async def test_async_execute_omits_cost_team_id_when_unspecified():
+    client = AsyncClientStub()
+
+    await execute_async(
+        client,
+        bundle_data=b"",
+        bundle_sha="sha",
+        key="key",
+        function_name="verify",
+        args=(),
+        args_array=[],
+        kwargs={},
+        needs_upload=False,
+    )
+
+    assert "cost_team_id" not in client.request_json
+
+
+def test_sync_execute_omits_cost_team_id_when_unspecified():
+    client = SyncClientStub()
+
+    execute_sync(
+        client,
+        bundle_data=b"",
+        bundle_sha="sha",
+        key="key",
+        function_name="verify",
+        args=(),
+        args_array=[],
+        kwargs={},
+        needs_upload=False,
+    )
+
+    assert "cost_team_id" not in client.request_json
+
+
+@pytest.mark.asyncio
+async def test_async_execute_preserves_existing_positional_async_arguments():
+    client = AsyncClientStub()
+
+    await execute_async(
+        client,
+        b"",
+        "sha",
+        "key",
+        "verify",
+        (),
+        [],
+        {},
+        30,
+        False,
+        None,
+        True,
+        0.01,
+    )
+
+    assert client.request_json["async"] is True
+    assert "cost_team_id" not in client.request_json
+
+
+def test_sync_execute_preserves_existing_positional_async_arguments():
+    client = SyncClientStub()
+
+    execute_sync(
+        client,
+        b"",
+        "sha",
+        "key",
+        "verify",
+        (),
+        [],
+        {},
+        30,
+        False,
+        None,
+        True,
+        0.01,
+    )
+
+    assert client.request_json["async"] is True
+    assert "cost_team_id" not in client.request_json

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "fleet-python"
-version = "0.2.129"
+version = "0.2.130"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- add optional `cost_team_id` to sync and async verifier execution APIs
- send it as top-level `/v1/verifiers/execute` request metadata, separate from verifier kwargs
- omit the field for existing clients and preserve positional `async_` compatibility
- bump `fleet-python` to `0.2.130` for the tag-driven PyPI release

## Validation
- `uv run --extra dev pytest -q` (190 passed, 11 skipped)
- `python -m build`
- `twine check dist/*`

## Release
This targets the current published SDK line (`fleet-python-v0.2.129` / `gautham/v0.2.129`), not `main`. After merge, push tag `fleet-python-v0.2.130`; `.github/workflows/publish-fleet-sdk.yml` builds and publishes it to PyPI.