### PR TITLE
feat(create): dedicated create timeout, wait declaration, duplicate-request recovery

### DIFF
--- a/fleet/_async/__init__.py
+++ b/fleet/_async/__init__.py
@@ -119,6 +119,8 @@ async def make(
     env_variables: Optional[Dict[str, Any]] = None,
     image_type: Optional[str] = None,
     ttl_seconds: Optional[int] = None,
+    timeout: Optional[float] = None,
+    max_wait_seconds: Optional[int] = None,
 ) -> AsyncEnv:
     """Create a new environment instance.
 
@@ -133,6 +135,8 @@ async def make(
         env_variables=env_variables,
         image_type=image_type,
         ttl_seconds=ttl_seconds,
+        timeout=timeout,
+        max_wait_seconds=max_wait_seconds,
     )
 
 

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -19,6 +19,7 @@ from .exceptions import (
     FleetVersionNotFoundError,
     FleetBadRequestError,
     FleetPermissionError,
+    FleetConflictError,
 )
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,7 @@ class AsyncWrapper(BaseWrapper):
             pass
 
         # Try to parse error response as JSON
+        duplicate_instance_id = None
         try:
             error_data = response.json()
             detail = error_data.get("detail", response.text)
@@ -120,6 +122,8 @@ class AsyncWrapper(BaseWrapper):
                     )
                 else:
                     error_message = detail.get("message", str(detail))
+                if detail.get("error") == "duplicate_request_id":
+                    duplicate_instance_id = detail.get("instance_id")
             else:
                 error_message = detail
 
@@ -235,6 +239,19 @@ class AsyncWrapper(BaseWrapper):
         elif status_code == 429:
             # Rate limit errors (not instance limit which is now 403)
             raise FleetRateLimitError(error_message)
+        elif status_code == 409:
+            # Conflict errors (resource already exists)
+            resource_name = None
+            # Try to extract resource name from error message
+            if "'" in error_message:
+                parts = error_message.split("'")
+                if len(parts) >= 2:
+                    resource_name = parts[1]
+            raise FleetConflictError(
+                error_message,
+                resource_name=resource_name,
+                instance_id=duplicate_instance_id,
+            )
         else:
             raise FleetAPIError(
                 error_message,

--- a/fleet/_async/client.py
+++ b/fleet/_async/client.py
@@ -167,9 +167,12 @@ from ..instance.models import (
 from ..config import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_TIMEOUT,
+    DEFAULT_CREATE_TIMEOUT,
+    CREATE_MAX_WAIT_MARGIN_S,
     REGION_BASE_URL,
     GLOBAL_BASE_URL,
 )
+from .exceptions import FleetConflictError
 from .instance.base import default_httpx_client
 from .instance.client import ValidatorType
 from .resources.base import Resource
@@ -552,6 +555,8 @@ class AsyncFleet:
         ttl_seconds: Optional[int] = None,
         run_id: Optional[str] = None,
         heartbeat_interval: Optional[int] = None,
+        timeout: Optional[float] = None,
+        max_wait_seconds: Optional[int] = None,
     ) -> AsyncEnv:
         if ":" in env_key:
             env_key_part, env_version = env_key.split(":", 1)
@@ -577,6 +582,15 @@ class AsyncFleet:
             data_key_part = data_key
             data_version = None
 
+        # Creates can wait on real infrastructure (node launch, image pull,
+        # seed hydration), so they run on their own budget: the server is
+        # asked to wait slightly less than the HTTP read timeout so a slow
+        # create returns a response instead of a client-side timeout.
+        create_timeout = DEFAULT_CREATE_TIMEOUT if timeout is None else timeout
+        if max_wait_seconds is None:
+            max_wait_seconds = max(int(create_timeout) - CREATE_MAX_WAIT_MARGIN_S, 0)
+        max_wait_seconds = min(max_wait_seconds, 3600)
+
         request = InstanceRequest(
             env_key=env_key_part,
             env_version=env_version,
@@ -589,6 +603,7 @@ class AsyncFleet:
             ttl_seconds=ttl_seconds,
             run_id=run_id,
             heartbeat_interval=heartbeat_interval,
+            max_wait_seconds=max_wait_seconds,
         )
 
         # Only use region-specific base URL if no custom base URL is set
@@ -596,12 +611,25 @@ class AsyncFleet:
         if region and self.client.base_url == GLOBAL_BASE_URL:
             base_url = REGION_BASE_URL.get(region)
 
-        response = await self.client.request(
-            "POST",
-            "/v1/env/instances",
-            json=request.model_dump(exclude_none=True),
-            base_url=base_url,
-        )
+        try:
+            response = await self.client.request(
+                "POST",
+                "/v1/env/instances",
+                json=request.model_dump(exclude_none=True),
+                base_url=base_url,
+                timeout=create_timeout,
+            )
+        except FleetConflictError as e:
+            # duplicate_request_id: a transport-level retry re-POSTed a create
+            # whose first attempt already succeeded server-side. Recover the
+            # original instance instead of failing the call.
+            if e.instance_id:
+                logger.warning(
+                    "Create request was already processed; recovering instance %s",
+                    e.instance_id,
+                )
+                return await self.instance(e.instance_id)
+            raise
 
         instance = AsyncEnv(client=self.client, **response.json())
         return instance

--- a/fleet/_async/client.py
+++ b/fleet/_async/client.py
@@ -22,6 +22,7 @@ import httpx
 import json
 import logging
 import os
+import time
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -172,7 +173,7 @@ from ..config import (
     REGION_BASE_URL,
     GLOBAL_BASE_URL,
 )
-from .exceptions import FleetConflictError
+from .exceptions import FleetConflictError, FleetTimeoutError
 from .instance.base import default_httpx_client
 from .instance.client import ValidatorType
 from .resources.base import Resource
@@ -183,6 +184,12 @@ from .resources.mcp import AsyncMCPResource
 from .resources.api import AsyncAPIResource
 
 logger = logging.getLogger(__name__)
+
+# Duplicate-create recovery: how often to re-check a still-provisioning
+# instance, and the minimum budget granted even when the create timeout is
+# nearly spent (one meaningful poll beats an instant timeout).
+DUPLICATE_RECOVERY_POLL_INTERVAL_S = 5.0
+DUPLICATE_RECOVERY_MIN_BUDGET_S = 30.0
 
 
 class AsyncSession:
@@ -611,6 +618,7 @@ class AsyncFleet:
         if region and self.client.base_url == GLOBAL_BASE_URL:
             base_url = REGION_BASE_URL.get(region)
 
+        create_started = time.monotonic()
         try:
             response = await self.client.request(
                 "POST",
@@ -621,18 +629,53 @@ class AsyncFleet:
             )
         except FleetConflictError as e:
             # duplicate_request_id: a transport-level retry re-POSTed a create
-            # whose first attempt already succeeded server-side. Recover the
-            # original instance instead of failing the call.
+            # the server had already accepted for this request id. The pointed
+            # instance may still be provisioning (the id is bound at insert,
+            # before the create finishes) or may have already died, so recover
+            # by status instead of returning it blindly.
             if e.instance_id:
-                logger.warning(
-                    "Create request was already processed; recovering instance %s",
-                    e.instance_id,
-                )
-                return await self.instance(e.instance_id)
+                remaining = create_timeout - (time.monotonic() - create_started)
+                return await self._recover_duplicate_create(e.instance_id, remaining)
             raise
 
         instance = AsyncEnv(client=self.client, **response.json())
         return instance
+
+    async def _recover_duplicate_create(
+        self, instance_id: str, budget_s: float
+    ) -> AsyncEnv:
+        """Recover the instance a duplicate-create 409 points at.
+
+        running -> return it; still provisioning -> poll out the remaining
+        create budget; error/stopped (the original attempt failed or the
+        instance already died) -> raise instead of handing back a dead env.
+        """
+        deadline = time.monotonic() + max(budget_s, DUPLICATE_RECOVERY_MIN_BUDGET_S)
+        while True:
+            env = await self.instance(instance_id)
+            status = env.status
+            if status == "running":
+                logger.warning(
+                    "Create request was already processed; recovered running "
+                    "instance %s",
+                    instance_id,
+                )
+                return env
+            if status in ("error", "stopped"):
+                raise FleetConflictError(
+                    f"Duplicate create request points at instance "
+                    f"'{instance_id}' in state '{status}': the original "
+                    "attempt did not produce a usable environment. Retry "
+                    "the create as a new request.",
+                    instance_id=instance_id,
+                )
+            if time.monotonic() >= deadline:
+                raise FleetTimeoutError(
+                    f"Instance '{instance_id}' recovered from a duplicate "
+                    f"create request was still '{status}' when the create "
+                    "budget ran out."
+                )
+            await asyncio.sleep(DUPLICATE_RECOVERY_POLL_INTERVAL_S)
 
     async def make_for_task(self, task: Task) -> AsyncEnv:
         return await self.make(env_key=f"{task.env_id}:{task.version}")

--- a/fleet/_async/env/client.py
+++ b/fleet/_async/env/client.py
@@ -12,6 +12,8 @@ async def make_async(
     ttl_seconds: Optional[int] = None,
     run_id: Optional[str] = None,
     heartbeat_interval: Optional[int] = None,
+    timeout: Optional[float] = None,
+    max_wait_seconds: Optional[int] = None,
 ) -> AsyncEnv:
     return await AsyncFleet().make(
         env_key,
@@ -22,6 +24,8 @@ async def make_async(
         ttl_seconds=ttl_seconds,
         run_id=run_id,
         heartbeat_interval=heartbeat_interval,
+        timeout=timeout,
+        max_wait_seconds=max_wait_seconds,
     )
 
 

--- a/fleet/_async/exceptions.py
+++ b/fleet/_async/exceptions.py
@@ -137,6 +137,25 @@ class FleetTeamNotFoundError(FleetPermissionError):
         self.team_id = team_id
 
 
+class FleetConflictError(FleetAPIError):
+    """Exception raised when there's a conflict (e.g., resource already exists).
+
+    For duplicate-create conflicts (409 duplicate_request_id), ``instance_id``
+    points at the instance the original request produced, so callers can
+    recover the result instead of failing.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        resource_name: Optional[str] = None,
+        instance_id: Optional[str] = None,
+    ):
+        super().__init__(message, status_code=409)
+        self.resource_name = resource_name
+        self.instance_id = instance_id
+
+
 class FleetEnvironmentError(FleetError):
     """Exception raised when environment operations fail."""
 

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -104,6 +104,7 @@ class SyncWrapper(BaseWrapper):
             pass
 
         # Try to parse error response as JSON
