### PR TITLE
fix(sqlite): don't parse a non-QueryResponse body as JSON

### DIFF
--- a/fleet/_async/resources/sqlite.py
+++ b/fleet/_async/resources/sqlite.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional, Dict, Tuple
 from ...instance.models import Resource as ResourceModel
 from ...instance.models import DescribeResponse, QueryRequest, QueryResponse
 from .base import Resource
+from ...resources.sqlite import _raise_for_non_query_response
 from datetime import datetime
 import tempfile
 import sqlite3
@@ -2409,6 +2410,8 @@ class AsyncSQLiteResource(Resource):
             f"/resources/sqlite/{self.resource.name}/query",
             json=request.model_dump(),
         )
+        # Shared with the sync path so the two can't drift.
+        _raise_for_non_query_response(response, self.resource.name)
         return QueryResponse(**response.json())
 
     async def _query_direct(

--- a/fleet/resources/sqlite.py
+++ b/fleet/resources/sqlite.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional, Dict, Tuple
 from ..instance.models import Resource as ResourceModel
 from ..instance.models import DescribeResponse, QueryRequest, QueryResponse
 from .base import Resource
+from ..exceptions import FleetEnvironmentError
 from datetime import datetime
 import tempfile
 import sqlite3
@@ -23,6 +24,41 @@ from fleet.verifiers.db import (
     _values_equivalent,
     validate_diff_expect_exactly,
 )
+
+
+def _raise_for_non_query_response(response: Any, resource_name: str) -> None:
+    """Fail loudly, and legibly, when a query response isn't a QueryResponse.
+
+    The query endpoint used to be parsed with a bare ``response.json()``. Any
+    response that wasn't 200-with-JSON therefore surfaced as an opaque
+    ``JSONDecodeError: Expecting value: line 1 column 1 (char 0)`` (non-JSON body)
+    or a pydantic ``ValidationError`` (a ``{"detail": ...}`` error body) -- with no
+    status code, URL or body text to work from.
+
+    That cost a full grading session on 2026-07-30: a BLOB column made the env
+    runner return ``500 Internal Server Error`` as text/plain, the char-0
+    JSONDecodeError reached the multi-app verifier, and its "app route is dead"
+    heuristic failed the run ENVIRONMENT_NOT_READY -- 90 minutes of rollout thrown
+    away pointing at the wrong layer.
+
+    Only paths that already raised are affected: a 200-with-JSON body is untouched,
+    so no working call changes behaviour. The body snippet is included deliberately
+    -- for a gateway failure it carries the reason phrase ("Bad Gateway", "Service
+    Unavailable") that callers classify unavailability on, so those keep working.
+    """
+    body = (response.text or "")[:500]
+    detail = (
+        f"SQLite query on resource '{resource_name}' did not return a QueryResponse: "
+        f"status_code={response.status_code} "
+        f"content_type={response.headers.get('content-type', 'unknown')!r} "
+        f"response={body or 'empty'}"
+    )
+    if response.status_code != 200:
+        raise FleetEnvironmentError(detail)
+    try:
+        response.json()
+    except ValueError as e:  # json.JSONDecodeError subclasses ValueError
+        raise FleetEnvironmentError(detail) from e
 
 
 def _quote_identifier(identifier: str) -> str:
@@ -2450,6 +2486,7 @@ class SQLiteResource(Resource):
             f"/resources/sqlite/{self.resource.name}/query",
             json=request.model_dump(),
         )
