### PR TITLE
feat(runner-auth): present X-Runner-Token on instance calls

### DIFF
--- a/fleet/_async/client.py
+++ b/fleet/_async/client.py
@@ -29,6 +29,7 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Dict, Any, TYPE_CHECKING, Union
 from uuid import UUID
+from fleet.runner_auth import RunnerTokenProvider
 
 from .base import EnvironmentBase, AsyncWrapper
 from ..models import (
@@ -361,12 +362,23 @@ class AsyncEnv(EnvironmentBase):
         self._apps: Dict[str, AsyncInstanceClient] = {}
         self._instance: Optional[AsyncInstanceClient] = None
         self._judge: Optional["AsyncJudge"] = None
+        self._runner_token_provider: Optional[RunnerTokenProvider] = None
+
+    def _runner_tokens(self) -> Optional[RunnerTokenProvider]:
+        """One provider per env, so instance + every app share one resolution."""
+        if self._client is None:
+            return None
+        if self._runner_token_provider is None:
+            self._runner_token_provider = RunnerTokenProvider(self._client)
+        return self._runner_token_provider
 
     @property
     def instance(self) -> AsyncInstanceClient:
         if self._instance is None:
             self._instance = AsyncInstanceClient(
-                self.manager_url, self._client.httpx_client if self._client else None
+                self.manager_url,
+                self._client.httpx_client if self._client else None,
+                runner_token_provider=self._runner_tokens(),
             )
         return self._instance
 
@@ -384,6 +396,7 @@ class AsyncEnv(EnvironmentBase):
             self._apps[name] = AsyncInstanceClient(
                 f"{base_url}/{name}/api/v1/env",
                 self._client.httpx_client if self._client else None,
+                runner_token_provider=self._runner_tokens(),
             )
         return self._apps[name]
 
@@ -534,6 +547,8 @@ class AsyncFleet:
         if base_url is None:
             base_url = os.getenv("FLEET_BASE_URL")
         self._httpx_client = httpx_client or default_httpx_client(max_retries, timeout)
+        # One per Fleet client: the token is resolved once, lazily, on the
+        # first runner call, and shared by every instance this client hands out.
         self.client = AsyncWrapper(
             api_key=api_key,
             base_url=base_url,
@@ -746,7 +761,9 @@ class AsyncFleet:
             AsyncEnv: Environment instance configured for URL mode
         """
         instance_client = AsyncInstanceClient(
-            url=base_url, httpx_client=self._httpx_client
+            url=base_url,
+            httpx_client=self._httpx_client,
+            runner_token_provider=RunnerTokenProvider(self.client),
         )
 
         # Create a minimal environment for URL mode
@@ -817,9 +834,7 @@ class AsyncFleet:
 
         instance_client = AsyncInstanceClient(url="local://", httpx_client=None)
         instance_client._resources = []  # Mark as loaded
-        instance_client._memory_anchors = (
-            {}
-        )  # Store anchor connections for in-memory DBs
+        instance_client._memory_anchors = {}  # Store anchor connections for in-memory DBs
 
         # Store creation parameters for local AsyncSQLiteResources
         # This allows db() to create new instances each time (matching HTTP mode behavior)

--- a/fleet/_async/instance/base.py
+++ b/fleet/_async/instance/base.py
@@ -1,5 +1,7 @@
 import httpx
 import httpx_retries
+
+from fleet.runner_auth import RUNNER_TOKEN_HEADER
 from typing import Dict, Any, Optional
 
 
@@ -30,14 +32,31 @@ def default_httpx_client(max_retries: int, timeout: float) -> httpx.AsyncClient:
 
 
 class BaseWrapper:
-    def __init__(self, *, url: str):
+    def __init__(self, *, url: str, runner_token_provider=None):
         self.url = url
+        # Optional so an InstanceClient built directly -- which callers do, and
+        # the tests do -- keeps working with no token and no control-plane call.
+        self.runner_token_provider = runner_token_provider
 
     def get_headers(self) -> Dict[str, str]:
         headers: Dict[str, str] = {
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": "1.0.0",
         }
+        return headers
+
+    async def _headers_with_runner_token(self) -> Dict[str, str]:
+        """SDK headers plus X-Runner-Token, when one is available.
+
+        Async all the way down: httpx.AsyncClient would not accept a coroutine
+        here, and resolving the token needs a network call the first time.
+        """
+        headers = self.get_headers()
+        if self.runner_token_provider is None:
+            return headers
+        token = await self.runner_token_provider.token_async()
+        if token:
+            headers[RUNNER_TOKEN_HEADER] = token
         return headers
 
 
@@ -57,7 +76,7 @@ class AsyncWrapper(BaseWrapper):
         return await self.httpx_client.request(
             method,
             f"{self.url}{path}",
-            headers=self.get_headers(),
+            headers=await self._headers_with_runner_token(),
             params=params,
             json=json,
             **kwargs,

--- a/fleet/_async/instance/client.py
+++ b/fleet/_async/instance/client.py
@@ -52,10 +52,12 @@ class AsyncInstanceClient:
         self,
         url: str,
         httpx_client: Optional[httpx.AsyncClient] = None,
+        runner_token_provider=None,
     ):
         self.base_url = url
         self.client = AsyncWrapper(
             url=self.base_url,
+            runner_token_provider=runner_token_provider,
             httpx_client=httpx_client
             or default_httpx_client(DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT),
         )
@@ -91,12 +93,12 @@ class AsyncInstanceClient:
         """
         resource_info = self._resources_state[ResourceType.db.value][name]
         # Local mode - resource_info is a dict with creation parameters
-        if isinstance(resource_info, dict) and resource_info.get('type') == 'local':
+        if isinstance(resource_info, dict) and resource_info.get("type") == "local":
             # Create new instance each time (matching HTTP mode behavior)
             return AsyncSQLiteResource(
-                resource_info['resource_model'],
+                resource_info["resource_model"],
                 client=None,
-                db_path=resource_info['db_path']
+                db_path=resource_info["db_path"],
             )
         # HTTP mode - resource_info is a ResourceModel, create new wrapper
         return AsyncSQLiteResource(resource_info, self.client)
@@ -231,7 +233,7 @@ class AsyncInstanceClient:
 
     def close(self):
         """Close anchor connections for in-memory databases."""
-        if hasattr(self, '_memory_anchors'):
+        if hasattr(self, "_memory_anchors"):
             for conn in self._memory_anchors.values():
                 conn.close()
             self._memory_anchors.clear()

--- a/fleet/client.py
+++ b/fleet/client.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import List, Optional, Dict, Any, TYPE_CHECKING, Union
 from urllib.parse import urlparse
 from uuid import UUID
+from fleet.runner_auth import RunnerTokenProvider
 
 from .base import EnvironmentBase, SyncWrapper
 from .models import (
@@ -365,6 +366,19 @@ class SyncEnv(EnvironmentBase):
         self._instance: Optional[InstanceClient] = None
         self._judge: Optional["SyncJudge"] = None
         self._manager_url_override: Optional[str] = None  # For URL mode
+        self._runner_token_provider: Optional[RunnerTokenProvider] = None
+
+    def _runner_tokens(self) -> Optional[RunnerTokenProvider]:
+        """One provider per env, so instance + every app share one resolution.
+
+        Built here rather than passed down from Fleet because an env can also be
+        constructed straight from a url, with no Fleet client above it.
+        """
+        if self._client is None:
+            return None
+        if self._runner_token_provider is None:
+            self._runner_token_provider = RunnerTokenProvider(self._client)
+        return self._runner_token_provider
 
     @property
     def manager_url(self) -> str:
@@ -377,7 +391,9 @@ class SyncEnv(EnvironmentBase):
     def instance(self) -> InstanceClient:
         if self._instance is None:
             self._instance = InstanceClient(
-                self.manager_url, self._client.httpx_client if self._client else None
+                self.manager_url,
+                self._client.httpx_client if self._client else None,
+                runner_token_provider=self._runner_tokens(),
             )
         return self._instance
 
@@ -395,6 +411,7 @@ class SyncEnv(EnvironmentBase):
             self._apps[name] = InstanceClient(
                 new_url,
                 self._client.httpx_client if self._client else None,
+                runner_token_provider=self._runner_tokens(),
             )
         return self._apps[name]
 
@@ -545,6 +562,8 @@ class Fleet:
         if base_url is None:
             base_url = os.getenv("FLEET_BASE_URL")
         self._httpx_client = httpx_client or default_httpx_client(max_retries, timeout)
+        # One per Fleet client: the token is resolved once, lazily, on the
+        # first runner call, and shared by every instance this client hands out.
         self.client = SyncWrapper(
             api_key=api_key,
             base_url=base_url,
@@ -752,7 +771,11 @@ class Fleet:
         Returns:
             SyncEnv: Environment instance configured for URL mode
         """
-        instance_client = InstanceClient(url=base_url, httpx_client=self._httpx_client)
+        instance_client = InstanceClient(
+            url=base_url,
+            httpx_client=self._httpx_client,
+            runner_token_provider=RunnerTokenProvider(self.client),
+        )
 
         # Create a minimal environment for URL mode
         env = SyncEnv(
@@ -823,9 +846,7 @@ class Fleet:
 
         instance_client = InstanceClient(url="local://", httpx_client=None)
         instance_client._resources = []  # Mark as loaded
-        instance_client._memory_anchors = (
-            {}
-        )  # Store anchor connections for in-memory DBs
+        instance_client._memory_anchors = {}  # Store anchor connections for in-memory DBs
 
         # Store creation parameters for local SQLiteResources
         # This allows db() to create new instances each time (matching HTTP mode behavior)

--- a/fleet/instance/base.py
+++ b/fleet/instance/base.py
@@ -1,5 +1,7 @@
 import httpx
 import httpx_retries
+
+from fleet.runner_auth import RUNNER_TOKEN_HEADER
 from typing import Dict, Any, Optional
 
 
@@ -30,14 +32,32 @@ def default_httpx_client(max_retries: int, timeout: float) -> httpx.Client:
 
 
 class BaseWrapper:
-    def __init__(self, *, url: str):
+    def __init__(self, *, url: str, runner_token_provider=None):
         self.url = url
+        # Optional so an InstanceClient built directly -- which callers do, and
+        # the tests do -- keeps working with no token and no control-plane call.
+        self.runner_token_provider = runner_token_provider
 
     def get_headers(self) -> Dict[str, str]:
         headers: Dict[str, str] = {
             "X-Fleet-SDK-Language": "Python",
             "X-Fleet-SDK-Version": "1.0.0",
         }
+        return headers
+
+    def _headers_with_runner_token(self) -> Dict[str, str]:
+        """SDK headers plus X-Runner-Token, when one is available.
+
+        self.url already ends in the instance's /api/v1/env base, so every
+        request this wrapper makes is a runner request -- there is no
+        control-plane traffic here to scope away from.
+        """
+        headers = self.get_headers()
+        if self.runner_token_provider is None:
+            return headers
+        token = self.runner_token_provider.token()
+        if token:
+            headers[RUNNER_TOKEN_HEADER] = token
         return headers
 
 
@@ -57,7 +77,7 @@ class SyncWrapper(BaseWrapper):
         return self.httpx_client.request(
             method,
             f"{self.url}{path}",
-            headers=self.get_headers(),
+            headers=self._headers_with_runner_token(),
             params=params,
             json=json,
             **kwargs,

--- a/fleet/instance/client.py
+++ b/fleet/instance/client.py
@@ -52,10 +52,12 @@ class InstanceClient:
         self,
         url: str,
         httpx_client: Optional[httpx.Client] = None,
+        runner_token_provider=None,
     ):
         self.base_url = url
         self.client = SyncWrapper(
             url=self.base_url,
+            runner_token_provider=runner_token_provider,
             httpx_client=httpx_client
             or default_httpx_client(DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT),
         )
@@ -89,12 +91,12 @@ class InstanceClient:
         """
         resource_info = self._resources_state[ResourceType.db.value][name]
         # Local mode - resource_info is a dict with creation parameters
-        if isinstance(resource_info, dict) and resource_info.get('type') == 'local':
+        if isinstance(resource_info, dict) and resource_info.get("type") == "local":
             # Create new instance each time (matching HTTP mode behavior)
             return SQLiteResource(
-                resource_info['resource_model'],
+                resource_info["resource_model"],
                 client=None,
-                db_path=resource_info['db_path']
+                db_path=resource_info["db_path"],
             )
         # HTTP mode - resource_info is a ResourceModel, create new wrapper
         return SQLiteResource(resource_info, self.client)
@@ -229,7 +231,7 @@ class InstanceClient:
 
     def close(self):
         """Close anchor connections for in-memory databases."""
-        if hasattr(self, '_memory_anchors'):
+        if hasattr(self, "_memory_anchors"):
             for conn in self._memory_anchors.values():
                 conn.close()
             self._memory_anchors.clear()

--- a/fleet/runner_auth.py
+++ b/fleet/runner_auth.py
@@ -1,0 +1,154 @@
+"""Present ``X-Runner-Token`` on calls into an instance's runner.
+
+Fleet's direct-router gates instance routes (``/api/v1/env/*``) on a shared
+token. Requests without it are answered 404 on a cluster with the gate enforcing
+-- so ``env.db(...).query(...)``, ``instance.reset()`` and the ``/resources``
+probe all fail, while the control-plane API keeps working, which makes it look
+like the instance is broken rather than the call being unauthorized.
+
+The token is resolved lazily, once per client, in this order:
+
+1. ``RUNNER_AUTH_TOKEN`` in the environment. Services running inside Fleet
+   already have it and should make no extra call.
+2. ``GET {base_url}/v1/runner-auth/token``, authenticated with whatever the
+   caller already uses for the control plane. The auth headers come from the
+   control-plane wrapper itself rather than being rebuilt here, so API keys and
+   ``flt login`` JWTs both work -- rebuilding them would have silently covered
+   only api_key callers.
+
+Fetching rather than embedding is deliberate. The value is not a secret in the
+usual sense, but one party must never hold it: the agent running inside an
+environment container. Shipping it in this package would hand it to exactly that
+party, since an agent can install the SDK. Serving it only to a caller with an
+API key keeps the channel closed -- an environment container carries no Fleet
+credentials.
+
+Every failure is soft. No API key, a 404 (deployment has no gate configured), a
+timeout, any error: send no header, which is exactly the behaviour before this
+existed and is correct against an ungated router, which ignores the header.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from typing import Optional
+
+import httpx
+
+RUNNER_TOKEN_HEADER = "X-Runner-Token"
+TOKEN_PATH = "/v1/runner-auth/token"
+
+# Matches the direct-router's predicate exactly. Note the trailing (/|$): a
+# substring test would also claim /api/v1/environments, a control-plane route
+# that must not receive this token.
+_RUNNER_PATH_RE = re.compile(r"^(/[^/]+)?/api/v1/env(/|$)")
+
+# Short: this is one small GET against the control plane, and a slow answer must
+# not stall the instance call that triggered it.
+_FETCH_TIMEOUT = 10.0
+
+
+def is_runner_path(path: Optional[str]) -> bool:
+    """True for the instance-runner routes the router gates."""
+    return bool(path) and bool(_RUNNER_PATH_RE.match(path))
+
+
+def _token_from_env() -> Optional[str]:
+    token = (os.environ.get("RUNNER_AUTH_TOKEN") or "").strip()
+    return token or None
+
+
+def _token_from_payload(payload: object) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    token = payload.get("token")
+    if not isinstance(token, str):
+        return None
+    return token.strip() or None
+
+
+class RunnerTokenProvider:
+    """Resolves the runner token once and remembers the answer.
+
+    Remembers a FAILURE too. Without that, a deployment with no gate configured
+    would pay a control-plane round trip on every single instance call, forever
+    -- turning an optional feature into a per-request tax on the common path.
+    """
+
+    def __init__(self, auth_source) -> None:
+        # Duck-typed on purpose: anything exposing get_headers() and base_url
+        # works, which is both control-plane wrappers and a test double.
+        self._auth = auth_source
+        self._token: Optional[str] = None
+        self._resolved = False
+        self._lock = threading.Lock()
+
+    def _endpoint(self) -> Optional[str]:
+        base_url = getattr(self._auth, "base_url", None)
+        return f"{str(base_url).rstrip('/')}{TOKEN_PATH}" if base_url else None
+
+    def _headers(self) -> Optional[dict]:
+        try:
+            headers = self._auth.get_headers()
+        except Exception:
+            return None
+        # No credential means no fetch: an unauthenticated GET would 401 and we
+        # would cache a negative for the life of the client.
+        return headers if headers.get("Authorization") else None
+
+    def token(self) -> Optional[str]:
+        if self._resolved:
+            return self._token
+        with self._lock:
+            if self._resolved:
+                return self._token
+            self._token = self._resolve()
+            self._resolved = True
+            return self._token
+
+    def _resolve(self) -> Optional[str]:
+        env_token = _token_from_env()
+        if env_token:
+            return env_token
+        endpoint, headers = self._endpoint(), self._headers()
+        if not endpoint or not headers:
+            return None
+        try:
+            # A separate client on purpose: this can be called from inside a
+            # request hook on the shared client, and reusing it there would
+            # recurse.
+            with httpx.Client(timeout=_FETCH_TIMEOUT) as client:
+                response = client.get(endpoint, headers=headers)
+            if response.status_code != 200:
+                return None
+            return _token_from_payload(response.json())
+        except Exception:
+            # Soft by design; see the module docstring.
+            return None
+
+    async def token_async(self) -> Optional[str]:
+        if self._resolved:
+            return self._token
+        env_token = _token_from_env()
+        if env_token:
+            self._token, self._resolved = env_token, True
+            return self._token
+        endpoint, headers = self._endpoint(), self._headers()
+        if not endpoint or not headers:
+            self._token, self._resolved = None, True
+            return None
+        token: Optional[str] = None
+        try:
+            async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT) as client:
+                response = await client.get(endpoint, headers=headers)
+            if response.status_code == 200:
+                token = _token_from_payload(response.json())
+        except Exception:
+            token = None
+        # Last write wins rather than holding a lock across an await; the value
+        # is idempotent, so a concurrent double-fetch costs one extra GET and
+        # settles on the same answer.
+        self._token, self._resolved = token, True
+        return token

--- a/fleet/runner_auth.py
+++ b/fleet/runner_auth.py
@@ -49,6 +49,15 @@ _RUNNER_PATH_RE = re.compile(r"^(/[^/]+)?/api/v1/env(/|$)")
 # not stall the instance call that triggered it.
 _FETCH_TIMEOUT = 10.0
 
+# The control plane accepts two credential shapes and get_headers() emits
+# whichever applies: an API key becomes Authorization, while an `flt login`
+# session becomes X-JWT-Token + X-Team-ID. Checking only Authorization looked
+# right and silently excluded every logged-in user -- their headers were valid,
+# got discarded as "no credential", and the resulting miss was cached, so gated
+# instance calls kept going out bare. Keyed off the header names the wrapper
+# actually sets.
+_CREDENTIAL_HEADERS = ("Authorization", "X-JWT-Token")
+
 
 def is_runner_path(path: Optional[str]) -> bool:
     """True for the instance-runner routes the router gates."""
@@ -96,7 +105,9 @@ class RunnerTokenProvider:
             return None
         # No credential means no fetch: an unauthenticated GET would 401 and we
         # would cache a negative for the life of the client.
-        return headers if headers.get("Authorization") else None
+        if not any(headers.get(name) for name in _CREDENTIAL_HEADERS):
+            return None
+        return headers
 
     def token(self) -> Optional[str]:
         if self._resolved:

--- a/tests/test_runner_auth.py
+++ b/tests/test_runner_auth.py
@@ -23,14 +23,23 @@ from fleet.runner_auth import (
 
 
 class _Auth:
-    """Stands in for a control-plane wrapper: get_headers() + base_url."""
+    """Stands in for a control-plane wrapper: get_headers() + base_url.
 
-    def __init__(self, base_url="https://orchestrator.fleetai.com", authorized=True):
+    ``mode`` mirrors the two credential shapes the real wrapper emits -- an API
+    key becomes Authorization, an `flt login` session becomes X-JWT-Token plus
+    X-Team-ID and no Authorization at all.
+    """
+
+    def __init__(self, base_url="https://orchestrator.fleetai.com", mode="api_key"):
         self.base_url = base_url
-        self._authorized = authorized
+        self._mode = mode
 
     def get_headers(self):
-        return {"Authorization": "Bearer sk-test"} if self._authorized else {}
+        if self._mode == "api_key":
+            return {"Authorization": "Bearer sk-test"}
+        if self._mode == "jwt":
+            return {"X-JWT-Token": "jwt-abc", "X-Team-ID": "team-1"}
+        return {}
 
 
 @pytest.fixture(autouse=True)
@@ -191,6 +200,38 @@ def test_a_failed_resolution_is_also_cached(monkeypatch):
     assert calls["n"] == 1
 
 
+def test_jwt_sessions_also_fetch(monkeypatch):
+    """`flt login` sends X-JWT-Token + X-Team-ID and no Authorization.
+
+    Keying the credential check on Authorization alone looked correct and
+    excluded every logged-in user: valid headers were discarded as "no
+    credential", the fetch was skipped, and the miss was cached -- so their
+    gated instance calls kept going out bare. Caught by Bugbot on the first
+    revision of this file.
+    """
+    seen = {}
+
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, url, headers=None):
+            seen.update(headers or {})
+            return httpx.Response(200, json={"token": "tok-jwt"})
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+    assert RunnerTokenProvider(_Auth(mode="jwt")).token() == "tok-jwt"
+    assert seen["X-JWT-Token"] == "jwt-abc"
+    assert seen["X-Team-ID"] == "team-1"
+
+
 def test_no_credential_means_no_fetch(monkeypatch):
     """An unauthenticated GET would 401 and poison the cache for the client."""
 
@@ -198,7 +239,7 @@ def test_no_credential_means_no_fetch(monkeypatch):
         raise AssertionError("fetched with no Authorization header")
 
     monkeypatch.setattr(httpx, "Client", _explode)
-    assert RunnerTokenProvider(_Auth(authorized=False)).token() is None
+    assert RunnerTokenProvider(_Auth(mode="none")).token() is None
 
 
 def test_no_base_url_means_no_fetch(monkeypatch):

--- a/tests/test_runner_auth.py
+++ b/tests/test_runner_auth.py
@@ -1,0 +1,284 @@
+"""The SDK must present X-Runner-Token on instance calls, and fail soft always.
+
+Fleet's direct-router gates /api/v1/env/* on a shared token. Before this, the
+SDK sent no credential to instances at all, so env.db().query() and
+instance.reset() were 404'd on an enforcing cluster while the control-plane API
+kept working -- which reads as a broken instance, not an unauthorized call.
+
+The failure modes matter more than the happy path here. This ships to users on
+clusters that may have no gate at all, so every way of not getting a token has
+to end in "send no header", never an exception and never a stall.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from fleet.runner_auth import (
+    RUNNER_TOKEN_HEADER,
+    RunnerTokenProvider,
+    is_runner_path,
+)
+
+
+class _Auth:
+    """Stands in for a control-plane wrapper: get_headers() + base_url."""
+
+    def __init__(self, base_url="https://orchestrator.fleetai.com", authorized=True):
+        self.base_url = base_url
+        self._authorized = authorized
+
+    def get_headers(self):
+        return {"Authorization": "Bearer sk-test"} if self._authorized else {}
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_token(monkeypatch):
+    """The env var wins over the fetch, so leaving it set would mask everything."""
+    monkeypatch.delenv("RUNNER_AUTH_TOKEN", raising=False)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/api/v1/env", True),
+        ("/api/v1/env/resources", True),
+        ("/api/v1/env/resources/sqlite/current/query", True),
+        ("/jira/api/v1/env/reset", True),
+        # A substring check would claim this control-plane route.
+        ("/api/v1/environments/launch", False),
+        ("/v1/env/instances", False),
+        ("/v1/tasks", False),
+    ],
+)
+def test_runner_path_predicate(path, expected):
+    assert is_runner_path(path) is expected
+
+
+def test_env_var_wins_and_makes_no_network_call(monkeypatch):
+    """Services inside Fleet already hold the token; they must not pay a fetch."""
+    monkeypatch.setenv("RUNNER_AUTH_TOKEN", "tok-from-env")
+
+    def _explode(*_a, **_k):
+        raise AssertionError("fetched despite RUNNER_AUTH_TOKEN being set")
+
+    monkeypatch.setattr(httpx, "Client", _explode)
+    assert RunnerTokenProvider(_Auth()).token() == "tok-from-env"
+
+
+def test_fetches_with_the_callers_credentials(monkeypatch):
+    seen = {}
+
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, url, headers=None):
+            seen["url"], seen["headers"] = url, headers
+            return httpx.Response(200, json={"token": "tok-fetched"})
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+    assert RunnerTokenProvider(_Auth()).token() == "tok-fetched"
+    assert seen["url"] == "https://orchestrator.fleetai.com/v1/runner-auth/token"
+    # Reuses the wrapper's own auth, so flt-login JWTs work too, not just keys.
+    assert seen["headers"]["Authorization"] == "Bearer sk-test"
+
+
+def test_resolves_once_and_caches_the_answer(monkeypatch):
+    calls = {"n": 0}
+
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, *_a, **_k):
+            calls["n"] += 1
+            return httpx.Response(200, json={"token": "tok"})
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    provider = RunnerTokenProvider(_Auth())
+
+    assert [provider.token() for _ in range(5)] == ["tok"] * 5
+    assert calls["n"] == 1
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(404, json={"detail": "no gate configured"}),
+        httpx.Response(401, json={"detail": "nope"}),
+        httpx.Response(500, text="boom"),
+        httpx.Response(200, json={"nothing": "useful"}),
+        httpx.Response(200, json={"token": "   "}),
+    ],
+)
+def test_every_bad_answer_yields_no_token(monkeypatch, response):
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, *_a, **_k):
+            return response
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    assert RunnerTokenProvider(_Auth()).token() is None
+
+
+def test_a_raising_transport_is_not_propagated(monkeypatch):
+    """A control plane that is down must not break instance calls that would
+    have worked fine on an ungated cluster."""
+
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, *_a, **_k):
+            raise httpx.ConnectTimeout("down")
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    assert RunnerTokenProvider(_Auth()).token() is None
+
+
+def test_a_failed_resolution_is_also_cached(monkeypatch):
+    """Otherwise a deployment with no gate pays a round trip on every call."""
+    calls = {"n": 0}
+
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, *_a, **_k):
+            calls["n"] += 1
+            return httpx.Response(404)
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    provider = RunnerTokenProvider(_Auth())
+
+    assert provider.token() is None
+    assert provider.token() is None
+    assert calls["n"] == 1
+
+
+def test_no_credential_means_no_fetch(monkeypatch):
+    """An unauthenticated GET would 401 and poison the cache for the client."""
+
+    def _explode(*_a, **_k):
+        raise AssertionError("fetched with no Authorization header")
+
+    monkeypatch.setattr(httpx, "Client", _explode)
+    assert RunnerTokenProvider(_Auth(authorized=False)).token() is None
+
+
+def test_no_base_url_means_no_fetch(monkeypatch):
+    def _explode(*_a, **_k):
+        raise AssertionError("fetched with no base_url")
+
+    monkeypatch.setattr(httpx, "Client", _explode)
+    assert RunnerTokenProvider(_Auth(base_url=None)).token() is None
+
+
+async def test_async_resolution(monkeypatch):
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def get(self, *_a, **_k):
+            return httpx.Response(200, json={"token": "tok-async"})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    assert await RunnerTokenProvider(_Auth()).token_async() == "tok-async"
+
+
+async def test_async_failure_is_soft(monkeypatch):
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def get(self, *_a, **_k):
+            raise httpx.ConnectTimeout("down")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    assert await RunnerTokenProvider(_Auth()).token_async() is None
+
+
+def test_wrapper_attaches_the_token_to_instance_requests(monkeypatch):
+    """End of the chain: the header must reach the wire, not just the provider."""
+    from fleet.instance.base import SyncWrapper
+
+    monkeypatch.setenv("RUNNER_AUTH_TOKEN", "tok-abc")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"x-echo": request.headers.get(RUNNER_TOKEN_HEADER, "")},
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    wrapper = SyncWrapper(
+        url="https://inst.env.test.fleetai.com/api/v1/env",
+        httpx_client=client,
+        runner_token_provider=RunnerTokenProvider(_Auth()),
+    )
+
+    assert wrapper.request("GET", "/resources").headers["x-echo"] == "tok-abc"
+
+
+def test_wrapper_without_a_provider_is_unchanged():
+    """An InstanceClient built directly still works with no token and no fetch."""
+    from fleet.instance.base import SyncWrapper
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, headers={"x-echo": request.headers.get(RUNNER_TOKEN_HEADER, "")}
+        )
+
+    wrapper = SyncWrapper(
+        url="https://inst.env.test.fleetai.com/api/v1/env",
+        httpx_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+    assert wrapper.request("GET", "/resources").headers["x-echo"] == ""


### PR DESCRIPTION
## Why

Fleet's direct-router gates instance routes (`/api/v1/env/*`) on a shared token. The SDK sends **no credential to instances at all** — `fleet/instance/base.py`'s `get_headers()` returns only the SDK language/version pair:

```python
def get_headers(self) -> Dict[str, str]:
    return {"X-Fleet-SDK-Language": "Python", "X-Fleet-SDK-Version": "1.0.0"}
```

So on a cluster with the gate enforcing, `env.db().query()`, `instance.reset()` and the `/resources` probe are 404'd while the control-plane API keeps working — which reads as a broken instance rather than an unauthorized call. Fleet's report-only audit shows a cohort of instances driven by SDK clients producing exactly this pattern.

## How

Resolved lazily, once per environment:

1. `RUNNER_AUTH_TOKEN` from the environment — services running inside Fleet already hold it and now make **no** extra call.
2. `GET /v1/runner-auth/token` on the control plane.

The fetch reuses the control-plane wrapper's own `get_headers()` rather than rebuilding an `Authorization` header, so **`flt login` JWT sessions work as well as API keys**. Rebuilding it would have silently covered only `api_key` callers.

## Fetching rather than embedding

The value isn't secret in the usual sense, but one party must never hold it: the agent running inside an environment container. Shipping it in this package would hand it to exactly that party — an agent can `pip install fleet`. Serving it only to an authenticated caller keeps the channel closed; an environment container carries no Fleet credentials.

## Every failure is soft

This ships to users whose clusters may have no gate at all, so no credential, no `base_url`, 404, 401, timeout, or a malformed body all end in **send no header** — never an exception, never a stall. That's identical to today's behaviour and correct against an ungated router, which ignores the header.

Failures are cached too. Without that, an ungated deployment would pay a control-plane round trip on *every* instance call forever, turning an optional feature into a per-request tax on the common path.

Local-mode clients (`url="local://"`) are deliberately untouched — they speak to no runner over HTTP.

## Tests

23 new, weighted toward failure modes rather than the happy path: the env var short-circuits the fetch entirely, a wrapper built without a provider behaves exactly as before, and each bad answer shape yields no token.

Full suite: **745 passed**, with the same 5 failures and 3 errors as an untouched checkout. Verified by running the suite stashed and diffing the failure sets — which caught a dangling `Fleet._runner_token_provider` reference that had broken 8 unrelated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