+        duplicate_instance_id = None
         try:
             error_data = response.json()
             detail = error_data.get("detail", response.text)
@@ -121,6 +122,8 @@ class SyncWrapper(BaseWrapper):
                     )
                 else:
                     error_message = detail.get("message", str(detail))
+                if detail.get("error") == "duplicate_request_id":
+                    duplicate_instance_id = detail.get("instance_id")
             else:
                 error_message = detail
 
@@ -244,7 +247,11 @@ class SyncWrapper(BaseWrapper):
                 parts = error_message.split("'")
                 if len(parts) >= 2:
                     resource_name = parts[1]
-            raise FleetConflictError(error_message, resource_name=resource_name)
+            raise FleetConflictError(
+                error_message,
+                resource_name=resource_name,
+                instance_id=duplicate_instance_id,
+            )
         else:
             raise FleetAPIError(
                 error_message,

--- a/fleet/client.py
+++ b/fleet/client.py
@@ -172,9 +172,12 @@ from .instance.models import (
 from .config import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_TIMEOUT,
+    DEFAULT_CREATE_TIMEOUT,
+    CREATE_MAX_WAIT_MARGIN_S,
     REGION_BASE_URL,
     GLOBAL_BASE_URL,
 )
+from .exceptions import FleetConflictError
 from .instance.base import default_httpx_client
 from .instance.client import ValidatorType
 from .resources.base import Resource
@@ -563,6 +566,8 @@ class Fleet:
         ttl_seconds: Optional[int] = None,
         run_id: Optional[str] = None,
         heartbeat_interval: Optional[int] = None,
+        timeout: Optional[float] = None,
+        max_wait_seconds: Optional[int] = None,
     ) -> SyncEnv:
         if ":" in env_key:
             env_key_part, env_version = env_key.split(":", 1)
