### PR TITLE
chore(release): 0.2.133

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fleet-python"
 
-version = "0.2.124"
+version = "0.2.133"
 description = "Python SDK for Fleet environments"
 authors = [
     {name = "Fleet AI", email = "nic@fleet.so"},


### PR DESCRIPTION
Ships the runner-auth change from #143 to PyPI.

## What #143 does

The SDK now presents `X-Runner-Token` on instance calls, so `env.db().query()`, `instance.reset()` and the `/resources` probe keep working on clusters where Fleet's direct-router gate is enforcing. Before it, those were 404'd while the control-plane API kept answering — which reads as a broken instance rather than an unauthorized call.

The token is fetched lazily from `GET /v1/runner-auth/token` using the caller's existing credentials, or taken from `RUNNER_AUTH_TOKEN` when already present. Every failure path sends no header, so behaviour on ungated clusters is unchanged.

## Why 0.2.133 and not 0.2.125

| | |
|---|---|
| PyPI latest | **0.2.132** |
| `main`'s `pyproject.toml` | **0.2.124** |
| Is `v0.2.132` on main? | **no** |

Releases have been cut from branches, so the in-repo version drifted eight behind what's published. `scripts/validate-release-tag.sh` requires `tag version == pyproject version`, so a tag matching main today (`v0.2.124`) would validate but be rejected by PyPI as an existing — and lower — version.

0.2.133 is the next version PyPI will accept.

## Worth fixing separately

With releases cut off-branch, main's version isn't a reliable statement of what's published. That's a footgun for the next person who tries to release from main.

## After merge

```bash
git checkout main && git pull
git tag fleet-python-v0.2.133
git push origin fleet-python-v0.2.133
```

The tag triggers `publish-fleet-sdk.yml` → validate → build → `twine check` → PyPI via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
