### PR TITLE
feat(judge): max_turns param on grade() for the agentic tool-turn budget

### DIFF
--- a/fleet/_async/judge.py
+++ b/fleet/_async/judge.py
@@ -63,6 +63,7 @@ class AsyncJudge:
         agentic: bool = False,
         collect: Optional[Dict[str, List[str]]] = None,
         task_id: Optional[str] = None,
+        max_turns: Optional[int] = None,
     ) -> JudgeResult:
         """Grade a submission using LLM-as-judge via the orchestrator API.
 
@@ -84,6 +85,9 @@ class AsyncJudge:
             agentic: If True, the orchestrator collects artifacts from the instance.
             collect: File patterns for orchestrator to collect (agentic mode).
             task_id: Optional task ID for tracking.
+            max_turns: Agentic tool-turn budget (1-50). None keeps the
+                orchestrator default; ignored when agentic is False and by
+                orchestrators that predate the field.
         """
         # Resolve Image.from_env images asynchronously before building request
         resolved_images = images
@@ -146,6 +150,7 @@ class AsyncJudge:
             agentic=agentic,
             collect=collect,
             task_id=task_id,
+            max_turns=max_turns,
         )
 
         _print_judge_call_start(rubric, resolved_images, agentic, model, files=resolved_files)

--- a/fleet/judge.py
+++ b/fleet/judge.py
@@ -755,6 +755,7 @@ def _build_grade_request(
     agentic: bool = False,
     collect: Optional[Dict[str, List[str]]] = None,
     task_id: Optional[str] = None,
+    max_turns: Optional[int] = None,
 ) -> dict:
     """Build the JSON request body for POST /v1/judge/grade."""
     body: Dict[str, Any] = {
@@ -794,6 +795,8 @@ def _build_grade_request(
         body["provider"] = provider
     if task_id is not None:
         body["task_id"] = task_id
+    if max_turns is not None:
+        body["max_turns"] = max_turns
     if collect is not None:
         body["collect"] = collect
 
@@ -969,6 +972,7 @@ class SyncJudge:
         agentic: bool = False,
         collect: Optional[Dict[str, List[str]]] = None,
         task_id: Optional[str] = None,
+        max_turns: Optional[int] = None,
     ) -> JudgeResult:
         """Grade a submission using LLM-as-judge via the orchestrator API.
 
@@ -990,6 +994,9 @@ class SyncJudge:
             agentic: If True, the orchestrator collects artifacts from the instance.
             collect: File patterns for orchestrator to collect (agentic mode).
             task_id: Optional task ID for tracking.
+            max_turns: Agentic tool-turn budget (1-50). None keeps the
+                orchestrator default; ignored when agentic is False and by
+                orchestrators that predate the field.
         """
         body = _build_grade_request(
             self._instance_id,
@@ -1007,6 +1014,7 @@ class SyncJudge:
             agentic=agentic,
             collect=collect,
             task_id=task_id,
+            max_turns=max_turns,
         )
 
         _print_judge_call_start(rubric, images, agentic, model, files=files)

--- a/tests/test_judge_max_turns.py
+++ b/tests/test_judge_max_turns.py
@@ -1,0 +1,54 @@
+"""max_turns must reach the request body from both grade() entry points."""
+
+from fleet.judge import _build_grade_request
+
+
+def test_builder_includes_max_turns():
+    body = _build_grade_request("inst-1", "rubric", "answer", max_turns=30)
+    assert body["max_turns"] == 30
+
+
+def test_builder_omits_max_turns_by_default():
+    body = _build_grade_request("inst-1", "rubric", "answer")
+    assert "max_turns" not in body
+
+
+def _grade_body(judge_cls, **kwargs):
+    captured = {}
+
+    class _Resp:
+        @staticmethod
+        def json():
+            return {
+                "normalized_score": 1.0,
+                "total_score": 1.0,
+                "max_score": 1.0,
+                "feedback": "",
+                "model_used": "m",
+                "execution_id": "e",
+            }
+
+    class _Client:
+        def request(self, method, path, json=None, extra_headers=None):
+            captured.update(json)
+            return _Resp()
+
+    judge = judge_cls.__new__(judge_cls)
+    judge._instance_id = "inst-1"
+    judge._client = _Client()
+    judge.grade("rubric", "answer", **kwargs)
+    return captured
+
+
+def test_sync_grade_passes_max_turns():
+    from fleet.judge import SyncJudge as JudgeClient
+
+    body = _grade_body(JudgeClient, max_turns=25)
+    assert body["max_turns"] == 25
+
+
+def test_sync_grade_defaults_to_no_max_turns():
+    from fleet.judge import SyncJudge as JudgeClient
+
+    body = _grade_body(JudgeClient)
+    assert "max_turns" not in body


### PR DESCRIPTION
## What

Adds `max_turns: Optional[int]` to `env.judge.grade()` (sync and async) and `_build_grade_request`, passed through to `POST /v1/judge/grade` as the agentic tool-turn budget.

## Why

Orchestrator support landed in [theseus #21411](https://github.com/fleet-ai/theseus/pull/21411) (bounds 1–50, server default 10 when omitted). In a 30-session grading audit of the meche expert45 dataset, 23/28 agentic gradings hit the hard-coded 10-turn cap before completing their rubric's checks; the dataset's verifiers currently inject `max_turns` by constructing the request body via SDK internals (`_build_grade_request` + `_client.request`), which this parameter makes unnecessary.

`None` (the default) omits the field entirely, so behavior is unchanged for all existing callers and against orchestrators that predate the field.

## Tests

`tests/test_judge_max_turns.py`: builder includes/omits the field correctly; `SyncJudge.grade` passes it through to the request body (captured via a stub client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