@@ -588,6 +593,15 @@ class Fleet:
             data_key_part = data_key
             data_version = None
 
+        # Creates can wait on real infrastructure (node launch, image pull,
+        # seed hydration), so they run on their own budget: the server is
+        # asked to wait slightly less than the HTTP read timeout so a slow
+        # create returns a response instead of a client-side timeout.
+        create_timeout = DEFAULT_CREATE_TIMEOUT if timeout is None else timeout
+        if max_wait_seconds is None:
+            max_wait_seconds = max(int(create_timeout) - CREATE_MAX_WAIT_MARGIN_S, 0)
+        max_wait_seconds = min(max_wait_seconds, 3600)
+
         request = InstanceRequest(
             env_key=env_key_part,
             env_version=env_version,
@@ -600,6 +614,7 @@ class Fleet:
             ttl_seconds=ttl_seconds,
             run_id=run_id,
             heartbeat_interval=heartbeat_interval,
+            max_wait_seconds=max_wait_seconds,
         )
 
         # Only use region-specific base URL if no custom base URL is set
@@ -607,12 +622,25 @@ class Fleet:
         if region and self.client.base_url == GLOBAL_BASE_URL:
             base_url = REGION_BASE_URL.get(region)
 
-        response = self.client.request(
-            "POST",
-            "/v1/env/instances",
-            json=request.model_dump(exclude_none=True),
-            base_url=base_url,
-        )
+        try:
+            response = self.client.request(
+                "POST",
+                "/v1/env/instances",
+                json=request.model_dump(exclude_none=True),
+                base_url=base_url,
+                timeout=create_timeout,
+            )
+        except FleetConflictError as e:
+            # duplicate_request_id: a transport-level retry re-POSTed a create
+            # whose first attempt already succeeded server-side. Recover the
+            # original instance instead of failing the call.
+            if e.instance_id:
+                logger.warning(
+                    "Create request was already processed; recovering instance %s",
+                    e.instance_id,
+                )
+                return self.instance(e.instance_id)
+            raise
 
         instance = SyncEnv(client=self.client, **response.json())
         return instance

--- a/fleet/client.py
+++ b/fleet/client.py
@@ -22,6 +22,7 @@ import httpx
 import json
 import logging
 import os
