### PR TITLE
chore(release): finish the 0.2.133 bump across every version string

### DIFF
--- a/fleet/__init__.py
+++ b/fleet/__init__.py
@@ -79,7 +79,7 @@ from . import env
 from . import global_client as _global_client
 from ._async import global_client as _async_global_client
 
-__version__ = "0.2.124"
+__version__ = "0.2.133"
 
 __all__ = [
     # Core classes

--- a/fleet/_async/__init__.py
+++ b/fleet/_async/__init__.py
@@ -44,7 +44,7 @@ from ..types import VerifierFunction
 from .. import env
 from . import global_client as _async_global_client
 
-__version__ = "0.2.124"
+__version__ = "0.2.133"
 
 __all__ = [
     # Core classes

--- a/fleet/_auth_headers.py
+++ b/fleet/_auth_headers.py
@@ -6,7 +6,7 @@ from .config import GLOBAL_BASE_URL
 try:
     from . import __version__
 except ImportError:
-    __version__ = "0.2.124"
+    __version__ = "0.2.133"
 
 
 class AuthenticatedWrapperMixin:

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "fleet-python"
-version = "0.2.124"
+version = "0.2.133"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Follow-up to #144, which bumped `pyproject.toml` alone and left `main` internally inconsistent.

[`5b4b3ec`](https://github.com/fleet-ai/fleet-sdk/commit/5b4b3ec3f35c35e2f1d53963e8e3274cdbca6863) (v0.2.132) is the convention — it touches every version string. This does the same.

## State on main before this

| File | Version |
|---|---|
| `pyproject.toml` | 0.2.133 ✅ |
| `fleet/__init__.py` | **0.2.124** |
| `fleet/_async/__init__.py` | **0.2.124** |
| `fleet/_auth_headers.py` | **0.2.124** |
| `uv.lock` | **0.2.124** |

## Why it isn't cosmetic

`fleet/__init__.py`'s `__version__` is what `get_headers()` sends as **`X-Fleet-SDK-Version` on every request**. Published as-is, the 0.2.133 wheel would report itself to the control plane as 0.2.124 — so version-keyed telemetry, and any future compatibility check, would read the wrong number.

`uv.lock` disagreeing with `pyproject.toml` is the other half: a lockfile that doesn't match the project version it locks.

The `_auth_headers.py` occurrence is the `except ImportError` fallback for `__version__`. It only surfaces when the package-level import fails — which is exactly when a stale literal is hardest to notice.

## Verification

Every version string now reads 0.2.133, and no `0.2.124` literal remains in any `.py`, `.toml` or `.lock`.

Tests: **746 passed**, with the same 5 failures and 3 errors as an untouched checkout.

## After merge

```bash
git checkout main && git pull
git tag fleet-python-v0.2.133
git push origin fleet-python-v0.2.133
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