+        _raise_for_non_query_response(response, self.resource.name)
         return QueryResponse(**response.json())
 
     def _query_direct(

--- a/tests/test_query_http_non_json_body.py
+++ b/tests/test_query_http_non_json_body.py
@@ -1,0 +1,167 @@
+"""The SQLite query path must not parse a non-QueryResponse body as JSON.
+
+``_query_http`` used to do a bare ``response.json()``, so anything that wasn't
+200-with-JSON surfaced as an opaque ``JSONDecodeError: Expecting value: line 1
+column 1 (char 0)`` (non-JSON body) or a pydantic ``ValidationError`` (a
+``{"detail": ...}`` error body) -- carrying no status code, URL or body text.
+
+On 2026-07-30 that cost a full grading session: a BLOB column made an env runner
+answer ``500 Internal Server Error`` as text/plain, the char-0 JSONDecodeError
+reached the generated multi-app verifier, and its "app route is dead" heuristic
+failed the run ENVIRONMENT_NOT_READY -- discarding ~90 minutes of rollout and
+pointing the investigation at the wrong layer.
+"""
+
+import json
+
+import pytest
+
+from fleet.exceptions import FleetEnvironmentError
+from fleet.instance.models import (
+    Resource as ResourceModel,
+    ResourceMode,
+    ResourceType,
+)
+from fleet.resources.sqlite import SQLiteResource
+
+# The literal 21-byte text/plain body Starlette returns for an unhandled
+# exception, and the one that actually broke grading.
+STARLETTE_500_BODY = "Internal Server Error"
+NGINX_502_BODY = (
+    "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n"
+    "<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n"
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code, text, content_type="application/json"):
+        self.status_code = status_code
+        self.text = text
+        self.headers = {"content-type": content_type}
+
+    def json(self):
+        return json.loads(self.text)
+
+
+class FakeClient:
+    """Stands in for SyncWrapper; records the call and returns a canned response."""
+
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def request(self, method, path, **kwargs):
+        self.calls.append((method, path, kwargs))
+        return self.response
+
+
+def _resource(client):
+    return SQLiteResource(
+        ResourceModel(name="current", type=ResourceType.db, mode=ResourceMode.rw),
+        client,
+    )
+
+
+def test_text_plain_500_raises_descriptive_error_not_jsondecodeerror():
+    """The exact production failure."""
+    client = FakeClient(
+        FakeResponse(500, STARLETTE_500_BODY, content_type="text/plain; charset=utf-8")
+    )
+
+    with pytest.raises(FleetEnvironmentError) as excinfo:
+        _resource(client).query("SELECT * FROM vendor_contract_documents WHERE id = 12")
+
+    message = str(excinfo.value)
+    assert "status_code=500" in message
+    assert STARLETTE_500_BODY in message
+    assert "current" in message
+    assert "text/plain" in message
+    # The old failure mode must be gone.
+    assert "line 1 column 1 (char 0)" not in message
+
+
+def test_gateway_body_is_preserved_for_unavailability_classification():
+    """Callers classify "unreachable" on the reason phrase, so keep the body.
+
+    orchestrator/tasks/activities/verifier.py matches phrases like "Bad Gateway"
+    to tell an unreachable app apart from a real task failure. Including the body
+    snippet keeps that working through the new exception.
+    """
+    client = FakeClient(FakeResponse(502, NGINX_502_BODY, content_type="text/html"))
+
+    with pytest.raises(FleetEnvironmentError) as excinfo:
+        _resource(client).query("SELECT 1")
+
+    assert "Bad Gateway" in str(excinfo.value)
+    assert "status_code=502" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        (404, '{"detail": "Database file not found: /alloc/data/current.sqlite"}'),
+        (401, '{"detail": "unauthorized: runner SQL write requires X-Runner-Token"}'),
+    ],
+)
+def test_json_error_bodies_raise_descriptive_error_not_validationerror(status, body):
+    """`{"detail": ...}` used to blow up as a pydantic ValidationError."""
+    client = FakeClient(FakeResponse(status, body))
+
+    with pytest.raises(FleetEnvironmentError) as excinfo:
+        _resource(client).query("SELECT 1")
+
+    assert f"status_code={status}" in str(excinfo.value)
+    assert "detail" in str(excinfo.value)
+
+
+def test_empty_200_body_raises_descriptive_error():
+    client = FakeClient(FakeResponse(200, ""))
+
+    with pytest.raises(FleetEnvironmentError) as excinfo:
+        _resource(client).query("SELECT 1")
+
+    assert "status_code=200" in str(excinfo.value)
+    assert "empty" in str(excinfo.value)
+
+
+def test_successful_query_is_untouched():
+    """No working call may change behaviour: 200-with-JSON still parses."""
+    payload = {
+        "success": True,
+        "columns": ["id", "file_name"],
+        "rows": [[12, "signed.pdf"]],
+        "message": "Query executed successfully",
+    }
+    client = FakeClient(FakeResponse(200, json.dumps(payload)))
+
+    result = _resource(client).query("SELECT id, file_name FROM t")
+
+    assert result.success is True
+    assert result.rows == [[12, "signed.pdf"]]
+    assert client.calls[0][0] == "POST"
+    assert client.calls[0][1] == "/resources/sqlite/current/query"
+
+
+def test_sql_error_response_still_returned_as_data_not_raised():
+    """A failed *query* (200 + success=False) is data, not a transport error."""
+    payload = {
+        "success": False,
+        "error": "no such table: nope",
+        "message": "Query execution failed",
+    }
+    client = FakeClient(FakeResponse(200, json.dumps(payload)))
+
+    result = _resource(client).query("SELECT * FROM nope")
+
+    assert result.success is False
+    assert "no such table" in result.error
+
+
+def test_write_path_shares_the_guard():
+    """`exec()` goes through the same helper."""
+    client = FakeClient(
+        FakeResponse(500, STARLETTE_500_BODY, content_type="text/plain")
+    )
+
+    with pytest.raises(FleetEnvironmentError):
+        _resource(client).exec("UPDATE t SET x = 1")