+import time
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -177,7 +178,7 @@ from .config import (
     REGION_BASE_URL,
     GLOBAL_BASE_URL,
 )
-from .exceptions import FleetConflictError
+from .exceptions import FleetConflictError, FleetTimeoutError
 from .instance.base import default_httpx_client
 from .instance.client import ValidatorType
 from .resources.base import Resource
@@ -188,6 +189,12 @@ from .resources.mcp import SyncMCPResource
 from .resources.api import APIResource
 
 logger = logging.getLogger(__name__)
+
+# Duplicate-create recovery: how often to re-check a still-provisioning
+# instance, and the minimum budget granted even when the create timeout is
+# nearly spent (one meaningful poll beats an instant timeout).
+DUPLICATE_RECOVERY_POLL_INTERVAL_S = 5.0
+DUPLICATE_RECOVERY_MIN_BUDGET_S = 30.0
 
 
 class Session:
@@ -622,6 +629,7 @@ class Fleet:
         if region and self.client.base_url == GLOBAL_BASE_URL:
             base_url = REGION_BASE_URL.get(region)
 
+        create_started = time.monotonic()
         try:
             response = self.client.request(
                 "POST",
@@ -632,18 +640,51 @@ class Fleet:
             )
         except FleetConflictError as e:
             # duplicate_request_id: a transport-level retry re-POSTed a create
-            # whose first attempt already succeeded server-side. Recover the
-            # original instance instead of failing the call.
+            # the server had already accepted for this request id. The pointed
+            # instance may still be provisioning (the id is bound at insert,
+            # before the create finishes) or may have already died, so recover
+            # by status instead of returning it blindly.
             if e.instance_id:
-                logger.warning(
-                    "Create request was already processed; recovering instance %s",
-                    e.instance_id,
-                )
-                return self.instance(e.instance_id)
+                remaining = create_timeout - (time.monotonic() - create_started)
+                return self._recover_duplicate_create(e.instance_id, remaining)
             raise
 
         instance = SyncEnv(client=self.client, **response.json())
         return instance
+
+    def _recover_duplicate_create(self, instance_id: str, budget_s: float) -> SyncEnv:
+        """Recover the instance a duplicate-create 409 points at.
+
+        running -> return it; still provisioning -> poll out the remaining
+        create budget; error/stopped (the original attempt failed or the
+        instance already died) -> raise instead of handing back a dead env.
+        """
+        deadline = time.monotonic() + max(budget_s, DUPLICATE_RECOVERY_MIN_BUDGET_S)
+        while True:
+            env = self.instance(instance_id)
+            status = env.status
+            if status == "running":
+                logger.warning(
+                    "Create request was already processed; recovered running "
+                    "instance %s",
+                    instance_id,
+                )
+                return env
+            if status in ("error", "stopped"):
+                raise FleetConflictError(
+                    f"Duplicate create request points at instance "
+                    f"'{instance_id}' in state '{status}': the original "
+                    "attempt did not produce a usable environment. Retry "
+                    "the create as a new request.",
+                    instance_id=instance_id,
+                )
+            if time.monotonic() >= deadline:
+                raise FleetTimeoutError(
+                    f"Instance '{instance_id}' recovered from a duplicate "
+                    f"create request was still '{status}' when the create "
+                    "budget ran out."
+                )
+            time.sleep(DUPLICATE_RECOVERY_POLL_INTERVAL_S)
 
     def make_for_task(self, task: Task) -> SyncEnv:
         return self.make(env_key=f"{task.env_id}:{task.version}")

--- a/fleet/config.py
+++ b/fleet/config.py
@@ -1,6 +1,13 @@
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_TIMEOUT = 300.0
 
