### PR TITLE
PLAT-423: release verifier judge cost-team propagation as v0.2.132

### DIFF
--- a/fleet/__init__.py
+++ b/fleet/__init__.py
@@ -78,7 +78,7 @@ from . import env
 from . import global_client as _global_client
 from ._async import global_client as _async_global_client
 
-__version__ = "0.2.130"
+__version__ = "0.2.132"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/__init__.py
+++ b/fleet/_async/__init__.py
@@ -44,7 +44,7 @@ from ..types import VerifierFunction
 from .. import env
 from . import global_client as _async_global_client
 
-__version__ = "0.2.130"
+__version__ = "0.2.132"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/base.py
+++ b/fleet/_async/base.py
@@ -27,7 +27,7 @@ from .exceptions import (
 try:
     from .. import __version__
 except ImportError:
-    __version__ = "0.2.130"
+    __version__ = "0.2.132"
 
 logger = logging.getLogger(__name__)
 

--- a/fleet/_async/judge.py
+++ b/fleet/_async/judge.py
@@ -3,7 +3,6 @@
 Provides env.judge.grade() for async verifier scripts.
 """
 
-import os
 from typing import Dict, List, Optional, Union, TYPE_CHECKING
 
 # Import shared classes and helpers from the sync module
@@ -14,6 +13,7 @@ from ..judge import (
     JudgeResult,
     Rubric,
     _build_grade_request,
+    _build_judge_headers,
     _collect_file_from_env_async,
     _collect_image_from_env_async,
     _guess_file_media_type,
@@ -148,12 +148,13 @@ class AsyncJudge:
             task_id=task_id,
         )
 
-        _print_judge_call_start(rubric, resolved_images, agentic, model, files=resolved_files)
-        extra_headers = None
-        token = os.environ.get("FLEET_JUDGE_TOKEN")
-        if token:
-            extra_headers = {"X-Fleet-Judge-Token": token}
+        _print_judge_call_start(
+            rubric, resolved_images, agentic, model, files=resolved_files
+        )
         response = await self._client.request(
-            "POST", "/v1/judge/grade", json=body, extra_headers=extra_headers
+            "POST",
+            "/v1/judge/grade",
+            json=body,
+            extra_headers=_build_judge_headers(),
         )
         return _parse_grade_response(response.json())

--- a/fleet/base.py
+++ b/fleet/base.py
@@ -27,7 +27,7 @@ from .exceptions import (
 try:
     from . import __version__
 except ImportError:
-    __version__ = "0.2.130"
+    __version__ = "0.2.132"
 
 logger = logging.getLogger(__name__)
 

--- a/fleet/judge.py
+++ b/fleet/judge.py
@@ -19,10 +19,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+JUDGE_TOKEN_HEADER = "X-Fleet-Judge-Token"
+JUDGE_COST_TEAM_HEADER = "X-Fleet-Cost-Team-ID"
+
 
 # ---------------------------------------------------------------------------
 # Data classes (used by both sync and async)
 # ---------------------------------------------------------------------------
+
+
+def _build_judge_headers() -> Optional[Dict[str, str]]:
+    """Build verifier-runtime context headers for the judge request."""
+    headers: Dict[str, str] = {}
+
+    token = os.environ.get("FLEET_JUDGE_TOKEN")
+    if token:
+        headers[JUDGE_TOKEN_HEADER] = token
+
+    cost_team_id = os.environ.get("FLEET_COST_TEAM_ID", "").strip()
+    if cost_team_id:
+        headers[JUDGE_COST_TEAM_HEADER] = cost_team_id
+
+    return headers or None
 
 
 def _guess_media_type(filename: str) -> str:
@@ -215,7 +233,8 @@ class Image:
             d = {
                 "source": "base64",
                 "data": self.data,
-                "media_type": self.media_type or _guess_media_type(self.filename or "image.png"),
+                "media_type": self.media_type
+                or _guess_media_type(self.filename or "image.png"),
             }
         elif self.source == "collect":
             d = {"source": "collect", "selector": self.filename}
@@ -307,7 +326,8 @@ class File:
                 "source": "base64",
                 "data": self.data,
                 "filename": self.filename,
-                "media_type": self.media_type or _guess_file_media_type(self.filename or "file"),
+                "media_type": self.media_type
+                or _guess_file_media_type(self.filename or "file"),
             }
         elif self.source == "collect":
             d = {"source": "collect", "selector": self.filename}
@@ -397,7 +417,9 @@ def _collect_image_from_env(env: Any, filename: str) -> Optional[str]:
         current = env.db("current")
         where = f"path = '{filename}' OR path LIKE '%/{filename}'"
         rows = _extract_query_rows(
-            current.query(f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}")
+            current.query(
+                f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}"
+            )
         )
         candidates = {}
         for row in rows:
@@ -434,14 +456,20 @@ def _collect_image_from_env(env: Any, filename: str) -> Optional[str]:
                 nb = json.loads(nb_bytes.decode("utf-8"))
                 for cell in reversed(nb.get("cells", [])):
                     for output in cell.get("outputs", []):
-                        if output.get("output_type") in ("display_data", "execute_result"):
+                        if output.get("output_type") in (
+                            "display_data",
+                            "execute_result",
+                        ):
                             img_data = output.get("data", {}).get("image/png")
                             if img_data:
                                 if isinstance(img_data, list):
                                     img_data = "".join(img_data)
                                 img_data = img_data.strip()
                                 if img_data:
-                                    logger.debug("Loaded image from notebook: %s", nb_row.get("path"))
+                                    logger.debug(
+                                        "Loaded image from notebook: %s",
+                                        nb_row.get("path"),
+                                    )
                                     return img_data
             except Exception:
                 pass
@@ -477,7 +505,9 @@ async def _collect_image_from_env_async(env: Any, filename: str) -> Optional[str
         current = env.db("current")
         where = f"path = '{filename}' OR path LIKE '%/{filename}'"
         rows = _extract_query_rows(
-            await current.query(f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}")
+            await current.query(
+                f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}"
+            )
         )
         candidates = {}
         for row in rows:
@@ -514,14 +544,20 @@ async def _collect_image_from_env_async(env: Any, filename: str) -> Optional[str
                 nb = json.loads(nb_bytes.decode("utf-8"))
                 for cell in reversed(nb.get("cells", [])):
                     for output in cell.get("outputs", []):
-                        if output.get("output_type") in ("display_data", "execute_result"):
+                        if output.get("output_type") in (
+                            "display_data",
+                            "execute_result",
+                        ):
                             img_data = output.get("data", {}).get("image/png")
                             if img_data:
                                 if isinstance(img_data, list):
                                     img_data = "".join(img_data)
                                 img_data = img_data.strip()
                                 if img_data:
-                                    logger.debug("Loaded image from notebook (async): %s", nb_row.get("path"))
+                                    logger.debug(
+                                        "Loaded image from notebook (async): %s",
+                                        nb_row.get("path"),
+                                    )
                                     return img_data
             except Exception:
                 pass
@@ -557,7 +593,9 @@ def _collect_file_from_env(env: Any, filename: str) -> Optional[str]:
         current = env.db("current")
         where = f"path = '{filename}' OR path LIKE '%/{filename}'"
         rows = _extract_query_rows(
-            current.query(f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}")
+            current.query(
+                f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}"
+            )
         )
         candidates = {}
         for row in rows:
@@ -605,7 +643,9 @@ async def _collect_file_from_env_async(env: Any, filename: str) -> Optional[str]
         current = env.db("current")
         where = f"path = '{filename}' OR path LIKE '%/{filename}'"
         rows = _extract_query_rows(
-            await current.query(f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}")
+            await current.query(
+                f"SELECT path, hex(content) AS content_hex FROM files WHERE {where}"
+            )
         )
         candidates = {}
         for row in rows:
@@ -711,7 +751,9 @@ def _print_judge_call_start(
 
     if isinstance(rubric, Rubric):
         criteria_names = [c.name for c in rubric.criteria]
-        print(f"[C] Rubric: {len(rubric.criteria)} criteria ({', '.join(criteria_names)}), max={rubric.max_score}")
+        print(
+            f"[C] Rubric: {len(rubric.criteria)} criteria ({', '.join(criteria_names)}), max={rubric.max_score}"
+        )
 
     if images:
         for label, img in images.items():
@@ -800,15 +842,13 @@ def _build_grade_request(
     # Serialize images as labeled array
     if images:
         body["images"] = [
-            img.serialize(label=label, agentic=agentic)
-            for label, img in images.items()
+            img.serialize(label=label, agentic=agentic) for label, img in images.items()
         ]
 
     # Serialize files as labeled array
     if files:
         body["files"] = [
-            f.serialize(label=label, agentic=agentic)
-            for label, f in files.items()
+            f.serialize(label=label, agentic=agentic) for label, f in files.items()
         ]
 
     return body
@@ -956,11 +996,10 @@ class SyncJudge:
         )
 
         _print_judge_call_start(rubric, images, agentic, model, files=files)
-        extra_headers = None
-        token = os.environ.get("FLEET_JUDGE_TOKEN")
-        if token:
-            extra_headers = {"X-Fleet-Judge-Token": token}
         response = self._client.request(
-            "POST", "/v1/judge/grade", json=body, extra_headers=extra_headers
+            "POST",
+            "/v1/judge/grade",
+            json=body,
+            extra_headers=_build_judge_headers(),
         )
         return _parse_grade_response(response.json())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fleet-python"
 
-version = "0.2.131"
+version = "0.2.132"
 description = "Python SDK for Fleet environments"
 authors = [
     {name = "Fleet AI", email = "nic@fleet.so"},

--- a/tests/test_judge_cost_team_headers.py
+++ b/tests/test_judge_cost_team_headers.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from fleet._async.judge import AsyncJudge
+from fleet.judge import SyncJudge
+
+
+class _Response:
+    def json(self) -> dict:
+        return {"normalized_score": 1.0}
+
+
+def test_sync_judge_sends_cost_team_and_auth_headers(monkeypatch):
+    monkeypatch.setenv("FLEET_JUDGE_TOKEN", "judge-token")
+    monkeypatch.setenv("FLEET_COST_TEAM_ID", "11111111-1111-4111-8111-111111111111")
+    client = Mock()
+    client.request.return_value = _Response()
+
+    SyncJudge(client, "instance-1").grade("rubric", "submission")
+
+    assert client.request.call_args.kwargs["extra_headers"] == {
+        "X-Fleet-Judge-Token": "judge-token",
+        "X-Fleet-Cost-Team-ID": "11111111-1111-4111-8111-111111111111",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_judge_sends_cost_team_and_auth_headers(monkeypatch):
+    monkeypatch.setenv("FLEET_JUDGE_TOKEN", "judge-token")
+    monkeypatch.setenv("FLEET_COST_TEAM_ID", "22222222-2222-4222-8222-222222222222")
+    client = Mock()
+    client.request = AsyncMock(return_value=_Response())
+
+    await AsyncJudge(client, "instance-1").grade("rubric", "submission")
+
+    assert client.request.call_args.kwargs["extra_headers"] == {
+        "X-Fleet-Judge-Token": "judge-token",
+        "X-Fleet-Cost-Team-ID": "22222222-2222-4222-8222-222222222222",
+    }
+
+
+def test_sync_judge_omits_blank_cost_team_header(monkeypatch):
+    monkeypatch.setenv("FLEET_JUDGE_TOKEN", "judge-token")
+    monkeypatch.setenv("FLEET_COST_TEAM_ID", "   ")
+    client = Mock()
+    client.request.return_value = _Response()
+
+    SyncJudge(client, "instance-1").grade("rubric", "submission")
+
+    assert client.request.call_args.kwargs["extra_headers"] == {
+        "X-Fleet-Judge-Token": "judge-token"
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "fleet-python"
-version = "0.2.130"
+version = "0.2.132"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- release from the current fleet-python v0.2.131 lineage, which already includes verifier cost_team_id transport from #134
- read FLEET_COST_TEAM_ID inside sync and async env.judge.grade calls
- send X-Fleet-Cost-Team-ID alongside the existing judge token header when set
- omit blank cost-team values without inventing a fallback
- bump pyproject, lockfile, sync/async package versions, and fallback user-agent versions to 0.2.132

## Validation
- uv run --extra dev --with pytest-mock python -m pytest -q (212 passed, 11 skipped)
- uv run ruff check fleet/judge.py fleet/_async/judge.py tests/test_judge_cost_team_headers.py
- uv run ruff format --check fleet/judge.py fleet/_async/judge.py tests/test_judge_cost_team_headers.py
- package/import version consistency: 0.2.132
- python -m build + twine check (wheel and sdist passed)

## CI note
This repository currently has no pull_request test workflow. PR checks only run Cursor Bugbot. The publish workflow is tag-only; it validates fleet-python-v* against pyproject, builds, twine-checks, and publishes, but does not execute pytest. The local suite above is therefore the regression gate for this change.

## Dependency
Consumed by the linked Theseus PLAT-423 verifier runtime/orchestrator change: https://github.com/fleet-ai/theseus/pull/18506

Linear: https://linear.app/fleet-ai/issue/PLAT-423/implement-strict-llmaj-cost-team-propagation-through-verifier-runtime