### PR DESCRIPTION
## What's wrong

`_query_http` parses the response with a bare `response.json()`:

```python
response = self.client.request("POST", f"/resources/sqlite/{name}/query", json=...)
return QueryResponse(**response.json())   # no status check, no shape check
```

So anything that isn't 200-with-JSON surfaces as either

- `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` — a non-JSON body
  (text/plain 500, nginx HTML 502, empty body), or
- a pydantic `ValidationError` — a `{"detail": ...}` error body from a 401/404

…with **no status code, no URL and no body text** in the exception.

## Why it mattered

This cost a full grading session on 2026-07-30 (see
[theseus#21168](https://github.com/fleet-ai/theseus/pull/21168)).

A BLOB column made an env runner raise during response serialization, so Starlette
answered `500 Internal Server Error` as **text/plain** (21 bytes). The resulting
char-0 `JSONDecodeError` reached the generated multi-app verifier, whose "app route is
dead" heuristic failed the run `ENVIRONMENT_NOT_READY` and threw away ~90 minutes of
completed rollout.

The environment was healthy the whole time — the runner served five 200s before the
500 in each of the four retries and was never restarted:

```
POST /ramp/api/v1/env/resources/sqlite/current/query   200  358
POST ...                                               200  386
POST ...                                               200  370
POST ...                                               200  290
POST ...                                               200  290
POST ...                                               500   21   <- text/plain
```

Diagnosing it required the cluster's edge access logs, purely because the exception
the SDK produced named neither the status nor the body. A caller cannot tell "app
returned 500" from "route is gone" — and here the difference decided whether a
session was scored or discarded.

## The change

Raise `FleetEnvironmentError` with `status_code`, `content-type` and a 500-char body
snippet, mirroring the `_describe_http` precedent a few lines above. Shared by the
sync and async paths (`from ...resources.sqlite import _raise_for_non_query_response`)
so they can't drift, and it covers `exec()` as well as `query()`.

**Only paths that already raised change.** A 200-with-JSON body is untouched, and a
failed *query* (`200` + `success=False`) is still returned as data rather than raised
— `test_successful_query_is_untouched` and
`test_sql_error_response_still_returned_as_data_not_raised` pin both, and they pass
with and without the patch.

The body snippet is deliberate, not incidental: callers classify unreachability on
the reason phrase in the body ("Bad Gateway", "Service Unavailable"), so gateway
failures keep classifying correctly through the new exception
(`test_gateway_body_is_preserved_for_unavailability_classification`).

## Tests

8 new tests in `tests/test_query_http_non_json_body.py`, covering the text/plain 500,
the nginx 502 HTML, `{"detail": ...}` bodies at 401/404, an empty 200, the two
must-not-change paths, and the write path. **6 of the 8 fail without the patch.**

Full suite: identical failure/error set before and after (5 pre-existing
`tests/track/test_mcp_install.py` failures and 3 pre-existing
`test_sqlite_resource_dual_mode.py` errors, all failing on `main` too).

## One consequence worth a decision, not worked around here

An app-side **500** no longer matches the char-0 heuristic in theseus's
`orchestrator/tasks/activities/verifier.py` `_app_unavailable()`. With this merged,
such a response would be scored **0** instead of raising `ENVIRONMENT_NOT_READY`.

Silently scoring 0 for an env-side fault is worse than failing loudly, so that
heuristic likely wants an explicit "app-route 5xx ⇒ unavailable" rule. Gateway codes
(502/503/504) are unaffected — their bodies still carry the phrases it matches. I've
flagged this on the theseus PR rather than quietly changing grading semantics from
inside the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