+# Instance creates can legitimately take several minutes (node launch, image
+# pull, seed hydration), so they get their own HTTP budget instead of
+# DEFAULT_TIMEOUT. The server is told to wait CREATE_MAX_WAIT_MARGIN_S less
+# than the client so slow creates come back as responses, not read timeouts.
+DEFAULT_CREATE_TIMEOUT = 900.0
+CREATE_MAX_WAIT_MARGIN_S = 30
+
 GLOBAL_BASE_URL = "https://orchestrator.fleetai.com"
 REGION_BASE_URL = {
     "us-west-1": "https://us-west-1.fleetai.com",

--- a/fleet/env/client.py
+++ b/fleet/env/client.py
@@ -12,6 +12,8 @@ def make(
     ttl_seconds: Optional[int] = None,
     run_id: Optional[str] = None,
     heartbeat_interval: Optional[int] = None,
+    timeout: Optional[float] = None,
+    max_wait_seconds: Optional[int] = None,
 ) -> SyncEnv:
     return Fleet().make(
         env_key,
@@ -22,6 +24,8 @@ def make(
         ttl_seconds=ttl_seconds,
         run_id=run_id,
         heartbeat_interval=heartbeat_interval,
+        timeout=timeout,
+        max_wait_seconds=max_wait_seconds,
     )
 
 

--- a/fleet/exceptions.py
+++ b/fleet/exceptions.py
@@ -138,11 +138,22 @@ class FleetTeamNotFoundError(FleetPermissionError):
 
 
 class FleetConflictError(FleetAPIError):
-    """Exception raised when there's a conflict (e.g., resource already exists)."""
+    """Exception raised when there's a conflict (e.g., resource already exists).
 
-    def __init__(self, message: str, resource_name: Optional[str] = None):
+    For duplicate-create conflicts (409 duplicate_request_id), ``instance_id``
+    points at the instance the original request produced, so callers can
+    recover the result instead of failing.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        resource_name: Optional[str] = None,
+        instance_id: Optional[str] = None,
+    ):
         super().__init__(message, status_code=409)
         self.resource_name = resource_name
+        self.instance_id = instance_id
 
 
 class FleetEnvironmentError(FleetError):

--- a/fleet/models.py
+++ b/fleet/models.py
@@ -72,6 +72,7 @@ class InstanceRequest(BaseModel):
     created_from: Optional[str] = Field(None, title="Created From")
     ttl_seconds: Optional[int] = Field(None, title="TTL Seconds")
     heartbeat_interval: Optional[int] = Field(None, title="Heartbeat Interval")
+    max_wait_seconds: Optional[int] = Field(None, title="Max Wait Seconds")
 
 
 class InstanceStatus(Enum):

--- a/tests/test_make_create_wait.py
+++ b/tests/test_make_create_wait.py
@@ -1,0 +1,203 @@
+"""Tests for instance-create wait declaration and duplicate-request recovery.
+
+Covers Fleet.make() / AsyncFleet.make():
+- max_wait_seconds derived from the create timeout (timeout - margin, capped)
+- explicit max_wait_seconds wins over derivation
+- the create request uses the create timeout, not the client default
+- 409 duplicate_request_id with an instance_id pointer recovers the original
+  instance; a 409 without a pointer is re-raised
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from fleet.client import Fleet
+from fleet._async.client import AsyncFleet
+from fleet.config import CREATE_MAX_WAIT_MARGIN_S, DEFAULT_CREATE_TIMEOUT
+from fleet.exceptions import FleetConflictError as SyncFleetConflictError
+from fleet._async.exceptions import FleetConflictError as AsyncFleetConflictError
+
+
+def _instance_payload(instance_id: str = "inst-123") -> dict:
+    return {
+        "instance_id": instance_id,
+        "env_key": "fira",
+        "version": "v0.0.69",
+        "status": "running",
+        "subdomain": f"{instance_id}.us-east-1",
+        "created_at": "2026-07-17T00:00:00Z",
+        "updated_at": "2026-07-17T00:00:00Z",
+        "terminated_at": None,
+        "team_id": "team-1",
+        "region": "us-east-1",
+        "env_variables": None,
+        "data_key": None,
+        "data_version": None,
+        "urls": None,
+        "health": True,
+    }
+
+
+def _response_with(payload: dict) -> Mock:
+    response = Mock()
+    response.json.return_value = payload
+    return response
+
+
+@pytest.fixture
+def fleet_client():
+    with patch("fleet.client.default_httpx_client") as mock_factory:
+        mock_factory.return_value = Mock()
+        client = Fleet(api_key="test_key")
+        client.client.request = Mock(return_value=_response_with(_instance_payload()))
+        yield client
+
+
+@pytest.fixture
+def async_fleet_client():
+    with patch("fleet._async.client.default_httpx_client") as mock_factory:
+        mock_factory.return_value = Mock()
+        client = AsyncFleet(api_key="test_key")
+        client.client.request = AsyncMock(
+            return_value=_response_with(_instance_payload())
+        )
+        yield client
+
+
+def _create_call(mock_request) -> dict:
+    call = mock_request.call_args
+    assert call.args[0] == "POST"
+    assert call.args[1] == "/v1/env/instances"
+    return call.kwargs
+
+
+class TestMakeWaitDeclaration:
+    def test_default_timeout_declares_wait(self, fleet_client):
+        fleet_client.make("fira")
+        kwargs = _create_call(fleet_client.client.request)
+        assert kwargs["timeout"] == DEFAULT_CREATE_TIMEOUT
+        assert kwargs["json"]["max_wait_seconds"] == (
+            int(DEFAULT_CREATE_TIMEOUT) - CREATE_MAX_WAIT_MARGIN_S
+        )
+
+    def test_explicit_timeout_derives_wait(self, fleet_client):
+        fleet_client.make("fira", timeout=300.0)
+        kwargs = _create_call(fleet_client.client.request)
+        assert kwargs["timeout"] == 300.0
+        assert kwargs["json"]["max_wait_seconds"] == 300 - CREATE_MAX_WAIT_MARGIN_S
+
+    def test_explicit_max_wait_wins(self, fleet_client):
+        fleet_client.make("fira", timeout=300.0, max_wait_seconds=120)
+        kwargs = _create_call(fleet_client.client.request)
+        assert kwargs["json"]["max_wait_seconds"] == 120
+
+    def test_max_wait_capped_at_3600(self, fleet_client):
+        fleet_client.make("fira", timeout=7200.0)
+        kwargs = _create_call(fleet_client.client.request)
+        assert kwargs["json"]["max_wait_seconds"] == 3600
+
+    def test_tiny_timeout_floors_at_zero(self, fleet_client):
+        fleet_client.make("fira", timeout=10.0)
+        kwargs = _create_call(fleet_client.client.request)
+        assert kwargs["json"]["max_wait_seconds"] == 0
+
+    async def test_async_default_timeout_declares_wait(self, async_fleet_client):
+        await async_fleet_client.make("fira")
+        kwargs = _create_call(async_fleet_client.client.request)
+        assert kwargs["timeout"] == DEFAULT_CREATE_TIMEOUT
+        assert kwargs["json"]["max_wait_seconds"] == (
+            int(DEFAULT_CREATE_TIMEOUT) - CREATE_MAX_WAIT_MARGIN_S
+        )
+
+
+class TestMakeDuplicateRecovery:
+    def test_conflict_with_pointer_recovers_instance(self, fleet_client):
+        conflict = SyncFleetConflictError(
+            "Request with ID 'abc' has already been processed.",
+            instance_id="inst-orig",
+        )
+        fleet_client.client.request.side_effect = [
+            conflict,
+            _response_with(_instance_payload("inst-orig")),
+        ]
+
+        env = fleet_client.make("fira")
+
+        assert env.instance_id == "inst-orig"
+        recovery_call = fleet_client.client.request.call_args_list[1]
+        assert recovery_call.args[0] == "GET"
+        assert recovery_call.args[1] == "/v1/env/instances/inst-orig"
+
+    def test_conflict_without_pointer_reraises(self, fleet_client):
+        fleet_client.client.request.side_effect = SyncFleetConflictError(
+            "Request with ID 'abc' has already been processed."
+        )
+        with pytest.raises(SyncFleetConflictError):
+            fleet_client.make("fira")
+
+    async def test_async_conflict_with_pointer_recovers_instance(
+        self, async_fleet_client
+    ):
+        conflict = AsyncFleetConflictError(
+            "Request with ID 'abc' has already been processed.",
+            instance_id="inst-orig",
+        )
+        async_fleet_client.client.request.side_effect = [
+            conflict,
+            _response_with(_instance_payload("inst-orig")),
+        ]
+
+        env = await async_fleet_client.make("fira")
+
+        assert env.instance_id == "inst-orig"
+        recovery_call = async_fleet_client.client.request.call_args_list[1]
+        assert recovery_call.args[0] == "GET"
+        assert recovery_call.args[1] == "/v1/env/instances/inst-orig"
+
+
+class TestConflictErrorParsing:
+    def test_sync_409_detail_carries_instance_pointer(self):
+        from fleet.base import SyncWrapper
+
+        wrapper = SyncWrapper.__new__(SyncWrapper)
+        response = Mock()
+        response.status_code = 409
+        response.json.return_value = {
+            "detail": {
+                "error": "duplicate_request_id",
+                "message": "Request with ID 'abc' has already been processed.",
+                "instance_id": "inst-orig",
+            }
+        }
+        with pytest.raises(SyncFleetConflictError) as exc_info:
+            wrapper._handle_error_response(response)
+        assert exc_info.value.instance_id == "inst-orig"
+
+    def test_async_409_detail_carries_instance_pointer(self):
+        from fleet._async.base import AsyncWrapper
+
+        wrapper = AsyncWrapper.__new__(AsyncWrapper)
+        response = Mock()
+        response.status_code = 409
+        response.json.return_value = {
+            "detail": {
+                "error": "duplicate_request_id",
+                "message": "Request with ID 'abc' has already been processed.",
+                "instance_id": "inst-orig",
+            }
+        }
+        with pytest.raises(AsyncFleetConflictError) as exc_info:
+            wrapper._handle_error_response(response)
+        assert exc_info.value.instance_id == "inst-orig"
+
+    def test_sync_409_without_structured_detail(self):
+        from fleet.base import SyncWrapper
+
+        wrapper = SyncWrapper.__new__(SyncWrapper)
+        response = Mock()
+        response.status_code = 409
+        response.json.return_value = {"detail": "resource 'foo' already exists"}
+        with pytest.raises(SyncFleetConflictError) as exc_info:
+            wrapper._handle_error_response(response)
+        assert exc_info.value.instance_id is None
+        assert exc_info.value.resource_name == "foo"

--- a/tests/test_make_create_wait.py
+++ b/tests/test_make_create_wait.py
@@ -18,12 +18,12 @@ from fleet.exceptions import FleetConflictError as SyncFleetConflictError
 from fleet._async.exceptions import FleetConflictError as AsyncFleetConflictError
 
 
-def _instance_payload(instance_id: str = "inst-123") -> dict:
+def _instance_payload(instance_id: str = "inst-123", status: str = "running") -> dict:
     return {
         "instance_id": instance_id,
         "env_key": "fira",
         "version": "v0.0.69",
-        "status": "running",
+        "status": status,
         "subdomain": f"{instance_id}.us-east-1",
         "created_at": "2026-07-17T00:00:00Z",
         "updated_at": "2026-07-17T00:00:00Z",
@@ -111,13 +111,24 @@ class TestMakeWaitDeclaration:
 
 
 class TestMakeDuplicateRecovery:
-    def test_conflict_with_pointer_recovers_instance(self, fleet_client):
-        conflict = SyncFleetConflictError(
+    @pytest.fixture(autouse=True)
+    def fast_recovery(self, monkeypatch):
+        import fleet.client as sync_client
+        import fleet._async.client as async_client
+
+        for mod in (sync_client, async_client):
+            monkeypatch.setattr(mod, "DUPLICATE_RECOVERY_POLL_INTERVAL_S", 0.001)
+            monkeypatch.setattr(mod, "DUPLICATE_RECOVERY_MIN_BUDGET_S", 0.05)
+
+    def _conflict(self, cls=SyncFleetConflictError):
+        return cls(
             "Request with ID 'abc' has already been processed.",
             instance_id="inst-orig",
         )
+
+    def test_conflict_with_running_pointer_recovers_instance(self, fleet_client):
         fleet_client.client.request.side_effect = [
-            conflict,
+            self._conflict(),
             _response_with(_instance_payload("inst-orig")),
         ]
 
@@ -128,6 +139,50 @@ class TestMakeDuplicateRecovery:
         assert recovery_call.args[0] == "GET"
         assert recovery_call.args[1] == "/v1/env/instances/inst-orig"
 
+    def test_conflict_with_pending_pointer_polls_until_running(self, fleet_client):
+        fleet_client.client.request.side_effect = [
+            self._conflict(),
+            _response_with(_instance_payload("inst-orig", status="pending")),
+            _response_with(_instance_payload("inst-orig", status="pending")),
+            _response_with(_instance_payload("inst-orig", status="running")),
+        ]
+
+        env = fleet_client.make("fira")
+
+        assert env.instance_id == "inst-orig"
+        assert env.status == "running"
+        assert fleet_client.client.request.call_count == 4
+
+    def test_conflict_with_error_pointer_raises(self, fleet_client):
+        fleet_client.client.request.side_effect = [
+            self._conflict(),
+            _response_with(_instance_payload("inst-orig", status="error")),
+        ]
+
+        with pytest.raises(SyncFleetConflictError) as exc_info:
+            fleet_client.make("fira")
+        assert exc_info.value.instance_id == "inst-orig"
+        assert "'error'" in str(exc_info.value)
+
+    def test_conflict_with_stopped_pointer_raises(self, fleet_client):
+        fleet_client.client.request.side_effect = [
+            self._conflict(),
+            _response_with(_instance_payload("inst-orig", status="stopped")),
+        ]
+
+        with pytest.raises(SyncFleetConflictError):
+            fleet_client.make("fira")
+
+    def test_conflict_with_stuck_pending_pointer_times_out(self, fleet_client):
+        from fleet.exceptions import FleetTimeoutError
+
+        fleet_client.client.request.side_effect = [self._conflict()] + [
+            _response_with(_instance_payload("inst-orig", status="pending"))
+        ] * 1000
+
+        with pytest.raises(FleetTimeoutError):
+            fleet_client.make("fira", timeout=0.1)
+
     def test_conflict_without_pointer_reraises(self, fleet_client):
         fleet_client.client.request.side_effect = SyncFleetConflictError(
             "Request with ID 'abc' has already been processed."
@@ -135,15 +190,11 @@ class TestMakeDuplicateRecovery:
         with pytest.raises(SyncFleetConflictError):
             fleet_client.make("fira")
 
-    async def test_async_conflict_with_pointer_recovers_instance(
+    async def test_async_conflict_with_running_pointer_recovers_instance(
         self, async_fleet_client
     ):
-        conflict = AsyncFleetConflictError(
-            "Request with ID 'abc' has already been processed.",
-            instance_id="inst-orig",
-        )
         async_fleet_client.client.request.side_effect = [
-            conflict,
+            self._conflict(AsyncFleetConflictError),
             _response_with(_instance_payload("inst-orig")),
         ]
 
@@ -153,6 +204,42 @@ class TestMakeDuplicateRecovery:
         recovery_call = async_fleet_client.client.request.call_args_list[1]
         assert recovery_call.args[0] == "GET"
         assert recovery_call.args[1] == "/v1/env/instances/inst-orig"
+
+    async def test_async_conflict_with_pending_pointer_polls_until_running(
+        self, async_fleet_client
+    ):
+        async_fleet_client.client.request.side_effect = [
+            self._conflict(AsyncFleetConflictError),
+            _response_with(_instance_payload("inst-orig", status="pending")),
+            _response_with(_instance_payload("inst-orig", status="running")),
+        ]
+
+        env = await async_fleet_client.make("fira")
+
+        assert env.status == "running"
+        assert async_fleet_client.client.request.call_count == 3
+
+    async def test_async_conflict_with_error_pointer_raises(self, async_fleet_client):
+        async_fleet_client.client.request.side_effect = [
+            self._conflict(AsyncFleetConflictError),
+            _response_with(_instance_payload("inst-orig", status="error")),
+        ]
+
+        with pytest.raises(AsyncFleetConflictError) as exc_info:
+            await async_fleet_client.make("fira")
+        assert exc_info.value.instance_id == "inst-orig"
+
+    async def test_async_conflict_with_stuck_pending_pointer_times_out(
+        self, async_fleet_client
+    ):
+        from fleet._async.exceptions import FleetTimeoutError as AsyncFleetTimeoutError
+
+        async_fleet_client.client.request.side_effect = [
+            self._conflict(AsyncFleetConflictError)
+        ] + [_response_with(_instance_payload("inst-orig", status="pending"))] * 1000
+
+        with pytest.raises(AsyncFleetTimeoutError):
+            await async_fleet_client.make("fira", timeout=0.1)
 
 
 class TestConflictErrorParsing:


### PR DESCRIPTION
## What

Three changes to instance creation, all client-side:

1. **Dedicated create timeout.** `make()` (sync/async, all entry points) now uses `DEFAULT_CREATE_TIMEOUT = 900s` for the create request instead of the client-wide 300s default. Overridable per call: `fleet.env.make("fira", timeout=600)`. The server bounds the actual wait (600s ceiling today); 900s is a network-failure backstop with headroom for future ceiling raises (up to 810s) without an SDK re-release.
2. **Server wait declaration.** Creates send `max_wait_seconds = timeout − 30` (clamped to [0, 3600]) so the orchestrator can hold the request up to its server-side ceiling and return a real response instead of the client timing out mid-create. Explicit `max_wait_seconds=` wins over derivation. Requires orchestrator ≥ fleet-ai/theseus#18438 (in prod); older servers ignore the extra field.
3. **Status-aware duplicate-request recovery.** The transport retries POSTs on 5xx/504 *and* on `TimeoutException`/`NetworkError`/`RemoteProtocolError`, re-sending the same `X-Request-ID`. The orchestrator (fleet-ai/theseus#18432 + #18446) answers such replays with 409 `duplicate_request_id` + an `instance_id` pointer that is bound at insert time — before provisioning finishes — so the pointed instance may be pending, running, or already dead. `make()` now recovers by status:
   - `running` → return it
   - `pending`/`queued` → poll (5s interval) within the remaining create budget; budget exhausted → `FleetTimeoutError`
   - `error`/`stopped` → raise `FleetConflictError` with the pointer (the original attempt did not produce a usable environment)
   - 409 without a pointer → raise as before

## Parity fix

`FleetConflictError` and the 409 branch in `_handle_error_response` existed only in the generated sync tree — the async source tree never got them. Both trees now match (edited by hand on both sides, consistent with recent practice; `make unasync` is not run because `fleet/models.py` has drifted from `fleet/_async/models.py` and regeneration would clobber it).

## Why

The 2026-07-15 nez incident chain: creates that wait on real infrastructure (node launch, image pull, seed hydration) blew through the 300s client timeout, httpx-retries re-POSTed with the same request id, and before server-side idempotency landed that meant duplicate instances; after it landed, harness retries of *failed* creates saw 409s (fixed in fleet-ai/theseus#18446). This PR is the client half: give creates enough budget, tell the server how long the client will actually wait, and turn lost-response replays into status-checked recoveries.

## Tests

`tests/test_make_create_wait.py` — 19 tests: wait derivation (default/explicit/override/clamp/floor), recovery for running/pending→running/error/stopped/stuck-pending-timeout/no-pointer (sync + async), and 409 detail parsing through both error handlers. Full suite: 741 passed; the 5 pre-existing `tests/track/test_mcp_install.py` failures are unrelated and fail identically on clean main.

## Live validation (prod orchestrator, 2026-07-17)

- `make("fira:v0.0.69", data_key="aequus:v0.0.1")` → running in 14.1s; Logfire confirms the declared wait shaped server budgets (`infra_timeout_ms=450000, health_check_timeout_ms=150000` = the 600s declared-sync split, vs 240s undeclared legacy).
- Same-request-id replay → `FleetConflictError` with correct `instance_id` pointer.
- Recovery running-branch → returned the pointed instance; after deleting it, recovery raised `FleetConflictError` (state `stopped`) instead of returning a dead env.
- All test instances cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
